### PR TITLE
iOS setup Objective-C fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -192,15 +192,6 @@ android {
                                  settings:@{kOSSettingsKeyAutoPrompt: @false}];
         ```
 
-    * After `application ` insert the code for the notification event:
-
-        ```objc
-        // Required for the notification event.
-        - (void)application:(UIApplication *)application didReceiveRemoteNotification:(NSDictionary *)notification {
-            [RCTOneSignal didReceiveRemoteNotification:notification];
-        }
-        ```
-
  * You're All Set!
 
 


### PR DESCRIPTION
* Calling `RCTOneSignal didReceiveRemoteNotification` isn't needed.
* This also creates a crash as `didReceiveRemoteNotification` is only defined in the .h but not the .m.