### PR TITLE
implement requiresMainQueueSetup for RN > 0.49

### DIFF
--- a/ios/RCTOneSignal/RCTOneSignalEventEmitter.m
+++ b/ios/RCTOneSignal/RCTOneSignalEventEmitter.m
@@ -27,6 +27,10 @@ static BOOL _didStartObserving = false;
     return _didStartObserving;
 }
 
++(BOOL)requiresMainQueueSetup {
+    return YES;
+}
+
 /*
      This class acts as the module & event emitter
      It is initialized automatically by React-Native


### PR DESCRIPTION
Module RCTOneSignalEventEmitter requires main queue setup since it overrides `init` but doesn't implement `requiresMainQueueSetup`. In a future release React Native will default to initializing all native modules on a background thread unless explicitly opted-out of.