### PR TITLE
Compile to v7+ of Google Play Services

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -37,7 +37,7 @@ dependencies {
     compile 'com.android.support:support-v4:23.4.0'
     compile 'com.facebook.react:react-native:+'
     compile 'com.onesignal:OneSignal:2.+@aar'
-    compile 'com.google.android.gms:play-services-gcm:+'
-    compile 'com.google.android.gms:play-services-analytics:+'
-    compile 'com.google.android.gms:play-services-location:+'
+    compile 'com.google.android.gms:play-services-gcm:7.+'
+    compile 'com.google.android.gms:play-services-analytics:7.+'
+    compile 'com.google.android.gms:play-services-location:7.+'
 }


### PR DESCRIPTION
This pull request updates build.gradle to compile against v7+ of Google Play Services.

According to OneSignal's documentation for Android:

> The OneSignal SDK supports back to version 7.0.0 of Google Play services. The version on the device must be the same version or newer than the version you build your app with.
