### PR TITLE
Fixed a bug when installing via cocoapods

### DIFF
--- a/ios/RCTOneSignal/RCTOneSignalEventEmitter.m
+++ b/ios/RCTOneSignal/RCTOneSignalEventEmitter.m
@@ -6,7 +6,11 @@
 //
 
 #import "RCTOneSignalEventEmitter.h"
+#if __has_include(<OneSignal/OneSignal.h>)
+#import <OneSignal/OneSignal.h>
+#else
 #import "OneSignal.h"
+#endif
 
 
 #pragma GCC diagnostic push


### PR DESCRIPTION
When installing via cocoapods, OneSignal is installed as a framework. As a result, build process fails. Can be fixed via conditional import.