### PR TITLE
Fix typo in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -150,7 +150,7 @@ android {
   If your dont want to use cocoapods add in the `Framework Search Paths` the following line before build the project:
   `$(SRCROOT)/../node_modules/react-native-onesignal` set to `recursive`.
 
-  And add to your project the OneSignal.framework which is on YOUR_PROJECT/node_modules/react-native-onesignal/ios/frameworks/OneSignal.framwork
+  And add to your project the OneSignal.framework which is on YOUR_PROJECT/node_modules/react-native-onesignal/ios/frameworks/OneSignal.framework
 
 ### Adding the Code
 


### PR DESCRIPTION
Fixed a typo. I changed 'framwork' to 'framework'