### PR TITLE
Move to RCTEventEmitter, unified JS initialization and more.

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -20,10 +20,6 @@ android {
         targetSdkVersion 22
         versionCode 1
         versionName "1.0"
-        // Do not set onesignal_app_id here, it will be set in the app project.
-        // Leave onesignal_google_project_number as it is now pulled from the dashboard.
-        manifestPlaceholders = [onesignal_app_id: "",
-                                onesignal_google_project_number: "REMOTE"]
     }
     buildTypes {
         release {

--- a/android/src/main/AndroidManifest.xml
+++ b/android/src/main/AndroidManifest.xml
@@ -1,3 +1,12 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
-    package="com.geektime.rnonesignalandroid">
+    package="com.geektime.rnonesignalandroid"
+    xmlns:tools="http://schemas.android.com/tools">
+
+
+    <application>
+        <!-- The OneSignal is initiated with app id from JS so these values are unnecessary. -->
+        <meta-data android:name="onesignal_app_id" tools:node="remove" />
+        <meta-data android:name="onesignal_google_project_number" tools:node="remove" />
+
+    </application>
 </manifest>

--- a/index.d.ts
+++ b/index.d.ts
@@ -1,0 +1,174 @@
+declare module 'react-native-onesignal' {
+  export enum OSEventName {
+    NotificationReceived = 'OneSignal-remoteNotificationReceived',
+    NotificationOpened = 'OneSignal-remoteNotificationOpened',
+    PermissionChanged = 'OneSignal-permissionChanged',
+    SubscriptionChanged = 'OneSignal-subscriptionChanged',
+  }
+
+  export interface OSPermissionState {
+    enabled: boolean;
+    [key: string]: any;
+  }
+
+  export interface OSPermissionStateChanges {
+    from: OSPermissionState;
+    to: OSPermissionState;
+  }
+
+  export interface OSSubscriptionState {
+    userId: string;
+    pushToken: string;
+    userSubscriptionSetting: boolean;
+    subscribed: boolean;
+    [key: string]: any;
+  }
+
+  export interface OSSubscriptionStateChanges {
+    from: OSSubscriptionState;
+    to: OSSubscriptionState;
+  }
+
+  export enum InFocusDisplayType {
+    None,
+    InAppAlert,
+    Notification,
+  }
+
+  interface IOSInitOptions {
+    autoPrompt?: boolean;
+    inAppAlerts?: boolean;
+    inAppLaunchURL?: boolean;
+    inFocusDisplayOption?: InFocusDisplayType;
+  }
+
+  enum ActionType {
+    Opened = 0,
+    ActionTaken = 1,
+  }
+
+  export interface OSNotificationAction {
+    type: ActionType;
+    actionID?: string;
+  }
+
+  interface OSNotificationPayload {
+    notificationID: string;
+    templateName: string;
+    templateId: string;
+    title: string;
+    body: string;
+    additionalData?: any;
+    launchURL?: string;
+    sound?: string;
+    actionButtons?: any[];
+    rawPayload: any;
+
+    // Android specific
+    smallIcon?: string;
+    largeIcon?: string;
+    bigPicture?: string;
+    smallIconAccentColor?: string;
+    ledColor?: string;
+    lockScreenVisibility: number;
+    groupKey?: string;
+    groupMessage?: string;
+    fromProjectNumber?: string;
+    collapseId: string;
+    priority: number;
+
+    // iOS specific
+    contentAvailable?: boolean;
+    mutableContent?: boolean;
+    category?: string;
+    badge?: number;
+    subtitle?: string;
+    attachments?: any;
+
+    [key: string]: any;
+  }
+
+  interface OSNotification {
+    isAppInFocus: boolean;
+    shown: boolean;
+    displayType: number;
+    payload: OSNotificationPayload;
+
+    // Android specific
+    androidNotificationId?: number;
+    groupedNotifications?: OSNotificationPayload[];
+
+    // iOS specific
+    silentNotification?: boolean;
+    mutableContent?: boolean;
+
+    [key: string]: any;
+  }
+
+  interface OSNotificationOpenResult {
+    notification: OSNotification;
+    action: OSNotificationAction;
+  }
+
+  export interface Subscription {
+    remove(): void;
+  }
+
+  export default class OneSignal {
+    static init(appId: string, iosOptions?: IOSInitOptions, googleProjectNumber?: string): void;
+
+    static on(eventName: typeof OSEventName.NotificationReceived, handler: (notification: OSNotification) => void): Subscription;
+    static on(eventName: typeof OSEventName.NotificationOpened, handler: (result: OSNotificationOpenResult) => void): Subscription;
+    static on(eventName: typeof OSEventName.PermissionChanged, handler: (changes: OSPermissionStateChanges) => void): Subscription;
+    static on(eventName: typeof OSEventName.SubscriptionChanged, handler: (changes: OSSubscriptionStateChanges) => void): Subscription;
+
+    /**
+     * @platform ios
+     */
+    static promptForPushNotificationsWithUserResponse(): Promise<boolean>;
+
+    static getPermissionSubscriptionState(): Promise<{ subscriptionStatus: OSSubscriptionState; permissionStatus: OSPermissionState }>;
+
+    static getTags(callback: (tags: string[]) => void): void;
+
+    static sendTag(key: string, value: string): Promise<any>;
+    static sendTags(tags: any): Promise<any>;
+
+    static deleteTag(key: string): Promise<any>;
+    static deleteTags(tags: ReadonlyArray<string>): Promise<any>;
+
+    static setInFocusDisplayType(displayOption: InFocusDisplayType): void;
+
+    /**
+     * @platform android
+     */
+    static enableVibrate(enable: boolean): void;
+
+    /**
+     * @platform android
+     */
+    static enableSound(enable: boolean): void;
+
+    static setLocationShared(shared: boolean): void;
+
+    static promptLocation(): void;
+
+    static syncHashedEmail(email: string): void;
+
+    static postNotification(notificationData: any): Promise<any>;
+
+    /**
+     * @platform android
+     */
+    static cancelNotification(id: string): void;
+
+    /**
+     * @platform android
+     */
+    static clearOneSignalNotifications(): void;
+
+    static setSubscription(enable: boolean): void;
+
+    static setLogLevel(nsLogLevel: number, visualLogLevel: number);
+  }
+}

--- a/index.js
+++ b/index.js
@@ -1,255 +1,125 @@
-
 'use strict';
+import { NativeModules, NativeAppEventEmitter, NativeEventEmitter, Platform } from 'react-native';
 
-import { NativeModules, NativeAppEventEmitter, NetInfo, Platform } from 'react-native';
-import invariant from 'invariant';
+const EventEmitter = new NativeEventEmitter(NativeModules.OneSignal || {});
 
-var _eventBroadcastNames = [
-    'OneSignal-remoteNotificationReceived',
-    'OneSignal-remoteNotificationOpened',
-    'OneSignal-remoteNotificationsRegistered',
-    'OneSignal-idsAvailable'
-];
+const RNOneSignal = NativeModules.OneSignal;
 
-var _eventNames = [ "received", "opened", "registered", "ids" ];
+export const OSEventName = {
+  NotificationReceived: 'OneSignal-remoteNotificationReceived',
+  NotificationOpened: 'OneSignal-remoteNotificationOpened',
+  PermissionChanged: 'OneSignal-permissionChanged',
+  SubscriptionChanged: 'OneSignal-subscriptionChanged',
+};
 
-var _notificationHandler = new Map();
-var _notificationCache = new Map();
-var _listeners = [];
-
-for(var i = 0; i < _eventBroadcastNames.length; i++) {
-    var eventBroadcastName = _eventBroadcastNames[i];
-    var eventName = _eventNames[i];
-
-    _listeners[eventName] = handleEventBroadcast(eventName, eventBroadcastName)
-}
-
-var RNOneSignal = NativeModules.OneSignal;
-
-
-var DEVICE_NOTIF_RECEIVED_EVENT = 'OneSignal-remoteNotificationReceived';
-var DEVICE_NOTIF_OPENED_EVENT = 'OneSignal-remoteNotificationOpened';
-var DEVICE_NOTIF_REG_EVENT = 'OneSignal-remoteNotificationsRegistered';
-var DEVICE_IDS_AVAILABLE = 'OneSignal-idsAvailable';
-
-function handleEventBroadcast(type, broadcast) {
-    return NativeAppEventEmitter.addListener(
-        broadcast, (notification) => { 
-            // Check if we have added listener for this type yet
-            // Cache the result first if we have not.
-            var handler = _notificationHandler.get(type);
-
-            if (handler) {
-                handler(notification);
-            } else {
-                _notificationCache.set(type, notification);
-            }
-        }
-    );
-}
-
-function handleConnectionStateChange(isConnected) {
-    if (!isConnected) return;
-
-    OneSignal.configure();
-    NetInfo.isConnected.removeEventListener('connectionChange', handleConnectionStateChange);
-}
-
-NetInfo.isConnected.fetch().then(isConnected => {
-    if (isConnected) return OneSignal.configure();
-    NetInfo.isConnected.addEventListener('connectionChange', handleConnectionStateChange);
-}).catch((...args) => console.warn("Error: ", args));
-
+export const InFocusDisplayType = {
+  None: 0,
+  InAppAlert: 1,
+  Notification: 2,
+};
 
 export default class OneSignal {
-
-    static addEventListener(type: any, handler: Function) {
-
-        // Listen to events of notification received, opened, device registered and IDSAvailable.
-
-        invariant(
-            type === 'received' || type === 'opened' || type === 'registered' || type === 'ids',
-            'OneSignal only supports `received`, `opened`, `registered`, and `ids` events'
-        );
-
-        _notificationHandler.set(type, handler);
-
-        // Check if there is a cache for this type of event
-        var cache = _notificationCache.get(type);
-        if (handler && cache) {
-            handler(cache);
-            _notificationCache.delete(type);
-        }
+  static init(appId, iosOptions = {}, googleProjectNumber = 'REMOTE') {
+    if (Platform.OS === 'ios') {
+      RNOneSignal.initOneSignal(appId, iosOptions);
+    } else {
+      RNOneSignal.initOneSignal(appId, googleProjectNumber);
     }
+  }
 
-    static removeEventListener(type: any, handler: Function) {
-        invariant(
-            type === 'received' || type === 'opened' || type === 'registered' || type === 'ids',
-            'OneSignal only supports `received`, `opened`, `registered`, and `ids` events'
-        );
+  static on(eventName, handler) {
+    return EventEmitter.addListener(eventName, handler);
+  }
 
-        _notificationHandler.delete(type);
+  static promptForPushNotificationsWithUserResponse() {
+    if (Platform.OS === 'ios') {
+      return RNOneSignal.promptForPushNotificationsWithUserResponse();
+    } else {
+      console.log('This function is not supported on Android');
     }
+  }
 
-    static clearListeners() {
-        for(var i = 0; i < _eventNames.length; i++) {
-            _listeners[_eventNames].remove();
-        }
-    }
+  static getPermissionSubscriptionState() {
+    return RNOneSignal.getPermissionSubscriptionState();
+  }
 
-    static registerForPushNotifications() {
-        if (Platform.OS === 'ios') {
-            RNOneSignal.registerForPushNotifications();
-        } else {
-            console.log("This function is not supported on Android");
-        }
-    }
-    
-    static promptForPushNotificationsWithUserResponse(callback: Function) {
-        if (Platform.OS === 'ios') {
-            invariant(
-                typeof callback === 'function',
-                'Must provide a valid callback'
-            );
-            RNOneSignal.promptForPushNotificationsWithUserResponse(callback);
-        } else {
-            console.log("This function is not supported on Android");
-        }
-    }
+  static getTags(callback) {
+    RNOneSignal.getTags(callback);
+  }
 
-    static requestPermissions(permissions) {
-        var requestedPermissions = {};
-        if (Platform.OS === 'ios') {
-            if (permissions) {
-                requestedPermissions = {
-                    alert: !!permissions.alert,
-                    badge: !!permissions.badge,
-                    sound: !!permissions.sound
-                };
-            } else {
-                requestedPermissions = {
-                    alert: true,
-                    badge: true,
-                    sound: true
-                };
-            }
-            RNOneSignal.requestPermissions(requestedPermissions);
-        } else {
-            console.log("This function is not supported on Android");
-        }
-    }
+  static sendTag(key, value) {
+    return RNOneSignal.sendTag(key, value);
+  }
 
-    static configure() {
-        RNOneSignal.configure();
-    }
+  static sendTags(tags) {
+    return RNOneSignal.sendTags(tags || {});
+  }
 
-    static checkPermissions(callback: Function) {
-        if (Platform.OS === 'ios') {
-            invariant(
-                typeof callback === 'function',
-                'Must provide a valid callback'
-            );
-            RNOneSignal.checkPermissions(callback);
-        } else {
-            console.log("This function is not supported on Android");
-        }
-    }
+  static deleteTag(key) {
+    return RNOneSignal.deleteTag(key);
+  }
 
-    static getPermissionSubscriptionState(callback: Function) {
-        invariant(
-            typeof callback === 'function',
-            'Must provide a valid callback'
-        );
-        RNOneSignal.getPermissionSubscriptionState(callback);
-    }
+  static deleteTags(keys) {
+    return RNOneSignal.deleteTag(keys);
+  }
 
-    static sendTag(key, value) {
-        RNOneSignal.sendTag(key, value);
-    }
+  static setInFocusDisplayType(displayOption) {
+    RNOneSignal.setInFocusDisplayType(displayOption);
+  }
 
-    static sendTags(tags) {
-        RNOneSignal.sendTags(tags || {});
+  static enableVibrate(enable) {
+    if (Platform.OS === 'android') {
+      RNOneSignal.enableVibrate(enable);
+    } else {
+      console.log('This function is not supported on iOS');
     }
+  }
 
-    static getTags(next) {
-        RNOneSignal.getTags(next);
+  static enableSound(enable) {
+    if (Platform.OS === 'android') {
+      RNOneSignal.enableSound(enable);
+    } else {
+      console.log('This function is not supported on iOS');
     }
+  }
 
-    static deleteTag(key) {
-        RNOneSignal.deleteTag(key);
-    }
+  static setLocationShared(shared) {
+    RNOneSignal.setLocationShared(shared);
+  }
 
-    static enableVibrate(enable) {
-        if (Platform.OS === 'android') {
-            RNOneSignal.enableVibrate(enable);
-        } else {
-            console.log("This function is not supported on iOS");
-        }
-    }
+  static promptLocation() {
+    RNOneSignal.promptLocation();
+  }
 
-    static enableSound(enable) {
-        if (Platform.OS === 'android') {
-            RNOneSignal.enableSound(enable);
-        } else {
-            console.log("This function is not supported on iOS");
-        }
-    }
-    
-    static setLocationShared(shared) {
-        RNOneSignal.setLocationShared(shared);
-    }
+  static syncHashedEmail(email) {
+    RNOneSignal.syncHashedEmail(email);
+  }
 
-    static setSubscription(enable) {
-        RNOneSignal.setSubscription(enable);
-    }
+  static postNotification(notificationData) {
+    return RNOneSignal.postNotification(notificationData);
+  }
 
-    static promptLocation() {
-        //Supported in both iOS & Android
-        RNOneSignal.promptLocation();
+  static cancelNotification(id) {
+    if (Platform.OS === 'android') {
+      RNOneSignal.cancelNotification(id);
+    } else {
+      console.log('This function is not supported on iOS');
     }
+  }
 
-    static inFocusDisplaying(displayOption) {
-        if (Platform.OS === 'android') {
-            //Android: Set Display option of the notifications. displayOption is of type OSInFocusDisplayOption
-            // 0 -> None, 1 -> InAppAlert, 2 -> Notification
-            RNOneSignal.inFocusDisplaying(displayOption);
-        } else {
-            //iOS: displayOption is a number, 0 -> None, 1 -> InAppAlert, 2 -> Notification
-            RNOneSignal.setInFocusDisplayType(displayOption);
-        }
+  static clearOneSignalNotifications() {
+    if (Platform.OS === 'android') {
+      RNOneSignal.clearOneSignalNotifications();
+    } else {
+      console.log('This function is not supported on iOS');
     }
+  }
 
-    static postNotification(contents, data, player_id, otherParameters) {
-        if (Platform.OS === 'android') {
-            RNOneSignal.postNotification(JSON.stringify(contents), JSON.stringify(data), player_id, JSON.stringify(otherParameters));
-        } else {
-            RNOneSignal.postNotification(contents, data, player_id, otherParameters);
-        }
-    }
+  static setSubscription(enable) {
+    RNOneSignal.setSubscription(enable);
+  }
 
-    static clearOneSignalNotifications() {
-        if (Platform.OS === 'android') {
-            RNOneSignal.clearOneSignalNotifications();
-        } else {
-            console.log("This function is not supported on iOS");
-        }
-    }
-
-    static cancelNotification(id) {
-        if (Platform.OS === 'android') {
-            RNOneSignal.cancelNotification(id);
-        } else {
-            console.log("This function is not supported on iOS");
-        }
-    }
-
-    //Sends MD5 and SHA1 hashes of the user's email address (https://documentation.onesignal.com/docs/ios-sdk-api#section-synchashedemail)
-    static syncHashedEmail(email) {
-        RNOneSignal.syncHashedEmail(email);
-    }
-
-    static setLogLevel(nsLogLevel, visualLogLevel) {
-        RNOneSignal.setLogLevel(nsLogLevel, visualLogLevel);
-    }
-
+  static setLogLevel(nsLogLevel, visualLogLevel) {
+    RNOneSignal.setLogLevel(nsLogLevel, visualLogLevel);
+  }
 }

--- a/ios/RCTOneSignal/RCTOneSignal.h
+++ b/ios/RCTOneSignal/RCTOneSignal.h
@@ -1,7 +1,9 @@
 #if __has_include(<React/RCTBridgeModule.h>)
 #import <React/RCTBridgeModule.h>
+#import <React/RCTEventEmitter.h>
 #elif __has_include("RCTBridgeModule.h")
 #import "RCTBridgeModule.h"
+#import "RCTEventEmitter.h"
 #endif
 
 #if __has_include(<OneSignal/OneSignal.h>)
@@ -10,9 +12,6 @@
 #import "OneSignal.h"
 #endif
 
-@interface RCTOneSignal : NSObject <RCTBridgeModule, OSSubscriptionObserver>
+@interface RCTOneSignal : RCTEventEmitter <RCTBridgeModule, OSSubscriptionObserver, OSPermissionObserver>
 
-- (id)initWithLaunchOptions:(NSDictionary *)launchOptions appId:(NSString *)appId;
-- (id)initWithLaunchOptions:(NSDictionary *)launchOptions appId:(NSString *)appId settings:(NSDictionary*)settings;
-+ (void)didReceiveRemoteNotification:(NSDictionary *)dictionary;
 @end


### PR DESCRIPTION
Hi,
I have recently needed to bring support for OneSignal to RN app which I'm working on and logically the first thing what I tried was this library - react-native-onesignal. Unfortunately, I was facing many issues, that was related to the setup of my app where I use for example react-native-navigation or redux-saga. The other thing is that the react-native-onesignal has many things implemented in way that is very different to that we can see in native onesignal library for iOS and Android and some things aren't implemented at all. I think that it's not good as on one side it's confusing for someone who wants to use this library. On the other side, it has to be very difficult to maintain it, particularly when there is some change in the native one's libs.
So for that reasons I have decided to look under the hood and try to solve some of that. Now I would like to show off what I have done for now and hear what do you think about that. Eventually, I will be more than happy to collaborate on merging it.

So now something about the changes.

1. RCTOneSignal class on iOS now inherits from RCTEventEmitter. Thanks to that it's not needed to use the deprecated way to interact with JS.
1. The initialization of OneSignal which was solved by the line that has to be copied to AppDelegate gets impossible that way, as the subclasses of RCTEventEmitter are instantiated by react-native. So I was finding some way how to do it differently and fortunately, I found that in the [OneSignal/OneSignal-Cordova-SDK](https://goo.gl/MMpQuP) they had to solve something similar. After some adjustments, it can be used in our case too. [Here](https://goo.gl/wmmFGb) I wrote some details about that.
1. The result is a unified way to set up the library on both iOS and  Android. Here is example: `OneSignal.init(Constants.oneSignalAppId, { autoPrompt: true });` this line have to be added to the main index.js of your app and it's all. No need to change something in Xcode or Android studio :slightly_smiling_face:.
1. Most of the functions return promise now. This is mainly advantaged on iOS because the implementation of native SDK for Android is different in the promise gets resolved instantly in most cases here despite the of real result. But I found it useful anyway, `async/await` syntax can be used now etc..
1. There shouldn't be any issues with initial notifications etc. as that events get holds on the native side even if they were dispatched and the JS context isn't initialized yet. They will be dispatched right to the appropriate handler for that event is registered on JS side.
1. Most of the functions now directly call that in native SDKs. So the developer experience should be unified with official SDKs on other platforms.
1. I have added TypeScript definitions file.

It still needs some work (documentation, ..) but I believe that the changes are meaningful.

Thanks.
PS: Sorry for the awkward title of PR.

## <!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/onesignal/react-native-onesignal/395)
<!-- Reviewable:end -->

