### PR TITLE
Expose OneSignal's getPermissionSubscriptionState

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,7 @@ React Native Push Notifications support with OneSignal integration.
 		- [Enable Sound](#enable-sound)
 		- [Set In App Focus Behavior](#set-in-app-focus-behavior)
 		- [Change User Subscription Status](#change-user-subscription-status)
+		- [Check Push Notification and User Subscription Status](#check-push-notification-and-user-subscription-status)
 		- [Post Notification (Peer-to-Peer Notifications)](#post-notification-peer-to-peer-notifications)
 		- [Prompt Location](#prompt-location)
 		- [Clear Notifications (Android Only)](#clear-notifications-android-only)
@@ -387,6 +388,20 @@ We exposed the setSubscription API of OneSignal (both Android & iOS).
 ```javascript
 // Setting setSubscription
 OneSignal.setSubscription(true);
+```
+
+
+### Check Push Notification and User Subscription Status
+
+We exposed the getPermissionSubscriptionState API of OneSignal (both Android & iOS).
+
+*Allows you to check whether notifications are enabled for the app, whether user is subscribed to notifications through OneSignal, and what the user's in-app subscription preference is. It also provides access to pushToken and userId*
+
+```javascript
+// Check push notification and OneSignal subscription statuses
+OneSignal.getPermissionSubscriptionState((status) => {
+    console.log(status);
+});
 ```
 
 ### Post Notification (Peer-to-Peer Notifications)

--- a/android/src/main/java/com/geektime/rnonesignalandroid/RNOneSignal.java
+++ b/android/src/main/java/com/geektime/rnonesignalandroid/RNOneSignal.java
@@ -20,6 +20,9 @@ import com.facebook.react.bridge.ReactMethod;
 import com.facebook.react.bridge.ReadableMap;
 import com.facebook.react.bridge.WritableMap;
 import com.facebook.react.modules.core.DeviceEventManagerModule;
+import com.onesignal.OSPermissionState;
+import com.onesignal.OSPermissionSubscriptionState;
+import com.onesignal.OSSubscriptionState;
 import com.onesignal.OneSignal;
 
 import org.json.JSONObject;
@@ -107,6 +110,36 @@ public class RNOneSignal extends ReactContextBaseJavaModule implements Lifecycle
                 sendEvent("OneSignal-idsAvailable", params);
             }
         });
+    }
+
+    @ReactMethod
+    public void getPermissionSubscriptionState(final Callback callback) {
+        OSPermissionSubscriptionState state = OneSignal.getPermissionSubscriptionState();
+        OSPermissionState permissionState = state.getPermissionStatus();
+        OSSubscriptionState subscriptionState = state.getSubscriptionStatus();
+
+        // Notifications enabled for app? (Android Settings)
+        boolean notificationsEnabled = permissionState.getEnabled();
+
+        // User subscribed to OneSignal? (automatically toggles with notificationsEnabled)
+        boolean subscriptionEnabled = subscriptionState.getSubscribed();
+
+        // User's original subscription preference (regardless of notificationsEnabled)
+        boolean userSubscriptionEnabled = subscriptionState.getUserSubscriptionSetting();
+
+        try {
+            JSONObject result = new JSONObject("{" +
+                "'notificationsEnabled': " + String.valueOf(notificationsEnabled) + "," +
+                "'subscriptionEnabled': " + String.valueOf(subscriptionEnabled) + "," +
+                "'userSubscriptionEnabled': " + String.valueOf(userSubscriptionEnabled) + "," +
+                "'pushToken': " + subscriptionState.getPushToken() + "," +
+                "'userId': " + subscriptionState.getUserId() +
+            "}");
+
+            callback.invoke(RNUtils.jsonToWritableMap(result));
+        } catch (JSONException e) {
+            e.printStackTrace();
+        }
     }
 
     @ReactMethod

--- a/index.js
+++ b/index.js
@@ -131,6 +131,14 @@ export default class OneSignal {
         }
     }
 
+    static getPermissionSubscriptionState(callback: Function) {
+        invariant(
+            typeof callback === 'function',
+            'Must provide a valid callback'
+        );
+        RNOneSignal.getPermissionSubscriptionState(callback);
+    }
+
     static sendTag(key, value) {
         RNOneSignal.sendTag(key, value);
     }

--- a/ios/RCTOneSignal/RCTOneSignal.m
+++ b/ios/RCTOneSignal/RCTOneSignal.m
@@ -202,8 +202,8 @@ RCT_EXPORT_METHOD(getPermissionSubscriptionState:(RCTResponseSenderBlock)callbac
         @"notificationsEnabled": @(notificationsEnabled),
         @"subscriptionEnabled": @(subscriptionEnabled),
         @"userSubscriptionEnabled": @(userSubscriptionEnabled),
-        @"pushToken": subscriptionState.pushToken,
-        @"userId": subscriptionState.userId,
+        @"pushToken": subscriptionState.pushToken != NULL ? subscriptionState.pushToken : [NSNull null],
+        @"userId": subscriptionState.userId != NULL ? subscriptionState.userId : [NSNull null],
     }]);
 }
 

--- a/ios/RCTOneSignal/RCTOneSignal.m
+++ b/ios/RCTOneSignal/RCTOneSignal.m
@@ -172,7 +172,7 @@ RCT_EXPORT_METHOD(getPermissionSubscriptionState:(RCTResponseSenderBlock)callbac
 {
     if (RCTRunningInAppExtension()) {
         callback(@[@{
-			@"hasPrompted": @NO,
+            @"hasPrompted": @NO,
             @"notificationsEnabled": @NO,
             @"subscriptionEnabled": @NO,
             @"userSubscriptionEnabled": @NO,
@@ -186,19 +186,19 @@ RCT_EXPORT_METHOD(getPermissionSubscriptionState:(RCTResponseSenderBlock)callbac
     OSSubscriptionState *subscriptionState = state.subscriptionStatus;
     
     // Received push notification prompt? (iOS only property)
-	BOOL hasPrompted = permissionState.hasPrompted == 1;
-	
-	// Notifications enabled for app? (iOS Settings)
-	BOOL notificationsEnabled = permissionState.status == 2;
-	
-	// User subscribed to OneSignal? (automatically toggles with notificationsEnabled)
-	BOOL subscriptionEnabled = subscriptionState.subscribed == 1;
-	
-	// User's original subscription preference (regardless of notificationsEnabled)
-	BOOL userSubscriptionEnabled = subscriptionState.userSubscriptionSetting == 1;
-    
+    BOOL hasPrompted = permissionState.hasPrompted == 1;
+
+    // Notifications enabled for app? (iOS Settings)
+    BOOL notificationsEnabled = permissionState.status == 2;
+
+    // User subscribed to OneSignal? (automatically toggles with notificationsEnabled)
+    BOOL subscriptionEnabled = subscriptionState.subscribed == 1;
+
+    // User's original subscription preference (regardless of notificationsEnabled)
+    BOOL userSubscriptionEnabled = subscriptionState.userSubscriptionSetting == 1;
+
     callback(@[@{
-		@"hasPrompted": @(hasPrompted),
+        @"hasPrompted": @(hasPrompted),
         @"notificationsEnabled": @(notificationsEnabled),
         @"subscriptionEnabled": @(subscriptionEnabled),
         @"userSubscriptionEnabled": @(userSubscriptionEnabled),

--- a/ios/RCTOneSignal/RCTOneSignal.m
+++ b/ios/RCTOneSignal/RCTOneSignal.m
@@ -168,6 +168,45 @@ RCT_EXPORT_METHOD(requestPermissions:(NSDictionary *)permissions) {
     }
 }
 
+RCT_EXPORT_METHOD(getPermissionSubscriptionState:(RCTResponseSenderBlock)callback)
+{
+    if (RCTRunningInAppExtension()) {
+        callback(@[@{
+			@"hasPrompted": @NO,
+            @"notificationsEnabled": @NO,
+            @"subscriptionEnabled": @NO,
+            @"userSubscriptionEnabled": @NO,
+            @"pushToken": [NSNull null],
+            @"userId": [NSNull null],
+        }]);
+    }
+    
+    OSPermissionSubscriptionState *state = [OneSignal getPermissionSubscriptionState];
+    OSPermissionState *permissionState = state.permissionStatus;
+    OSSubscriptionState *subscriptionState = state.subscriptionStatus;
+    
+    // Received push notification prompt? (iOS only property)
+	BOOL hasPrompted = permissionState.hasPrompted == 1;
+	
+	// Notifications enabled for app? (iOS Settings)
+	BOOL notificationsEnabled = permissionState.status == 2;
+	
+	// User subscribed to OneSignal? (automatically toggles with notificationsEnabled)
+	BOOL subscriptionEnabled = subscriptionState.subscribed == 1;
+	
+	// User's original subscription preference (regardless of notificationsEnabled)
+	BOOL userSubscriptionEnabled = subscriptionState.userSubscriptionSetting == 1;
+    
+    callback(@[@{
+		@"hasPrompted": @(hasPrompted),
+        @"notificationsEnabled": @(notificationsEnabled),
+        @"subscriptionEnabled": @(subscriptionEnabled),
+        @"userSubscriptionEnabled": @(userSubscriptionEnabled),
+        @"pushToken": subscriptionState.pushToken,
+        @"userId": subscriptionState.userId,
+    }]);
+}
+
 RCT_EXPORT_METHOD(registerForPushNotifications) {
     [OneSignal registerForPushNotifications];
 }


### PR DESCRIPTION
Implementations for both Android and iOS. I changed numeric properties to booleans to ensure compatibility between the two platforms (permissionStatus.status returns 2 or 1 in iOS, but 1 or 0 in Android).