### PR TITLE
Bind `this` to event listeners to easily access app props and state

### DIFF
--- a/README.md
+++ b/README.md
@@ -207,10 +207,10 @@ import OneSignal from 'react-native-onesignal'; // Import package from node modu
 export default class App extends Component {
 
     componentWillMount() {
-        OneSignal.addEventListener('received', this.onReceived);
-        OneSignal.addEventListener('opened', this.onOpened);
-        OneSignal.addEventListener('registered', this.onRegistered);
-        OneSignal.addEventListener('ids', this.onIds);
+        OneSignal.addEventListener('received', this.onReceived.bind(this));
+        OneSignal.addEventListener('opened', this.onOpened.bind(this));
+        OneSignal.addEventListener('registered', this.onRegistered.bind(this));
+        OneSignal.addEventListener('ids', this.onIds.bind(this));
     }
 
     componentWillUnmount() {


### PR DESCRIPTION
As seen in https://stackoverflow.com/questions/44668422/react-native-onesignal-implementation, `this.props`, `this.state` and `this.setState` are all unusable because `this` is undefined unless listeners are bound to `this` in `componentWillMount`.

