### PR TITLE
Remove deprecated method for RN 0.47 compat

### DIFF
--- a/android/src/main/java/com/geektime/rnonesignalandroid/ReactNativeOneSignalPackage.java
+++ b/android/src/main/java/com/geektime/rnonesignalandroid/ReactNativeOneSignalPackage.java
@@ -27,11 +27,6 @@ public class ReactNativeOneSignalPackage implements ReactPackage {
     }
 
     @Override
-    public List<Class<? extends JavaScriptModule>> createJSModules() {
-        return Collections.emptyList();
-    }
-
-    @Override
     public List<ViewManager> createViewManagers(ReactApplicationContext reactContext) {
         return new ArrayList<>();
     }


### PR DESCRIPTION
The component doesn't compile in RN 0.47-rc5 - discussion at https://github.com/facebook/react-native/issues/15232