### PR TITLE
Add invariant to dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,6 +6,9 @@
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1"
   },
+  "dependencies": {
+    "invariant": "^2.2.2"
+  },
   "keywords": [
     "react-component",
     "react-native",


### PR DESCRIPTION
Add `invariant` to the dependencies as it is used in [index.js](https://github.com/geektimecoil/react-native-onesignal/blob/master/index.js#L8)

Test Plan: 
Verify this error doesn't appear with the change:
![simulator_screen_shot_nov_30 _2016 _11 49 54_pm](https://cloud.githubusercontent.com/assets/19673711/20811060/10b2bb8e-b7c1-11e6-8325-f6a67542412f.png)

