### PR TITLE
Prefixed event names with 'OneSignal'

### DIFF
--- a/android/src/main/java/com/geektime/rnonesignalandroid/RNOneSignal.java
+++ b/android/src/main/java/com/geektime/rnonesignalandroid/RNOneSignal.java
@@ -101,7 +101,7 @@ public class RNOneSignal extends ReactContextBaseJavaModule implements Lifecycle
                 params.putString("userId", userId);
                 params.putString("pushToken", registrationId);
 
-                sendEvent("idsAvailable", params);
+                sendEvent("OneSignal-idsAvailable", params);
             }
         });
     }
@@ -199,7 +199,7 @@ public class RNOneSignal extends ReactContextBaseJavaModule implements Lifecycle
     private void notifyNotificationReceived(Bundle bundle) {
         try {
             JSONObject jsonObject = new JSONObject(bundle.getString("notification"));
-            sendEvent("remoteNotificationReceived", RNUtils.jsonToWritableMap(jsonObject));
+            sendEvent("OneSignal-remoteNotificationReceived", RNUtils.jsonToWritableMap(jsonObject));
         } catch(Throwable t) {
             t.printStackTrace();
         }
@@ -208,7 +208,7 @@ public class RNOneSignal extends ReactContextBaseJavaModule implements Lifecycle
     private void notifyNotificationOpened(Bundle bundle) {
         try {
             JSONObject jsonObject = new JSONObject(bundle.getString("result"));
-            sendEvent("remoteNotificationOpened",  RNUtils.jsonToWritableMap(jsonObject));
+            sendEvent("OneSignal-remoteNotificationOpened",  RNUtils.jsonToWritableMap(jsonObject));
         } catch(Throwable t) {
             t.printStackTrace();
         }

--- a/index.js
+++ b/index.js
@@ -6,10 +6,10 @@ import invariant from 'invariant';
 
 var RNOneSignal = NativeModules.OneSignal;
 
-var DEVICE_NOTIF_RECEIVED_EVENT = 'remoteNotificationReceived';
-var DEVICE_NOTIF_OPENED_EVENT = 'remoteNotificationOpened';
-var DEVICE_NOTIF_REG_EVENT = 'remoteNotificationsRegistered';
-var DEVICE_IDS_AVAILABLE = 'idsAvailable';
+var DEVICE_NOTIF_RECEIVED_EVENT = 'OneSignal-remoteNotificationReceived';
+var DEVICE_NOTIF_OPENED_EVENT = 'OneSignal-remoteNotificationOpened';
+var DEVICE_NOTIF_REG_EVENT = 'OneSignal-remoteNotificationsRegistered';
+var DEVICE_IDS_AVAILABLE = 'OneSignal-idsAvailable';
 
 const _notifHandlers = new Map();
 

--- a/ios/RCTOneSignal/RCTOneSignal.m
+++ b/ios/RCTOneSignal/RCTOneSignal.m
@@ -81,7 +81,7 @@ OSNotificationOpenedResult* coldStartOSNotificationOpenedResult;
     
     // prints out all properties
     NSLog(@"SubscriptionStateChanges:\n%@", stateChanges.to);
-    [self.bridge.eventDispatcher sendAppEventWithName:@"idsAvailable" body:stateChanges.to];
+    [self.bridge.eventDispatcher sendAppEventWithName:@"OneSignal-idsAvailable" body:stateChanges.to];
 }
 
 - (void)handleRemoteNotificationReceived:(NSString *)notification {
@@ -94,7 +94,7 @@ OSNotificationOpenedResult* coldStartOSNotificationOpenedResult;
 
     
     
-    [curRCTBridge.eventDispatcher sendAppEventWithName:@"remoteNotificationReceived" body:json];
+    [curRCTBridge.eventDispatcher sendAppEventWithName:@"OneSignal-remoteNotificationReceived" body:json];
 }
 
 - (void)handleRemoteNotificationOpened:(NSString *)result {
@@ -105,11 +105,11 @@ OSNotificationOpenedResult* coldStartOSNotificationOpenedResult;
                                                          options:NSJSONReadingMutableContainers
                                                            error:&jsonError];
     
-    [curRCTBridge.eventDispatcher sendAppEventWithName:@"remoteNotificationOpened" body:json];
+    [curRCTBridge.eventDispatcher sendAppEventWithName:@"OneSignal-remoteNotificationOpened" body:json];
 }
 
 - (void)handleRemoteNotificationsRegistered:(NSNotification *)notification {
-    [self.bridge.eventDispatcher sendAppEventWithName:@"remoteNotificationsRegistered" body:notification.userInfo];
+    [self.bridge.eventDispatcher sendAppEventWithName:@"OneSignal-remoteNotificationsRegistered" body:notification.userInfo];
 }
 
 RCT_EXPORT_METHOD(checkPermissions:(RCTResponseSenderBlock)callback)
@@ -184,7 +184,7 @@ RCT_EXPORT_METHOD(configure) {
           @"userId" : userId ?: [NSNull null]
         };
 
-        [self.bridge.eventDispatcher sendAppEventWithName:@"idsAvailable" body:params];
+        [self.bridge.eventDispatcher sendAppEventWithName:@"OneSignal-idsAvailable" body:params];
     }];
 }
 


### PR DESCRIPTION
This PR will fix #240, it's just a prefix on all *OneSignal* app events to avoid conflicts :)

In this way this library can coexist with others such as [react-native-push-notification](https://github.com/zo0r/react-native-push-notification).