### PR TITLE
Fixed push notifications crashing on iOS 9 when app is open

### DIFF
--- a/ios/RCTOneSignal/RCTOneSignal.m
+++ b/ios/RCTOneSignal/RCTOneSignal.m
@@ -32,6 +32,9 @@
 
 OSNotificationOpenedResult* coldStartOSNotificationOpenedResult;
 
++ (void)didReceiveRemoteNotification:(NSDictionary *)dictionary {   
+}
+
 - (void)didStartObserving {
     didStartObserving = true;
     


### PR DESCRIPTION
When an app is open and receives a push notification, it fails.

```
NSInvalidArgumentException +[RCTOneSignal didReceiveRemoteNotification:]: unrecognized selector sent to class 0x5bbb04 
    Frameworks/CoreFoundation.framework/CoreFoundation ___exceptionPreprocess
    /usr/lib/libobjc.A.dylib _objc_exception_throw
    Frameworks/CoreFoundation.framework/CoreFoundation +[NSObject(NSObject) doesNotRecognizeSelector:]
    Frameworks/CoreFoundation.framework/CoreFoundation ____forwarding___
    Frameworks/CoreFoundation.framework/CoreFoundation ___forwarding_prep_0___
    Navi RCTFBQuickPerformanceLoggerConfigureHooks
    Navi RCTFBQuickPerformanceLoggerConfigureHooks
    Frameworks/UIKit.framework/UIKit -[UIApplication _handleNonLaunchSpecificActions:forScene:withTransitionContext:completion:]
    Frameworks/UIKit.framework/UIKit -[UIApplication workspace:didReceiveActions:]
    PrivateFrameworks/FrontBoardServices.framework/FrontBoardServices __FBSSERIALQUEUE_IS_CALLING_OUT_TO_A_BLOCK__
    PrivateFrameworks/FrontBoardServices.framework/FrontBoardServices -[FBSSerialQueue _performNext]
    PrivateFrameworks/FrontBoardServices.framework/FrontBoardServices -[FBSSerialQueue _performNextFromRunLoopSource]
    Frameworks/CoreFoundation.framework/CoreFoundation ___CFRUNLOOP_IS_CALLING_OUT_TO_A_SOURCE0_PERFORM_FUNCTION__
    Frameworks/CoreFoundation.framework/CoreFoundation ___CFRunLoopDoSources0
    Frameworks/CoreFoundation.framework/CoreFoundation ___CFRunLoopRun
    Frameworks/CoreFoundation.framework/CoreFoundation _CFRunLoopRunSpecific
    Frameworks/CoreFoundation.framework/CoreFoundation _CFRunLoopRunInMode
    PrivateFrameworks/GraphicsServices.framework/GraphicsServices _GSEventRunModal
    Frameworks/UIKit.framework/UIKit _UIApplicationMain
    Navi _mh_execute_header
    /usr/lib/system/libdyld.dylib _start
```