### PR TITLE
Fix setEmail and improve readme

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,31 @@
+# Contributing to the OneSignal React-Native SDK
+
+:+1::tada: First off, thanks for taking the time to contribute! :tada::+1:
+
+### How to Contribute
+We love the open source community and enjoy the support and contributions of many of our users. We ask that any potential contributors to the SDK Follow the following guidelines:
+
+If your proposed contribution is a small bug fix, please feel free to create your own fork of the repository and create a pull request.
+
+If your contribution would _break_ or _change_ the functionality of the SDK, please reach out to us on (contact) before you put in a lot of effort into a change we may not be able to use. We try our best to make sure that the SDK remains stable so that developers do not have to continually change their code, however some breaking changes _are_ desirable, so please get in touch to discuss your idea before you put in a lot of effort.
+
+### Reporting Bugs
+• If you have found a bug with the SDK, please feel free to open an Issue. 
+      If you are pretty certain that the issue is only related to the native iOS SDK, please open the issue in our [native iOS SDK repository](https://github.com/OneSignal/OneSignal-iOS-SDK).
+      If you are certain the issue is contained to the Android SDK, please open the issue in our [Android SDK repository](https://github.com/OneSignal/OneSignal-Android-SDK)
+
+#### Before Submitting A Bug Report
+Before creating bug reports, please check this list of steps to follow.
+
+1. Make sure that you are actually encountering an _issue_ and not a _question_. If you simply have a question about the SDK, we would be more than happy to assist you in our Support section on the web (https://www.onesignal.com - click the Message button at the bottom right)
+2. Please make sure to [include as many details as possible](#how-do-i-submit-a-good-bug-report)
+
+> **Note:** If you find a **Closed** issue that seems like it is the same thing that you're experiencing, open a new issue and include a link to the original issue in the body of your new one.
+
+
+#### How Do I Submit a Good Bug Report
+* **Use a clear and descriptive title** for the issue to identify the problem.
+* **Include Reproducibility** It is nearly always a good idea to include steps to reproduct the issue. If you cannot reliably reproduce the issue yourself, that's ok, but reproducible steps help best.
+* **Describe your environment**, tell us what version of react-native your app is using, what version of the react-native-onesignal SDK you're using, how you added it to your project, and so on.
+* **Include a Stack Trace** If your issue involves a crash/exception, ***PLEASE*** post the stack trace to help us identify the root issue.
+* **Include an Example Project** This isn't required, but if you want your issue fixed quickly, it's often a good idea to include an example project as a zip and include it with the issue. You can also download the Demo project (included in the `/examples` folder of this repo) and set up an example project with this code as a starting point.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -11,8 +11,8 @@ If your contribution would _break_ or _change_ the functionality of the SDK, ple
 
 ### Reporting Bugs
 • If you have found a bug with the SDK, please feel free to open an Issue. 
-      If you are pretty certain that the issue is only related to the native iOS SDK, please open the issue in our [native iOS SDK repository](https://github.com/OneSignal/OneSignal-iOS-SDK).
-      If you are certain the issue is contained to the Android SDK, please open the issue in our [Android SDK repository](https://github.com/OneSignal/OneSignal-Android-SDK)
+      * If you are pretty certain that the issue is only related to the native iOS SDK, please open the issue in our [native iOS SDK repository](https://github.com/OneSignal/OneSignal-iOS-SDK).
+      * If you are certain the issue is contained to the Android SDK, please open the issue in our [Android SDK repository](https://github.com/OneSignal/OneSignal-Android-SDK)
 
 #### Before Submitting A Bug Report
 Before creating bug reports, please check this list of steps to follow.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -9,10 +9,12 @@ If your proposed contribution is a small bug fix, please feel free to create you
 
 If your contribution would _break_ or _change_ the functionality of the SDK, please reach out to us on (contact) before you put in a lot of effort into a change we may not be able to use. We try our best to make sure that the SDK remains stable so that developers do not have to continually change their code, however some breaking changes _are_ desirable, so please get in touch to discuss your idea before you put in a lot of effort.
 
-### Reporting Bugs
-• If you have found a bug with the SDK, please feel free to open an Issue. 
-      * If you are pretty certain that the issue is only related to the native iOS SDK, please open the issue in our [native iOS SDK repository](https://github.com/OneSignal/OneSignal-iOS-SDK).
-      * If you are certain the issue is contained to the Android SDK, please open the issue in our [Android SDK repository](https://github.com/OneSignal/OneSignal-Android-SDK)
+#### Reporting Bugs
+If you have found a bug with the SDK, please feel free to open an Issue. 
+
+If you are pretty certain that the issue is only related to the native iOS SDK, please open the issue in our [native iOS SDK repository](https://github.com/OneSignal/OneSignal-iOS-SDK).
+
+If you are certain the issue is contained to the Android SDK, please open the issue in our [Android SDK repository](https://github.com/OneSignal/OneSignal-Android-SDK)
 
 #### Before Submitting A Bug Report
 Before creating bug reports, please check this list of steps to follow.

--- a/README.md
+++ b/README.md
@@ -159,6 +159,8 @@ android {
 
 ### Adding the Code
 
+<details><summary>Objective-C</summary><p>
+
  * in `AppDelegate.h`:
    * Import `RCTOneSignal.h`:
 
@@ -186,13 +188,49 @@ android {
         self.oneSignal = [[RCTOneSignal alloc] initWithLaunchOptions:launchOptions
                                                                appId:@"YOUR_ONESIGNAL_APP_ID"];
         ```
-
+    * You can also pass settings to OneSignal to control various effects, such as whether OneSignal automatically asks for permission to send push notifications shortly after launch or not.
         ```objc
-  	    // For requiring push notification permissions manually.
         self.oneSignal = [[RCTOneSignal alloc] initWithLaunchOptions:launchOptions
                                                                appId:@"YOUR_ONESIGNAL_APP_ID"
                                  settings:@{kOSSettingsKeyAutoPrompt: @false}];
         ```
+</p></details>
+
+<details><summary>Swift</summary><p>
+
+* If you don't already have one, create an Objective-C Bridging header for your project (`YourProjectName-Bridging-Header.h`) and import the React-Native-Onesignal library:
+
+```objc
+#import <RCTOneSignal.h>
+```
+ * In your AppDelegate, add the following property:
+
+ ```swift
+var oneSignal : RCTOneSignal!
+ ```
+
+* On the `application didFinishLaunchingWithOptions` method, insert the following code (replace YOUR_ONESIGNAL_APP_ID with your OneSignal app ID):
+
+```swift
+func application(_ application: UIApplication, didFinishLaunchingWithOptions launchOptions: [UIApplicationLaunchOptionsKey : Any]? = nil) -> Bool {
+    
+    self.oneSignal = RCTOneSignal(launchOptions: launchOptions, appId: "YOUR_ONESIGNAL_APP_ID");
+}
+
+```
+
+* You can also pass settings to OneSignal to control various effects, such as whether OneSignal automatically asks for permission to send push notifications shortly after launch or not.
+
+```swift
+func application(_ application: UIApplication, didFinishLaunchingWithOptions launchOptions: [UIApplicationLaunchOptionsKey : Any]? = nil) -> Bool {
+    
+    self.oneSignal = RCTOneSignal(launchOptions: launchOptions, appId: "YOUR_ONESIGNAL_APP_ID", settings: [kOSSettingsKeyAutoPrompt : false])
+}
+```
+
+</p></details>
+
+
 
 ### Add Notification Service Extension
 This step is optional but highly recommended. The `OneSignalNotificationServiceExtension` allows your application (in iOS) to receive rich notifications with images and/or buttons. If you do not follow this step, your application will not be able to show images in push notifications, and won't be able to add action buttons to notifications either.

--- a/android/src/main/java/com/geektime/rnonesignalandroid/RNOneSignal.java
+++ b/android/src/main/java/com/geektime/rnonesignalandroid/RNOneSignal.java
@@ -23,6 +23,7 @@ import com.facebook.react.modules.core.DeviceEventManagerModule;
 import com.onesignal.OSPermissionState;
 import com.onesignal.OSPermissionSubscriptionState;
 import com.onesignal.OSSubscriptionState;
+import com.onesignal.OSEmailSubscriptionState;
 import com.onesignal.OneSignal;
 import com.onesignal.OneSignal.EmailUpdateHandler;
 import com.onesignal.OneSignal.EmailUpdateError;
@@ -32,326 +33,331 @@ import org.json.JSONException;
 
 
 /**
- * Created by Avishay on 1/31/16.
- */
+* Created by Avishay on 1/31/16.
+*/
 public class RNOneSignal extends ReactContextBaseJavaModule implements LifecycleEventListener {
-    public static final String NOTIFICATION_OPENED_INTENT_FILTER = "GTNotificationOpened";
-    public static final String NOTIFICATION_RECEIVED_INTENT_FILTER = "GTNotificationReceived";
-    public static final String HIDDEN_MESSAGE_KEY = "hidden";
+   public static final String NOTIFICATION_OPENED_INTENT_FILTER = "GTNotificationOpened";
+   public static final String NOTIFICATION_RECEIVED_INTENT_FILTER = "GTNotificationReceived";
+   public static final String HIDDEN_MESSAGE_KEY = "hidden";
 
-    private ReactContext mReactContext;
-    private boolean oneSignalInitDone;
+   private ReactContext mReactContext;
+   private boolean oneSignalInitDone;
 
-    public RNOneSignal(ReactApplicationContext reactContext) {
-        super(reactContext);
-        mReactContext = reactContext;
-        mReactContext.addLifecycleEventListener(this);
-        initOneSignal();
-    }
+   public RNOneSignal(ReactApplicationContext reactContext) {
+      super(reactContext);
+      mReactContext = reactContext;
+      mReactContext.addLifecycleEventListener(this);
+      initOneSignal();
+   }
 
-    // Initialize OneSignal only once when an Activity is available.
-    // React creates an instance of this class to late for OneSignal to get the current Activity
-    // based on registerActivityLifecycleCallbacks it uses to listen for the first Activity.
-    // However it seems it is also to soon to call getCurrentActivity() from the reactContext as well.
-    // This will normally succeed when onHostResume fires instead.
-    private void initOneSignal() {
+   // Initialize OneSignal only once when an Activity is available.
+   // React creates an instance of this class to late for OneSignal to get the current Activity
+   // based on registerActivityLifecycleCallbacks it uses to listen for the first Activity.
+   // However it seems it is also to soon to call getCurrentActivity() from the reactContext as well.
+   // This will normally succeed when onHostResume fires instead.
+   private void initOneSignal() {
 
-        Activity activity = getCurrentActivity();
-        if (activity == null || oneSignalInitDone)
-            return;
+      Activity activity = getCurrentActivity();
+      if (activity == null || oneSignalInitDone)
+         return;
 
-        // Uncomment to debug init issues.
-        // OneSignal.setLogLevel(OneSignal.LOG_LEVEL.VERBOSE, OneSignal.LOG_LEVEL.ERROR);
+      // Uncomment to debug init issues.
+      // OneSignal.setLogLevel(OneSignal.LOG_LEVEL.VERBOSE, OneSignal.LOG_LEVEL.ERROR);
 
-        oneSignalInitDone = true;
+      oneSignalInitDone = true;
 
-        registerNotificationsOpenedNotification();
-        registerNotificationsReceivedNotification();
+      registerNotificationsOpenedNotification();
+      registerNotificationsReceivedNotification();
 
-        OneSignal.sdkType = "react";
-        OneSignal.startInit(activity)
-                .setNotificationOpenedHandler(new NotificationOpenedHandler(mReactContext))
-                .setNotificationReceivedHandler(new NotificationReceivedHandler(mReactContext))
-                .init();
-    }
+      OneSignal.sdkType = "react";
+      OneSignal.startInit(activity)
+               .setNotificationOpenedHandler(new NotificationOpenedHandler(mReactContext))
+               .setNotificationReceivedHandler(new NotificationReceivedHandler(mReactContext))
+               .init();
+   }
 
-    private void sendEvent(String eventName, Object params) {
-        mReactContext
-                .getJSModule(DeviceEventManagerModule.RCTDeviceEventEmitter.class)
-                .emit(eventName, params);
-    }
+   private void sendEvent(String eventName, Object params) {
+      mReactContext
+               .getJSModule(DeviceEventManagerModule.RCTDeviceEventEmitter.class)
+               .emit(eventName, params);
+   }
 
-    @ReactMethod
-    public void sendTag(String key, String value) {
-        OneSignal.sendTag(key, value);
-    }
+   @ReactMethod
+   public void sendTag(String key, String value) {
+      OneSignal.sendTag(key, value);
+   }
 
-    @ReactMethod
-    public void sendTags(ReadableMap tags) {
-        OneSignal.sendTags(RNUtils.readableMapToJson(tags));
-    }
+   @ReactMethod
+   public void sendTags(ReadableMap tags) {
+      OneSignal.sendTags(RNUtils.readableMapToJson(tags));
+   }
 
-    @ReactMethod
-    public void getTags(final Callback callback) {
-        OneSignal.getTags(new OneSignal.GetTagsHandler() {
-            @Override
-            public void tagsAvailable(JSONObject tags) {
-                callback.invoke(RNUtils.jsonToWritableMap(tags));
-            }
-        });
-    }
+   @ReactMethod
+   public void getTags(final Callback callback) {
+      OneSignal.getTags(new OneSignal.GetTagsHandler() {
+         @Override
+         public void tagsAvailable(JSONObject tags) {
+               callback.invoke(RNUtils.jsonToWritableMap(tags));
+         }
+      });
+   }
 
-    @ReactMethod 
-    public void setUnauthenticatedEmail(String email, final Callback callback) {
-        OneSignal.setEmail(email, null, new OneSignal.EmailUpdateHandler() {
-            @Override
-            public void onSuccess() {
-                callback.invoke();
-            }
+   @ReactMethod 
+   public void setUnauthenticatedEmail(String email, final Callback callback) {
+      OneSignal.setEmail(email, null, new OneSignal.EmailUpdateHandler() {
+         @Override
+         public void onSuccess() {
+               callback.invoke();
+         }
 
-            @Override
-            public void onFailure(EmailUpdateError error) {
-                try {
-                    JSONObject errorObject = new JSONObject("{'error' : '" + error.getMessage() + "'}");
-                    callback.invoke(RNUtils.jsonToWritableMap(errorObject));
-                } catch (JSONException exception) {
-                    exception.printStackTrace();
-                }
-            }
-        });
-    }
+         @Override
+         public void onFailure(EmailUpdateError error) {
+               try {
+                  JSONObject errorObject = new JSONObject("{'error' : '" + error.getMessage() + "'}");
+                  callback.invoke(RNUtils.jsonToWritableMap(errorObject));
+               } catch (JSONException exception) {
+                  exception.printStackTrace();
+               }
+         }
+      });
+   }
 
-    @ReactMethod 
-    public void setEmail(String email, String emailAuthToken, final Callback callback) {
-        OneSignal.setEmail(email, emailAuthToken, new EmailUpdateHandler() {
-            @Override
-            public void onSuccess() {
-                callback.invoke();
-            }
+   @ReactMethod 
+   public void setEmail(String email, String emailAuthToken, final Callback callback) {
+      OneSignal.setEmail(email, emailAuthToken, new EmailUpdateHandler() {
+         @Override
+         public void onSuccess() {
+               callback.invoke();
+         }
 
-            @Override
-            public void onFailure(EmailUpdateError error) {
-                try {
-                    JSONObject errorObject = new JSONObject("{'error' : '" + error.getMessage() + "'}");
-                    callback.invoke(RNUtils.jsonToWritableMap(errorObject));
-                } catch (JSONException exception) {
-                    exception.printStackTrace();
-                }
-            }
-        });
-    }
+         @Override
+         public void onFailure(EmailUpdateError error) {
+               try {
+                  JSONObject errorObject = new JSONObject("{'error' : '" + error.getMessage() + "'}");
+                  callback.invoke(RNUtils.jsonToWritableMap(errorObject));
+               } catch (JSONException exception) {
+                  exception.printStackTrace();
+               }
+         }
+      });
+   }
 
-    @ReactMethod
-    public void logoutEmail(final Callback callback) {
-        OneSignal.logoutEmail(new EmailUpdateHandler() {
-            @Override
-            public void onSuccess() {
-                callback.invoke();
-            }
+   @ReactMethod
+   public void logoutEmail(final Callback callback) {
+      OneSignal.logoutEmail(new EmailUpdateHandler() {
+         @Override
+         public void onSuccess() {
+               callback.invoke();
+         }
 
-            @Override
-            public void onFailure(EmailUpdateError error) {
-                try {
-                    JSONObject errorObject = new JSONObject("{'error' : '" + error.getMessage() + "'}");
-                    callback.invoke(RNUtils.jsonToWritableMap(errorObject));
-                } catch (JSONException exception) {
-                    exception.printStackTrace();
-                }
-            }
-        });
-    }
+         @Override
+         public void onFailure(EmailUpdateError error) {
+               try {
+                  JSONObject errorObject = new JSONObject("{'error' : '" + error.getMessage() + "'}");
+                  callback.invoke(RNUtils.jsonToWritableMap(errorObject));
+               } catch (JSONException exception) {
+                  exception.printStackTrace();
+               }
+         }
+      });
+   }
 
-    @ReactMethod
-    public void configure() {
-        OneSignal.idsAvailable(new OneSignal.IdsAvailableHandler() {
-            public void idsAvailable(String userId, String registrationId) {
-                final WritableMap params = Arguments.createMap();
+   @ReactMethod
+   public void configure() {
+      OneSignal.idsAvailable(new OneSignal.IdsAvailableHandler() {
+         public void idsAvailable(String userId, String registrationId) {
+               final WritableMap params = Arguments.createMap();
 
-                params.putString("userId", userId);
-                params.putString("pushToken", registrationId);
+               params.putString("userId", userId);
+               params.putString("pushToken", registrationId);
 
-                sendEvent("OneSignal-idsAvailable", params);
-            }
-        });
-    }
+               sendEvent("OneSignal-idsAvailable", params);
+         }
+      });
+   }
 
-    @ReactMethod
-    public void getPermissionSubscriptionState(final Callback callback) {
-        OSPermissionSubscriptionState state = OneSignal.getPermissionSubscriptionState();
-        OSPermissionState permissionState = state.getPermissionStatus();
-        OSSubscriptionState subscriptionState = state.getSubscriptionStatus();
+   @ReactMethod
+   public void getPermissionSubscriptionState(final Callback callback) {
+      OSPermissionSubscriptionState state = OneSignal.getPermissionSubscriptionState();
+      OSPermissionState permissionState = state.getPermissionStatus();
+      OSSubscriptionState subscriptionState = state.getSubscriptionStatus();
+      OSEmailSubscriptionState emailSubscriptionState = state.getEmailSubscriptionStatus();
 
-        // Notifications enabled for app? (Android Settings)
-        boolean notificationsEnabled = permissionState.getEnabled();
+      // Notifications enabled for app? (Android Settings)
+      boolean notificationsEnabled = permissionState.getEnabled();
 
-        // User subscribed to OneSignal? (automatically toggles with notificationsEnabled)
-        boolean subscriptionEnabled = subscriptionState.getSubscribed();
+      // User subscribed to OneSignal? (automatically toggles with notificationsEnabled)
+      boolean subscriptionEnabled = subscriptionState.getSubscribed();
 
-        // User's original subscription preference (regardless of notificationsEnabled)
-        boolean userSubscriptionEnabled = subscriptionState.getUserSubscriptionSetting();
+      // User's original subscription preference (regardless of notificationsEnabled)
+      boolean userSubscriptionEnabled = subscriptionState.getUserSubscriptionSetting();
 
-        try {
-            JSONObject result = new JSONObject("{" +
-                "'notificationsEnabled': " + String.valueOf(notificationsEnabled) + "," +
-                "'subscriptionEnabled': " + String.valueOf(subscriptionEnabled) + "," +
-                "'userSubscriptionEnabled': " + String.valueOf(userSubscriptionEnabled) + "," +
-                "'pushToken': " + subscriptionState.getPushToken() + "," +
-                "'userId': " + subscriptionState.getUserId() +
-            "}");
+      try {
+         JSONObject result = new JSONObject("{" +
+               "'notificationsEnabled': " + String.valueOf(notificationsEnabled) + "," +
+               "'subscriptionEnabled': " + String.valueOf(subscriptionEnabled) + "," +
+               "'userSubscriptionEnabled': " + String.valueOf(userSubscriptionEnabled) + "," +
+               "'pushToken': " + subscriptionState.getPushToken() + "," +
+               "'userId': " + subscriptionState.getUserId() + "," +
+               "'emailUserId' : " + emailSubscriptionState.getEmailUserId() + "," +
+               "'emailAddress' : " + emailSubscriptionState.getEmailAddress() +
+         "}");
 
-            callback.invoke(RNUtils.jsonToWritableMap(result));
-        } catch (JSONException e) {
-            e.printStackTrace();
-        }
-    }
+         Log.d("onesignal", "permission subscription state: " + result.toString());
 
-    @ReactMethod
-    public void inFocusDisplaying(int displayOption) {
-        OneSignal.setInFocusDisplaying(displayOption);
-    }
+         callback.invoke(RNUtils.jsonToWritableMap(result));
+      } catch (JSONException e) {
+         e.printStackTrace();
+      }
+   }
 
-    @ReactMethod
-    public void deleteTag(String key) {
-        OneSignal.deleteTag(key);
-    }
+   @ReactMethod
+   public void inFocusDisplaying(int displayOption) {
+      OneSignal.setInFocusDisplaying(displayOption);
+   }
 
-    @ReactMethod
-    public void enableVibrate(Boolean enable) {
-        OneSignal.enableVibrate(enable);
-    }
+   @ReactMethod
+   public void deleteTag(String key) {
+      OneSignal.deleteTag(key);
+   }
 
-    @ReactMethod
-    public void enableSound(Boolean enable) {
-        OneSignal.enableSound(enable);
-    }
+   @ReactMethod
+   public void enableVibrate(Boolean enable) {
+      OneSignal.enableVibrate(enable);
+   }
 
-    @ReactMethod
-    public void setSubscription(Boolean enable) {
-        OneSignal.setSubscription(enable);
-    }
+   @ReactMethod
+   public void enableSound(Boolean enable) {
+      OneSignal.enableSound(enable);
+   }
 
-    @ReactMethod
-    public void promptLocation() {
-        OneSignal.promptLocation();
-    }
+   @ReactMethod
+   public void setSubscription(Boolean enable) {
+      OneSignal.setSubscription(enable);
+   }
 
-    @ReactMethod
-    public void syncHashedEmail(String email) {
-        OneSignal.syncHashedEmail(email);
-    }
+   @ReactMethod
+   public void promptLocation() {
+      OneSignal.promptLocation();
+   }
 
-    @ReactMethod
-    public void setLogLevel(int logLevel, int visualLogLevel) {
-        OneSignal.setLogLevel(logLevel, visualLogLevel);
-    }
+   @ReactMethod
+   public void syncHashedEmail(String email) {
+      OneSignal.syncHashedEmail(email);
+   }
 
-    @ReactMethod
-    public void setLocationShared(Boolean shared) {
-        OneSignal.setLocationShared(shared);
-    }
+   @ReactMethod
+   public void setLogLevel(int logLevel, int visualLogLevel) {
+      OneSignal.setLogLevel(logLevel, visualLogLevel);
+   }
 
-    @ReactMethod
-    public void postNotification(String contents, String data, String playerId, String otherParameters) {
-        try {
-            JSONObject postNotification = new JSONObject("{'contents': " + contents + ", 'data': {'p2p_notification': " + data + "}, 'include_player_ids': ['" + playerId + "']}");
-            if (otherParameters != null && !otherParameters.trim().isEmpty()) {
-                JSONObject parametersJson = new JSONObject(otherParameters.trim());
-                Iterator<String> keys = parametersJson.keys();
-                while (keys.hasNext()) {
-                    String key = keys.next();
-                    postNotification.put(key, parametersJson.get(key));
-                }
+   @ReactMethod
+   public void setLocationShared(Boolean shared) {
+      OneSignal.setLocationShared(shared);
+   }
 
-                if (parametersJson.has(HIDDEN_MESSAGE_KEY) && parametersJson.getBoolean(HIDDEN_MESSAGE_KEY)) {
-                    postNotification.getJSONObject("data").put(HIDDEN_MESSAGE_KEY, true);
-                }
-            }
+   @ReactMethod
+   public void postNotification(String contents, String data, String playerId, String otherParameters) {
+      try {
+         JSONObject postNotification = new JSONObject("{'contents': " + contents + ", 'data': {'p2p_notification': " + data + "}, 'include_player_ids': ['" + playerId + "']}");
+         if (otherParameters != null && !otherParameters.trim().isEmpty()) {
+               JSONObject parametersJson = new JSONObject(otherParameters.trim());
+               Iterator<String> keys = parametersJson.keys();
+               while (keys.hasNext()) {
+                  String key = keys.next();
+                  postNotification.put(key, parametersJson.get(key));
+               }
 
-            OneSignal.postNotification(
-                postNotification,
-                new OneSignal.PostNotificationResponseHandler() {
-                    @Override
-                    public void onSuccess(JSONObject response) {
-                        Log.i("OneSignal", "postNotification Success: " + response.toString());
-                    }
+               if (parametersJson.has(HIDDEN_MESSAGE_KEY) && parametersJson.getBoolean(HIDDEN_MESSAGE_KEY)) {
+                  postNotification.getJSONObject("data").put(HIDDEN_MESSAGE_KEY, true);
+               }
+         }
 
-                    @Override
-                    public void onFailure(JSONObject response) {
-                        Log.e("OneSignal", "postNotification Failure: " + response.toString());
-                    }
-                }
-            );
-        } catch (JSONException e) {
-            e.printStackTrace();
-        }
-    }
+         OneSignal.postNotification(
+               postNotification,
+               new OneSignal.PostNotificationResponseHandler() {
+                  @Override
+                  public void onSuccess(JSONObject response) {
+                     Log.i("OneSignal", "postNotification Success: " + response.toString());
+                  }
 
-    @ReactMethod
-    public void clearOneSignalNotifications() {
-        OneSignal.clearOneSignalNotifications();
-    }
+                  @Override
+                  public void onFailure(JSONObject response) {
+                     Log.e("OneSignal", "postNotification Failure: " + response.toString());
+                  }
+               }
+         );
+      } catch (JSONException e) {
+         e.printStackTrace();
+      }
+   }
 
-    @ReactMethod
-    public void cancelNotification(int id) {
-        OneSignal.cancelNotification(id);
-    }
+   @ReactMethod
+   public void clearOneSignalNotifications() {
+      OneSignal.clearOneSignalNotifications();
+   }
 
-    private void registerNotificationsReceivedNotification() {
-        IntentFilter intentFilter = new IntentFilter(NOTIFICATION_RECEIVED_INTENT_FILTER);
-        mReactContext.registerReceiver(new BroadcastReceiver() {
-            @Override
-            public void onReceive(Context context, Intent intent) {
-                notifyNotificationReceived(intent.getExtras());
-            }
-        }, intentFilter);
-    }
+   @ReactMethod
+   public void cancelNotification(int id) {
+      OneSignal.cancelNotification(id);
+   }
 
-    private void registerNotificationsOpenedNotification() {
-        IntentFilter intentFilter = new IntentFilter(NOTIFICATION_OPENED_INTENT_FILTER);
-        mReactContext.registerReceiver(new BroadcastReceiver() {
-            @Override
-            public void onReceive(Context context, Intent intent) {
-                notifyNotificationOpened(intent.getExtras());
-            }
-        }, intentFilter);
-    }
+   private void registerNotificationsReceivedNotification() {
+      IntentFilter intentFilter = new IntentFilter(NOTIFICATION_RECEIVED_INTENT_FILTER);
+      mReactContext.registerReceiver(new BroadcastReceiver() {
+         @Override
+         public void onReceive(Context context, Intent intent) {
+               notifyNotificationReceived(intent.getExtras());
+         }
+      }, intentFilter);
+   }
 
-    private void notifyNotificationReceived(Bundle bundle) {
-        try {
-            JSONObject jsonObject = new JSONObject(bundle.getString("notification"));
-            sendEvent("OneSignal-remoteNotificationReceived", RNUtils.jsonToWritableMap(jsonObject));
-        } catch(Throwable t) {
-            t.printStackTrace();
-        }
-    }
+   private void registerNotificationsOpenedNotification() {
+      IntentFilter intentFilter = new IntentFilter(NOTIFICATION_OPENED_INTENT_FILTER);
+      mReactContext.registerReceiver(new BroadcastReceiver() {
+         @Override
+         public void onReceive(Context context, Intent intent) {
+               notifyNotificationOpened(intent.getExtras());
+         }
+      }, intentFilter);
+   }
 
-    private void notifyNotificationOpened(Bundle bundle) {
-        try {
-            JSONObject jsonObject = new JSONObject(bundle.getString("result"));
-            sendEvent("OneSignal-remoteNotificationOpened",  RNUtils.jsonToWritableMap(jsonObject));
-        } catch(Throwable t) {
-            t.printStackTrace();
-        }
-    }
+   private void notifyNotificationReceived(Bundle bundle) {
+      try {
+         JSONObject jsonObject = new JSONObject(bundle.getString("notification"));
+         sendEvent("OneSignal-remoteNotificationReceived", RNUtils.jsonToWritableMap(jsonObject));
+      } catch(Throwable t) {
+         t.printStackTrace();
+      }
+   }
 
-    @Override
-    public String getName() {
-        return "OneSignal";
-    }
+   private void notifyNotificationOpened(Bundle bundle) {
+      try {
+         JSONObject jsonObject = new JSONObject(bundle.getString("result"));
+         sendEvent("OneSignal-remoteNotificationOpened",  RNUtils.jsonToWritableMap(jsonObject));
+      } catch(Throwable t) {
+         t.printStackTrace();
+      }
+   }
 
-    @Override
-    public void onHostDestroy() {
+   @Override
+   public String getName() {
+      return "OneSignal";
+   }
 
-    }
+   @Override
+   public void onHostDestroy() {
 
-    @Override
-    public void onHostPause() {
+   }
 
-    }
+   @Override
+   public void onHostPause() {
 
-    @Override
-    public void onHostResume() {
-        initOneSignal();
-    }
+   }
+
+   @Override
+   public void onHostResume() {
+      initOneSignal();
+   }
 
 }

--- a/index.js
+++ b/index.js
@@ -200,17 +200,17 @@ export default class OneSignal {
     }
 
     static setEmail(email, emailAuthCode, callback) {
-
-        if (callback == undefined && typeof emailAuthCode == 'function') {
+        if (emailAuthCode == undefined) {
             //emailAuthCode is an optional parameter
             //since JS does not support function overloading,
             //unauthenticated setEmail calls will have emailAuthCode as the callback
 
-            var callback = emailAuthCode;
-
-            RNOneSignal.setUnauthenticatedEmail(email, callback);
+            RNOneSignal.setUnauthenticatedEmail(email, function(){});
+        } else if (callback == undefined && typeof emailAuthCode == 'function') {
+            RNOneSignal.setUnauthenticatedEmail(email, emailAuthCode);
+        } else if (callback == undefined) {
+            RNOneSignal.setEmail(email, emailAuthCode, function(){});
         } else {
-
             RNOneSignal.setEmail(email, emailAuthCode, callback);
         }
     }

--- a/index.js
+++ b/index.js
@@ -42,8 +42,6 @@ function handleEventBroadcast(type, broadcast) {
             }
         }
     );
-
-    console.log("NATIVE MODULES: ", NativeModules);
 }
 
 function handleConnectionStateChange(isConnected) {
@@ -66,8 +64,8 @@ export default class OneSignal {
         // Listen to events of notification received, opened, device registered and IDSAvailable.
 
         invariant(
-            type === 'received' || type === 'opened' || type === 'registered' || type === 'ids' || type == 'emailSubscription',
-            'OneSignal only supports `received`, `opened`, `registered`, and `ids` events'
+            type === 'received' || type === 'opened' || type === 'ids' || type == 'emailSubscription',
+            'OneSignal only supports `received`, `opened`, and `ids` events'
         );
 
         _notificationHandler.set(type, handler);
@@ -80,10 +78,10 @@ export default class OneSignal {
         }
     }
 
-    static removeEventListener(type: any, handler: Function) {
+    static removeEventListener(type, handler) {
         invariant(
-            type === 'received' || type === 'opened' || type === 'registered' || type === 'ids' || type == 'emailSubscription',
-            'OneSignal only supports `received`, `opened`, `registered`, and `ids` events'
+            type === 'received' || type === 'opened' || type === 'ids' || type == 'emailSubscription',
+            'OneSignal only supports `received`, `opened`, and `ids` events'
         );
 
         _notificationHandler.delete(type);
@@ -151,6 +149,14 @@ export default class OneSignal {
         } else {
             console.log("This function is not supported on Android");
         }
+    }
+
+    static promptForPushNotificationPermissions(callback) {
+       if (Platform.OS === 'ios') {
+         RNOneSignal.promptForPushNotificationPermissions(callback);
+       } else {
+          console.log('This function is not supported on Android');
+       }
     }
 
     static getPermissionSubscriptionState(callback: Function) {

--- a/ios/RCTOneSignal/RCTOneSignalEventEmitter.m
+++ b/ios/RCTOneSignal/RCTOneSignalEventEmitter.m
@@ -86,8 +86,13 @@ RCT_EXPORT_MODULE(RCTOneSignal)
 
 #pragma mark Exported Methods
 
-RCT_EXPORT_METHOD(checkPermissions:(RCTResponseSenderBlock)callback)
-{
+RCT_EXPORT_METHOD(promptForPushNotificationPermissions:(RCTResponseSenderBlock)callback) {
+    [OneSignal promptForPushNotificationsWithUserResponse:^(BOOL accepted) {
+        callback(@[@(accepted)]);
+    }];
+}
+
+RCT_EXPORT_METHOD(checkPermissions:(RCTResponseSenderBlock)callback) {
     if (RCTRunningInAppExtension()) {
         callback(@[@{@"alert": @NO, @"badge": @NO, @"sound": @NO}]);
         return;
@@ -173,13 +178,16 @@ RCT_EXPORT_METHOD(getPermissionSubscriptionState:(RCTResponseSenderBlock)callbac
 {
     if (RCTRunningInAppExtension()) {
         callback(@[@{
-                       @"hasPrompted": @NO,
-                       @"notificationsEnabled": @NO,
-                       @"subscriptionEnabled": @NO,
-                       @"userSubscriptionEnabled": @NO,
-                       @"pushToken": [NSNull null],
-                       @"userId": [NSNull null],
-                       }]);
+            @"hasPrompted": @NO,
+            @"notificationsEnabled": @NO,
+            @"subscriptionEnabled": @NO,
+            @"userSubscriptionEnabled": @NO,
+            @"pushToken": [NSNull null],
+            @"userId": [NSNull null],
+            @"emailUserId" : [NSNull null],
+            @"emailAddress" : [NSNull null],
+            @"emailSubscribed" : @false
+         }]);
     }
     
     OSPermissionSubscriptionState *state = [OneSignal getPermissionSubscriptionState];
@@ -206,6 +214,7 @@ RCT_EXPORT_METHOD(getPermissionSubscriptionState:(RCTResponseSenderBlock)callbac
        @"userSubscriptionEnabled": @(userSubscriptionEnabled),
        @"pushToken": subscriptionState.pushToken ?: [NSNull null],
        @"userId": subscriptionState.userId ?: [NSNull null],
+       @"emailUserId" : emailState.emailUserId ?: [NSNull null],
        @"emailSubscribed" : @(emailState.subscribed),
        @"emailAddress" : emailState.emailAddress ?: [NSNull null]
     }]);


### PR DESCRIPTION
• Adds Swift instructions to the iOS section of the Readme
• Adds a `contributing.md` document

Email Fixes:
• Fixes an issue with `setEmail()` which would have crashed an application if a callback was not provided.
• Adds Email to the `getPermissionSubscriptionState()` method