### PR TITLE
fix(#83) add catch for rejection and passthrough to onError

### DIFF
--- a/index.js
+++ b/index.js
@@ -58,7 +58,7 @@ Notifications.configure = function(options: Object) {
   NetInfo.isConnected.fetch().then(isConnected => {
     if(isConnected) return RNOneSignal.configure();
     NetInfo.isConnected.addEventListener('change', handleConnectionStateChange);
-  });
+  }).catch((...args)=>this.onError(args));
 };
 
 /* Unregister */


### PR DESCRIPTION
Changes the configure function to catch error from `isConnected.fetch()` and pass them through to the `onError` handler.
