### PR TITLE
Remove unused RCTRootView import

### DIFF
--- a/ios/RCTOneSignal/RCTOneSignal.h
+++ b/ios/RCTOneSignal/RCTOneSignal.h
@@ -1,6 +1,4 @@
 #import <React/RCTBridgeModule.h>
-#import <React/RCTRootView.h>
-
 #import <OneSignal/OneSignal.h>
 
 @interface RCTOneSignal : NSObject <RCTBridgeModule>


### PR DESCRIPTION
This import seems to be unused and was causing redefinition errors for me when
building. Removing it from the header resolves this