### PR TITLE
Add fix for no registration on Android to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -761,6 +761,10 @@ When you install `react-native-onesignal` it will automaticly include a specific
 
 Please see the `examples/RNOneSignal/redux-index.js` file for example code and comments. Note that it will not compile, but instead serves as a template for how to handle Redux integration in general, and specifically including the edge case for intercepting the `onOpened` event when a User taps a push notification and prompts the app to open from a previously unopened state.
 
+### Issue 7 - Phone does not register on Android
+
+Check whether the `<application>` tag in your `AndroidManifest.xml` file contains `tools:node="replace"`. If it does, remove this line, save the manifest file, and re-run the application using `react-native run-android`. 
+
 ## CREDITS
 Thanks for all the awesome fellows that contributed to this repository!
 @danpe, @lunchieapp, @gaykov, @williamrijksen, @adrienbrault, @kennym, @dunghuynh, @holmesal, @joshuapinter, @jkasten2, @JKalash


### PR DESCRIPTION
The last few days various people have reported that their devices do no longer register on Android (e.g., #382). A fix was proposed in #396. To avoid confusion and redundant issues, I propose this PR which adds the fix into the README.

## <!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/onesignal/react-native-onesignal/402)
<!-- Reviewable:end -->

