### PR TITLE
Registering for push notifications at a later time

### DIFF
--- a/index.js
+++ b/index.js
@@ -42,6 +42,11 @@ Notifications.unregister = function() {
 	this.onNotificationOpened = false;
 };
 
+Notifications.registerForPushNotifications = function(){
+
+	RNOneSignal.registerForPushNotifications();
+}
+
 Notifications._onNotificationOpened = function(message, data, isActive) {
 	if ( this.onNotificationOpened === false ) {
 		var notification = {message: message, data: data, isActive: isActive};

--- a/ios/RCTOneSignal/RCTOneSignal.h
+++ b/ios/RCTOneSignal/RCTOneSignal.h
@@ -4,7 +4,8 @@
 
 @interface RCTOneSignal : NSObject <RCTBridgeModule>
 
-- (id)initWithLaunchOptions:(NSDictionary*)launchOptions appId:(NSString *)appId;
+- (id)initWithLaunchOptions:(NSDictionary *)launchOptions appId:(NSString *)appId;
+- (id)initWithLaunchOptions:(NSDictionary*)launchOptions appId:(NSString *)appId autoRegister:(BOOL)autoRegister;
 + (void)didReceiveRemoteNotification:(NSDictionary *)dictionary;
 
 @end

--- a/ios/RCTOneSignal/RCTOneSignal.m
+++ b/ios/RCTOneSignal/RCTOneSignal.m
@@ -29,7 +29,12 @@ RCT_EXPORT_MODULE(RNOneSignal)
                                                object:nil];
 }
 
-- (id)initWithLaunchOptions:(NSDictionary *)launchOptions appId:(NSString *)appId  {
+- (id)initWithLaunchOptions:(NSDictionary *)launchOptions appId:(NSString *)appId{
+    
+    return [self initWithLaunchOptions:launchOptions appId:appId autoRegister:YES];
+}
+
+- (id)initWithLaunchOptions:(NSDictionary *)launchOptions appId:(NSString *)appId autoRegister:(BOOL)autoRegister {
     // Eanble logging to help debug issues. visualLevel will show alert dialog boxes.
     [OneSignal setLogLevel:ONE_S_LL_NONE visualLevel:ONE_S_LL_NONE];
     
@@ -53,7 +58,8 @@ RCT_EXPORT_MODULE(RNOneSignal)
                           }
                           [[NSNotificationCenter defaultCenter] postNotificationName:RCTRemoteNotificationReceived
                                                                               object:self userInfo:dictionary];
-                      }];
+                      }
+                 autoRegister:autoRegister];
     
     [oneSignal enableInAppAlertNotification:NO];
     return self;
@@ -66,6 +72,11 @@ RCT_EXPORT_MODULE(RNOneSignal)
 
 - (void)handleRemoteNotificationReceived:(NSNotification *)notification {
     [_bridge.eventDispatcher sendDeviceEventWithName:@"remoteNotificationOpened" body:notification.userInfo];
+}
+
+RCT_EXPORT_METHOD(registerForPushNotifications){
+    
+    [oneSignal registerForPushNotifications];
 }
 
 RCT_EXPORT_METHOD(sendTag:(NSString *)key value:(NSString*)value) {


### PR DESCRIPTION
I've added the ability to register for push notifications at a later time. It is sometimes advantageous for the app to ask for push permissions in the context of some action or behaviour. For example, subscribing to a topic. This could mean increased push registration rates, and a better user experience than simply asking for push permissions on app first launch.
