### PR TITLE
[Android] lint errors

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -14,6 +14,13 @@ apply plugin: 'com.android.library'
 android {
     compileSdkVersion 23
     buildToolsVersion "23.0.1"
+    
+    android {
+        lintOptions {
+            abortOnError false
+            warning 'InvalidPackage'
+        }
+    }
 
     defaultConfig {
         minSdkVersion 16


### PR DESCRIPTION
On latest release project build fails as there are lint errors in `react-native-onesignal` plugin.
(This PR simply ignores that error as it is false-positive)
### Version info:

```
react-native-onesignal@latest:
  version "1.2.2"
```
### Linter error

**InvalidPackage: Package not included in Android**
okio-1.9.0.jar: Invalid package reference in library; not included in Android: java.nio.file. Referenced from `okio.Okio`.
Priority: 6 / 10
Category: Correctness
Severity: Error
Explanation: Package not included in Android.
### More info

To suppress this error, use the issue id "**InvalidPackage**" as explained in the Suppressing Warnings and Errors section.

[Full Lint Report ](https://github.com/geektimecoil/react-native-onesignal/files/559857/react-native-onesignal-lint.pdf)

**UPDATE** Full lint error report is attached.
