### PR TITLE
Remove createJSModules @ovveride marker - RN 0.47 compatibility

### DIFF
--- a/android/src/main/java/com/geektime/rnonesignalandroid/ReactNativeOneSignalPackage.java
+++ b/android/src/main/java/com/geektime/rnonesignalandroid/ReactNativeOneSignalPackage.java
@@ -26,7 +26,7 @@ public class ReactNativeOneSignalPackage implements ReactPackage {
         return modules;
     }
 
-    @Override
+    // Deprecated RN 0.47
     public List<Class<? extends JavaScriptModule>> createJSModules() {
         return Collections.emptyList();
     }


### PR DESCRIPTION
[`createJSModules` is now not required on Android](https://github.com/facebook/react-native/commit/ce6fb337a146e6f261f2afb564aa19363774a7a8) from RN 0.47. I actually can't build an app on RN 0.47 without removing this method/@ovveride marker. There is similar PR (#292), but this solution seems better for backwards compatibility.