### PR TITLE
fix android package name

### DIFF
--- a/android/src/main/AndroidManifest.xml
+++ b/android/src/main/AndroidManifest.xml
@@ -1,3 +1,3 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
-    package="com.geektime.rnonesignalandroid">
+    package="com.geektime.reactnativeonesignal">
 </manifest>


### PR DESCRIPTION
Fix android package name.

`react-native link` is adding the following import to `MainApplication.java`:

```
import com.geektime.rnonesignalandroid.ReactNativeOneSignalPackage;
```