### PR TITLE
Fixed errors with CocoaPods

### DIFF
--- a/ios/RCTOneSignal/RCTOneSignal.h
+++ b/ios/RCTOneSignal/RCTOneSignal.h
@@ -4,8 +4,6 @@
 #import "RCTBridgeModule.h"
 #endif
 
-#import "OneSignal.h"
-
 @interface RCTOneSignal : NSObject <RCTBridgeModule>
 
 - (id)initWithLaunchOptions:(NSDictionary *)launchOptions appId:(NSString *)appId;

--- a/ios/RCTOneSignal/RCTOneSignal.m
+++ b/ios/RCTOneSignal/RCTOneSignal.m
@@ -10,6 +10,12 @@
 #import "RCTUtils.h"
 #endif
 
+#if __has_include(<OneSignal/OneSignal.h>)
+#import <OneSignal/OneSignal.h>
+#else
+#import "OneSignal.h"
+#endif
+
 #import "RCTOneSignal.h"
 
 #if __IPHONE_OS_VERSION_MIN_REQUIRED < __IPHONE_8_0

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "git://git@github.com:geektimecoil/react-native-onesignal.git"
+    "url": "https://github.com/geektimecoil/react-native-onesignal"
   },
   "author": "Geektime <http://www.geektime.co.il>",
   "license": "MIT"

--- a/react-native-onesignal.podspec
+++ b/react-native-onesignal.podspec
@@ -10,7 +10,7 @@ Pod::Spec.new do |s|
   s.license        = package_json["license"]
   s.author         = { package_json["author"] => package_json["author"] }
   s.platform       = :ios, "7.0"
-  s.source         = { :git => package_json["repository"]["url"] }
+  s.source         = { :git => "#{package_json["repository"]["url"]}.git", :tag => "v#{s.version}" }
   s.source_files   = 'ios/RCTOneSignal/*.{h,m}'
   s.dependency 'React'
   s.dependency 'OneSignal'


### PR DESCRIPTION
Hi,

I'm using CocoaPods with a React Native app and got the following exception when I tried to add this library during `pod install`:

```
URI::InvalidURIError - bad URI(is not URI?): git://git@github.com:geektimecoil/react-native-onesignal.git
```

Using CocoaPods 1.2.0

Another error was with the `OneSignal` header import.

I also fixed the podspec lint warnings.

Note that `pod spec lint react-native-onesignal.podspec --verbose` still reports the following error:

```
- ERROR | [iOS] unknown: Encountered an unknown error (The 'Pods-App' target has transitive dependencies that include static binaries: (/private/var/folders/bd/rv_syh756ys0z9y48jd2_2400000gn/T/CocoaPods/Lint/Pods/OneSignal/iOS_SDK/Framework/OneSignal.framework)
```

but it doesn't prevent a successful `pod install` (at least when NOT using `use_frameworks!` in the podfile).

Let me know what you think.