### PR TITLE
Returns Meta data of notification

### DIFF
--- a/index.js
+++ b/index.js
@@ -210,8 +210,9 @@ Notifications.idsAvailable = function(idsAvailable) {
 
 DeviceEventEmitter.addListener(DEVICE_NOTIF_EVENT, function(notifData) {
 	var message = notifData.message;
-	var hasAdditionalData = notifData.additionalData !== null && typeof notifData.additionalData === 'object';
-	var data = hasAdditionalData ? notifData.additionalData : null;
+	var additionalData = notifData.additionalData !== '{}' ? JSON.parse(notifData.additionalData) : null;
+	var hasAdditionalData = additionalData !== null && typeof additionalData === 'object';
+	var data = hasAdditionalData ? additionalData : null;
 	var isActive = notifData.isActive;
 	Notifications._onNotificationOpened(message, data, isActive);
 });

--- a/index.js
+++ b/index.js
@@ -209,20 +209,17 @@ Notifications.idsAvailable = function(idsAvailable) {
 };
 
 DeviceEventEmitter.addListener(DEVICE_NOTIF_EVENT, function(notifData) {
-    console.log('notifData->', notifData);
-    var message = notifData.message;
-    console.log('notifData.additionalData->', notifData.additionalData);
-    var data = null;
-    console.log('typeof->', typeof notifData.additionalData === 'object');
-    if (notifData.additionalData != null && notifData.additionalData != '{}') {
-        if (typeof notifData.additionalData === 'object')
-            data = notifData.additionalData;
-        else
-            data = JSON.parse(notifData.additionalData);
-    }
-    console.log('data->', data);
-    var isActive = notifData.isActive;
-    Notifications._onNotificationOpened(message, data, isActive);
+	var message = notifData.message;
+	var data = null;
+	if (notifData.additionalData != null && notifData.additionalData != '{}') {
+		if (typeof notifData.additionalData === 'object') {
+			data = notifData.additionalData;
+		} else {
+			data = JSON.parse(notifData.additionalData);	
+		}
+    	}
+	var isActive = notifData.isActive;
+	Notifications._onNotificationOpened(message, data, isActive);
 });
 
 DeviceEventEmitter.addListener(DEVICE_NOTIF_REG_EVENT, function(notifData) {

--- a/index.js
+++ b/index.js
@@ -209,14 +209,20 @@ Notifications.idsAvailable = function(idsAvailable) {
 };
 
 DeviceEventEmitter.addListener(DEVICE_NOTIF_EVENT, function(notifData) {
-	console.log('notifData->', notifData);
-	var message = notifData.message;
-	console.log('notifData.additionalData->', notifData.additionalData);
-	var additionalData = notifData.additionalData !== '{}' ? JSON.parse(notifData.additionalData) : null;
-	var hasAdditionalData = additionalData !== null && typeof additionalData === 'object';
-	var data = hasAdditionalData ? additionalData : null;
-	var isActive = notifData.isActive;
-	Notifications._onNotificationOpened(message, data, isActive);
+    console.log('notifData->', notifData);
+    var message = notifData.message;
+    console.log('notifData.additionalData->', notifData.additionalData);
+    var data = null;
+    console.log('typeof->', typeof notifData.additionalData === 'object');
+    if (notifData.additionalData != null && notifData.additionalData != '{}') {
+        if (typeof notifData.additionalData === 'object')
+            data = notifData.additionalData;
+        else
+            data = JSON.parse(notifData.additionalData);
+    }
+    console.log('data->', data);
+    var isActive = notifData.isActive;
+    Notifications._onNotificationOpened(message, data, isActive);
 });
 
 DeviceEventEmitter.addListener(DEVICE_NOTIF_REG_EVENT, function(notifData) {

--- a/index.js
+++ b/index.js
@@ -209,7 +209,9 @@ Notifications.idsAvailable = function(idsAvailable) {
 };
 
 DeviceEventEmitter.addListener(DEVICE_NOTIF_EVENT, function(notifData) {
+	console.log('notifData->', notifData);
 	var message = notifData.message;
+	console.log('notifData.additionalData->', notifData.additionalData);
 	var additionalData = notifData.additionalData !== '{}' ? JSON.parse(notifData.additionalData) : null;
 	var hasAdditionalData = additionalData !== null && typeof additionalData === 'object';
 	var data = hasAdditionalData ? additionalData : null;


### PR DESCRIPTION
Meta data was always returning null in `onNotificationOpened(message, data, isActive) {}` 
Looks like 
<img width="593" alt="screen shot 2016-10-27 at 11 22 37 am" src="https://cloud.githubusercontent.com/assets/8682058/19779936/07186d16-9c38-11e6-8256-e39f2145aac2.png"> now one signal is sending empty stringify object {} in additionalData for Android & for iOS its in form of Object. In case of data 
<img width="664" alt="screen shot 2016-10-27 at 11 22 49 am" src="https://cloud.githubusercontent.com/assets/8682058/19779971/3b256cf8-9c38-11e6-98ac-314a93a652f5.png">.
Changed the way how additional data was being handled. first checking if additionalData: `{}` return null else convert string to object. 
