### PR TITLE
Allow iOS versions >= 7.0 in Podspec

### DIFF
--- a/react-native-onesignal.podspec
+++ b/react-native-onesignal.podspec
@@ -9,7 +9,7 @@ Pod::Spec.new do |s|
   s.homepage       = "https://github.com/geektimecoil/react-native-onesignal"
   s.license        = package_json["license"]
   s.author         = { package_json["author"] => package_json["author"] }
-  s.platform       = :ios, "9.0"
+  s.platform       = :ios, "7.0"
   s.source         = { :git => package_json["repository"]["url"] }
   s.source_files   = 'ios/RCTOneSignal/*.{h,m}'
   s.dependency 'React'


### PR DESCRIPTION
OneSignal itself needs >= 6.1 and React Native needs >= 7.0.

We've been successfully using this library for iOS < 9.0, when not requiring the library with CocoaPods. But I would personally rather use CocoaPods for iOS library management when possible.
