### PR TITLE
RCTRemoteNotificationReceived ---> OSRemoteNotificationReceived

### DIFF
--- a/ios/RCTOneSignal/RCTOneSignal.m
+++ b/ios/RCTOneSignal/RCTOneSignal.m
@@ -3,7 +3,7 @@
 #import "RCTBridge.h"
 #import "RCTEventDispatcher.h"
 
-NSString *const RCTRemoteNotificationReceived = @"RemoteNotificationReceived";
+NSString *const OSRemoteNotificationReceived = @"RemoteNotificationReceived";
 
 @interface RCTOneSignal()
 
@@ -25,7 +25,7 @@ RCT_EXPORT_MODULE(RNOneSignal)
     
     [[NSNotificationCenter defaultCenter] addObserver:self
                                              selector:@selector(handleRemoteNotificationReceived:)
-                                                 name:RCTRemoteNotificationReceived
+                                                 name:OSRemoteNotificationReceived
                                                object:nil];
 }
 
@@ -51,7 +51,7 @@ RCT_EXPORT_MODULE(RNOneSignal)
                                              @"isActive" : [NSNumber numberWithBool:isActive]
                                              };
                           }
-                          [[NSNotificationCenter defaultCenter] postNotificationName:RCTRemoteNotificationReceived
+                          [[NSNotificationCenter defaultCenter] postNotificationName:OSRemoteNotificationReceived
                                                                               object:self userInfo:dictionary];
                       }];
     
@@ -60,7 +60,7 @@ RCT_EXPORT_MODULE(RNOneSignal)
 }
 
 + (void)didReceiveRemoteNotification:(NSDictionary *)dictionary {
-    [[NSNotificationCenter defaultCenter] postNotificationName:RCTRemoteNotificationReceived
+    [[NSNotificationCenter defaultCenter] postNotificationName:OSRemoteNotificationReceived
                                                         object:self userInfo:dictionary];
 }
 


### PR DESCRIPTION
Building this while using `RCTPushNotification` results in the following error:

```
duplicate symbol _RCTRemoteNotificationReceived in:
    /Users/alonso/dev/audience/mobile/ios/DerivedData/Audience/Build/Products/Debug-iphoneos/libRCTOneSignal.a(RCTOneSignal.o)
    /Users/alonso/dev/audience/mobile/ios/DerivedData/Audience/Build/Products/Debug-iphoneos/libRCTPushNotification.a(RCTPushNotificationManager.o)
ld: 1 duplicate symbol for architecture arm64
clang: error: linker command failed with exit code 1 (use -v to see invocation)
```

Changing this constant's name to not conflict with react-native's solves the problem.
