### PR TITLE
Fix when there's not additional data available

### DIFF
--- a/ios/RCTOneSignal/RCTOneSignal.m
+++ b/ios/RCTOneSignal/RCTOneSignal.m
@@ -36,12 +36,21 @@ RCT_EXPORT_MODULE(RNOneSignal)
     oneSignal = [[OneSignal alloc]
                       initWithLaunchOptions:launchOptions
                       appId:appId
-                      handleNotification:^(NSString* message, NSDictionary* additionalData, BOOL isActive) {
-                          NSDictionary *dictionary = @{
-                                                       @"message"     : message,
-                                                       @"additionalData" : additionalData,
-                                                       @"isActive" : [NSNumber numberWithBool:isActive]
-                                                       };
+                 handleNotification:^(NSString* message, NSDictionary* additionalData, BOOL isActive) {
+                          NSDictionary *dictionary;
+                          if (additionalData) {
+                              dictionary = @{
+                                  @"message"     : message,
+                                  @"additionalData" : additionalData,
+                                  @"isActive" : [NSNumber numberWithBool:isActive]
+                                  };
+                          } else {
+                              dictionary = @{
+                                             @"message"     : message,
+                                             @"additionalData" : [[NSDictionary alloc] init],
+                                             @"isActive" : [NSNumber numberWithBool:isActive]
+                                             };
+                          }
                           [[NSNotificationCenter defaultCenter] postNotificationName:RCTRemoteNotificationReceived
                                                                               object:self userInfo:dictionary];
                       }];


### PR DESCRIPTION
The application crashes when the app is opened and a notification without additionalData has been received.

This PR will fix that issue.
