### PR TITLE
Allowed to send extra parameters and added ability to send hidden messages.

### DIFF
--- a/android/src/main/java/com/geektime/rnonesignalandroid/NotificationNotDisplayingExtender.java
+++ b/android/src/main/java/com/geektime/rnonesignalandroid/NotificationNotDisplayingExtender.java
@@ -1,0 +1,30 @@
+package com.geektime.rnonesignalandroid;
+
+import android.util.Log;
+
+import com.onesignal.NotificationExtenderService;
+import com.onesignal.OSNotificationReceivedResult;
+
+import org.json.JSONException;
+import org.json.JSONObject;
+
+/**
+ * Created by Andrey Beletsky on 6/5/17.
+ */
+public class NotificationNotDisplayingExtender extends NotificationExtenderService {
+	@Override
+	protected boolean onNotificationProcessing(OSNotificationReceivedResult receivedResult) {
+        JSONObject additionalData = receivedResult.payload.additionalData;
+        boolean hidden = false;
+        try {
+            if (additionalData.has(RNOneSignal.HIDDEN_MESSAGE_KEY)) {
+                hidden = additionalData.getBoolean(RNOneSignal.HIDDEN_MESSAGE_KEY);
+            }
+        } catch (JSONException e) {
+            Log.e("OneSignal", "onNotificationProcessing Failure: " + e.getMessage());
+        }
+
+        // Return true to stop the notification from displaying.
+		return hidden;
+	}
+}

--- a/android/src/main/java/com/geektime/rnonesignalandroid/NotificationNotDisplayingExtender.java
+++ b/android/src/main/java/com/geektime/rnonesignalandroid/NotificationNotDisplayingExtender.java
@@ -12,8 +12,8 @@ import org.json.JSONObject;
  * Created by Andrey Beletsky on 6/5/17.
  */
 public class NotificationNotDisplayingExtender extends NotificationExtenderService {
-	@Override
-	protected boolean onNotificationProcessing(OSNotificationReceivedResult receivedResult) {
+    @Override
+    protected boolean onNotificationProcessing(OSNotificationReceivedResult receivedResult) {
         JSONObject additionalData = receivedResult.payload.additionalData;
         boolean hidden = false;
         try {
@@ -26,5 +26,5 @@ public class NotificationNotDisplayingExtender extends NotificationExtenderServi
 
         // Return true to stop the notification from displaying.
         return hidden;
-	}
+    }
 }

--- a/android/src/main/java/com/geektime/rnonesignalandroid/NotificationNotDisplayingExtender.java
+++ b/android/src/main/java/com/geektime/rnonesignalandroid/NotificationNotDisplayingExtender.java
@@ -25,6 +25,6 @@ public class NotificationNotDisplayingExtender extends NotificationExtenderServi
         }
 
         // Return true to stop the notification from displaying.
-		return hidden;
+        return hidden;
 	}
 }

--- a/android/src/main/java/com/geektime/rnonesignalandroid/RNOneSignal.java
+++ b/android/src/main/java/com/geektime/rnonesignalandroid/RNOneSignal.java
@@ -1,5 +1,7 @@
 package com.geektime.rnonesignalandroid;
 
+import java.util.Iterator;
+
 import android.app.Activity;
 import android.content.BroadcastReceiver;
 import android.content.Context;
@@ -147,22 +149,32 @@ public class RNOneSignal extends ReactContextBaseJavaModule implements Lifecycle
     }
 
     @ReactMethod
-    public void postNotification(String contents, String data, String player_id) {
+    public void postNotification(String contents, String data, String player_id, String otherParameters) {
         try {
-          OneSignal.postNotification(new JSONObject("{'contents': " + contents + ", 'data': {'p2p_notification': " + data +"}, 'include_player_ids': ['" + player_id + "']}"),
-             new OneSignal.PostNotificationResponseHandler() {
-               @Override
-               public void onSuccess(JSONObject response) {
-                 Log.i("OneSignal", "postNotification Success: " + response.toString());
-               }
+            JSONObject postNotification = new JSONObject("{'contents': " + contents + ", 'data': {'p2p_notification': " + data +"}, 'include_player_ids': ['" + player_id + "']}");
+            if (otherParameters != null && !otherParameters.trim().isEmpty()) {
+                JSONObject parametersJson = new JSONObject(otherParameters.trim());
+                Iterator<String> keys = parametersJson.keys();
+                while (keys.hasNext()) {
+                    String key = keys.next();
+                    postNotification.put(key, parametersJson.get(key));
+                }
+            }
 
-               @Override
-               public void onFailure(JSONObject response) {
-                 Log.e("OneSignal", "postNotification Failure: " + response.toString());
-               }
-             });
+            OneSignal.postNotification(postNotification,
+                new OneSignal.PostNotificationResponseHandler() {
+                    @Override
+                    public void onSuccess(JSONObject response) {
+                        Log.i("OneSignal", "postNotification Success: " + response.toString());
+                    }
+
+                    @Override
+                    public void onFailure(JSONObject response) {
+                        Log.e("OneSignal", "postNotification Failure: " + response.toString());
+                    }
+                });
         } catch (JSONException e) {
-          e.printStackTrace();
+            e.printStackTrace();
         }
     }
 

--- a/android/src/main/java/com/geektime/rnonesignalandroid/RNOneSignal.java
+++ b/android/src/main/java/com/geektime/rnonesignalandroid/RNOneSignal.java
@@ -32,6 +32,7 @@ import org.json.JSONException;
 public class RNOneSignal extends ReactContextBaseJavaModule implements LifecycleEventListener {
     public static final String NOTIFICATION_OPENED_INTENT_FILTER = "GTNotificationOpened";
     public static final String NOTIFICATION_RECEIVED_INTENT_FILTER = "GTNotificationReceived";
+    public static final String HIDDEN_MESSAGE_KEY = "hidden";
 
     private ReactContext mReactContext;
     private boolean oneSignalInitDone;
@@ -149,15 +150,19 @@ public class RNOneSignal extends ReactContextBaseJavaModule implements Lifecycle
     }
 
     @ReactMethod
-    public void postNotification(String contents, String data, String player_id, String otherParameters) {
+    public void postNotification(String contents, String data, String playerId, String otherParameters) {
         try {
-            JSONObject postNotification = new JSONObject("{'contents': " + contents + ", 'data': {'p2p_notification': " + data +"}, 'include_player_ids': ['" + player_id + "']}");
+            JSONObject postNotification = new JSONObject("{'contents': " + contents + ", 'data': {'p2p_notification': " + data +"}, 'include_player_ids': ['" + playerId + "']}");
             if (otherParameters != null && !otherParameters.trim().isEmpty()) {
                 JSONObject parametersJson = new JSONObject(otherParameters.trim());
                 Iterator<String> keys = parametersJson.keys();
                 while (keys.hasNext()) {
                     String key = keys.next();
                     postNotification.put(key, parametersJson.get(key));
+                }
+
+                if (parametersJson.has(HIDDEN_MESSAGE_KEY) && parametersJson.getBoolean(HIDDEN_MESSAGE_KEY)) {
+                    postNotification.getJSONObject("data").put(HIDDEN_MESSAGE_KEY, true);
                 }
             }
 

--- a/android/src/main/java/com/geektime/rnonesignalandroid/RNOneSignal.java
+++ b/android/src/main/java/com/geektime/rnonesignalandroid/RNOneSignal.java
@@ -152,7 +152,7 @@ public class RNOneSignal extends ReactContextBaseJavaModule implements Lifecycle
     @ReactMethod
     public void postNotification(String contents, String data, String playerId, String otherParameters) {
         try {
-            JSONObject postNotification = new JSONObject("{'contents': " + contents + ", 'data': {'p2p_notification': " + data +"}, 'include_player_ids': ['" + playerId + "']}");
+            JSONObject postNotification = new JSONObject("{'contents': " + contents + ", 'data': {'p2p_notification': " + data + "}, 'include_player_ids': ['" + playerId + "']}");
             if (otherParameters != null && !otherParameters.trim().isEmpty()) {
                 JSONObject parametersJson = new JSONObject(otherParameters.trim());
                 Iterator<String> keys = parametersJson.keys();
@@ -166,7 +166,8 @@ public class RNOneSignal extends ReactContextBaseJavaModule implements Lifecycle
                 }
             }
 
-            OneSignal.postNotification(postNotification,
+            OneSignal.postNotification(
+                postNotification,
                 new OneSignal.PostNotificationResponseHandler() {
                     @Override
                     public void onSuccess(JSONObject response) {
@@ -177,7 +178,8 @@ public class RNOneSignal extends ReactContextBaseJavaModule implements Lifecycle
                     public void onFailure(JSONObject response) {
                         Log.e("OneSignal", "postNotification Failure: " + response.toString());
                     }
-                });
+                }
+            );
         } catch (JSONException e) {
             e.printStackTrace();
         }

--- a/index.js
+++ b/index.js
@@ -86,7 +86,7 @@ export default class OneSignal {
     }
 
     static registerForPushNotifications() {
-        if (Platform.OS == 'ios') {
+        if (Platform.OS === 'ios') {
             RNOneSignal.registerForPushNotifications();
         } else {
             console.log("This function is not supported on Android");
@@ -95,7 +95,7 @@ export default class OneSignal {
 
     static requestPermissions(permissions) {
         var requestedPermissions = {};
-        if (Platform.OS == 'ios') {
+        if (Platform.OS === 'ios') {
             if (permissions) {
                 requestedPermissions = {
                     alert: !!permissions.alert,
@@ -120,7 +120,7 @@ export default class OneSignal {
     }
 
     static checkPermissions(callback: Function) {
-        if (Platform.OS == 'ios') {
+        if (Platform.OS === 'ios') {
             invariant(
                 typeof callback === 'function',
                 'Must provide a valid callback'
@@ -148,7 +148,7 @@ export default class OneSignal {
     }
 
     static enableVibrate(enable) {
-        if (Platform.OS == 'android') {
+        if (Platform.OS === 'android') {
             RNOneSignal.enableVibrate(enable);
         } else {
             console.log("This function is not supported on iOS");
@@ -156,7 +156,7 @@ export default class OneSignal {
     }
 
     static enableSound(enable) {
-        if (Platform.OS == 'android') {
+        if (Platform.OS === 'android') {
             RNOneSignal.enableSound(enable);
         } else {
             console.log("This function is not supported on iOS");
@@ -176,21 +176,21 @@ export default class OneSignal {
     //Android only: Set Display option of the notifications. displayOption is of type OSInFocusDisplayOption
     // 0 -> None, 1 -> InAppAlert, 2 -> Notification
     static inFocusDisplaying(displayOption) {
-        if (Platform.OS == 'android') {
+        if (Platform.OS === 'android') {
             RNOneSignal.inFocusDisplaying(displayOption);
         }
     }
 
-    static postNotification(contents, data, player_id) {
-        if (Platform.OS == 'android') {
-            RNOneSignal.postNotification(JSON.stringify(contents), JSON.stringify(data), player_id);
+    static postNotification(contents, data, player_id, otherParameters) {
+        if (Platform.OS === 'android') {
+            RNOneSignal.postNotification(JSON.stringify(contents), JSON.stringify(data), player_id, JSON.stringify(otherParameters));
         } else {
-            RNOneSignal.postNotification(contents, data, player_id);
+            RNOneSignal.postNotification(contents, data, player_id, otherParameters);
         }
     }
 
     static clearOneSignalNotifications() {
-        if (Platform.OS == 'android') {
+        if (Platform.OS === 'android') {
             RNOneSignal.clearOneSignalNotifications();
         } else {
             console.log("This function is not supported on iOS");
@@ -198,7 +198,7 @@ export default class OneSignal {
     }
 
     static cancelNotification(id) {
-        if (Platform.OS == 'android') {
+        if (Platform.OS === 'android') {
             RNOneSignal.cancelNotification(id);
         } else {
             console.log("This function is not supported on iOS");

--- a/ios/RCTOneSignal/RCTOneSignal.m
+++ b/ios/RCTOneSignal/RCTOneSignal.m
@@ -218,9 +218,17 @@ RCT_EXPORT_METHOD(promptLocation) {
 }
 
 RCT_EXPORT_METHOD(postNotification:(NSDictionary *)contents data:(NSDictionary *)data player_id:(NSString*)player_id other_parameters:(NSDictionary *)other_parameters) {
+    NSDictionary * additionalData = @{@"p2p_notification": data};
+
+    NSMutableDictionary * extendedData = [additionalData mutableCopy];
+    BOOL isHidden = [[other_parameters objectForKey:@"hidden"] boolValue];
+    if (isHidden) {
+        [extendedData setObject:[NSNumber numberWithBool:YES] forKey:@"hidden"];
+    }
+
     NSDictionary *notification = @{
         @"contents" : contents,
-        @"data" : @{@"p2p_notification": data},
+        @"data" : extendedData,
         @"include_player_ids": @[player_id]
     };
     NSMutableDictionary * extendedNotification = [notification mutableCopy];

--- a/ios/RCTOneSignal/RCTOneSignal.m
+++ b/ios/RCTOneSignal/RCTOneSignal.m
@@ -217,12 +217,16 @@ RCT_EXPORT_METHOD(promptLocation) {
     [OneSignal promptLocation];
 }
 
-RCT_EXPORT_METHOD(postNotification:(NSDictionary *)contents data:(NSDictionary *)data player_id:(NSString*)player_id) {
-    [OneSignal postNotification:@{
-                                  @"contents" : contents,
-                                  @"data" : @{@"p2p_notification": data},
-                                  @"include_player_ids": @[player_id]
-                                  }];
+RCT_EXPORT_METHOD(postNotification:(NSDictionary *)contents data:(NSDictionary *)data player_id:(NSString*)player_id other_parameters:(NSDictionary *)other_parameters) {
+    NSDictionary *notification = @{
+        @"contents" : contents,
+        @"data" : @{@"p2p_notification": data},
+        @"include_player_ids": @[player_id]
+    };
+    NSMutableDictionary * extendedNotification = [notification mutableCopy];
+    [extendedNotification addEntriesFromDictionary: other_parameters];
+
+    [OneSignal postNotification:extendedNotification];
 }
 
 RCT_EXPORT_METHOD(syncHashedEmail:(NSString*)email) {


### PR DESCRIPTION
Hidden messages were verified on Android. On iOS it should work out-of-the-box using empty `contents` and `content_available=1`.

It should fix https://github.com/geektimecoil/react-native-onesignal/issues/115