### PR TITLE
Export promptForPushNotificationsWithUserResponse

### DIFF
--- a/index.js
+++ b/index.js
@@ -92,6 +92,18 @@ export default class OneSignal {
             console.log("This function is not supported on Android");
         }
     }
+    
+    static promptForPushNotificationsWithUserResponse(callback: Function) {
+        if (Platform.OS === 'ios') {
+            invariant(
+                typeof callback === 'function',
+                'Must provide a valid callback'
+            );
+            RNOneSignal.promptForPushNotificationsWithUserResponse(callback);
+        } else {
+            console.log("This function is not supported on Android");
+        }
+    }
 
     static requestPermissions(permissions) {
         var requestedPermissions = {};

--- a/ios/RCTOneSignal/RCTOneSignal.m
+++ b/ios/RCTOneSignal/RCTOneSignal.m
@@ -172,6 +172,13 @@ RCT_EXPORT_METHOD(registerForPushNotifications) {
     [OneSignal registerForPushNotifications];
 }
 
+RCT_EXPORT_METHOD(promptForPushNotificationsWithUserResponse:(RCTResponseSenderBlock)callback) {
+    [OneSignal promptForPushNotificationsWithUserResponse:^(BOOL accepted) {
+        NSLog(@"Prompt For Push Notifications Success");
+        callback(@[accepted]);
+    }];
+}
+
 RCT_EXPORT_METHOD(sendTag:(NSString *)key value:(NSString*)value) {
     [OneSignal sendTag:key value:value];
 }

--- a/ios/RCTOneSignal/RCTOneSignal.m
+++ b/ios/RCTOneSignal/RCTOneSignal.m
@@ -175,7 +175,7 @@ RCT_EXPORT_METHOD(registerForPushNotifications) {
 RCT_EXPORT_METHOD(promptForPushNotificationsWithUserResponse:(RCTResponseSenderBlock)callback) {
     [OneSignal promptForPushNotificationsWithUserResponse:^(BOOL accepted) {
         NSLog(@"Prompt For Push Notifications Success");
-        callback(@[accepted]);
+        callback(@[@(accepted)]);
     }];
 }
 


### PR DESCRIPTION
* Export promptForPushNotificationsWithUserResponse method from SDK 2.5.0

(Relates to https://github.com/geektimecoil/react-native-onesignal/issues/282)