### PR TITLE
Copy Headers

### DIFF
--- a/ios/RCTOneSignal.xcodeproj/project.pbxproj
+++ b/ios/RCTOneSignal.xcodeproj/project.pbxproj
@@ -8,6 +8,10 @@
 
 /* Begin PBXBuildFile section */
 		CA1CC868200FE3C3005B66AA /* RCTOneSignalExtensionService.m in Sources */ = {isa = PBXBuildFile; fileRef = CA1CC867200FE3C3005B66AA /* RCTOneSignalExtensionService.m */; };
+		CA3D8B582076D83C006F3572 /* RCTOneSignal.h in Headers */ = {isa = PBXBuildFile; fileRef = FDB40CC21C5E4E5500CBF09B /* RCTOneSignal.h */; };
+		CA3D8B592076D83C006F3572 /* RCTOneSignalExtensionService.h in Headers */ = {isa = PBXBuildFile; fileRef = CA1CC866200FE3C3005B66AA /* RCTOneSignalExtensionService.h */; };
+		CA3D8B5A2076D84E006F3572 /* RCTOneSignal.h in Copy Headers */ = {isa = PBXBuildFile; fileRef = FDB40CC21C5E4E5500CBF09B /* RCTOneSignal.h */; };
+		CA3D8B5B2076D84E006F3572 /* RCTOneSignalExtensionService.h in Copy Headers */ = {isa = PBXBuildFile; fileRef = CA1CC866200FE3C3005B66AA /* RCTOneSignalExtensionService.h */; };
 		CA8BBC6E205881CB002CDF67 /* libOneSignal.a in Frameworks */ = {isa = PBXBuildFile; fileRef = CA8BBC6D205881CB002CDF67 /* libOneSignal.a */; };
 		CACB39D6202D232A00D86CD1 /* RCTOneSignalEventEmitter.m in Sources */ = {isa = PBXBuildFile; fileRef = CACB39D5202D232A00D86CD1 /* RCTOneSignalEventEmitter.m */; };
 		FD2CCC851C772B4200B2B24E /* SystemConfiguration.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = FD2CCC841C772B4200B2B24E /* SystemConfiguration.framework */; };
@@ -15,13 +19,16 @@
 /* End PBXBuildFile section */
 
 /* Begin PBXCopyFilesBuildPhase section */
-		3245CDEB1BFEE35C00EABF68 /* CopyFiles */ = {
+		3245CDEB1BFEE35C00EABF68 /* Copy Headers */ = {
 			isa = PBXCopyFilesBuildPhase;
 			buildActionMask = 2147483647;
 			dstPath = "include/$(PRODUCT_NAME)";
 			dstSubfolderSpec = 16;
 			files = (
+				CA3D8B5A2076D84E006F3572 /* RCTOneSignal.h in Copy Headers */,
+				CA3D8B5B2076D84E006F3572 /* RCTOneSignalExtensionService.h in Copy Headers */,
 			);
+			name = "Copy Headers";
 			runOnlyForDeploymentPostprocessing = 0;
 		};
 /* End PBXCopyFilesBuildPhase section */
@@ -94,6 +101,18 @@
 		};
 /* End PBXGroup section */
 
+/* Begin PBXHeadersBuildPhase section */
+		CA3D8B572076D824006F3572 /* Headers */ = {
+			isa = PBXHeadersBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				CA3D8B582076D83C006F3572 /* RCTOneSignal.h in Headers */,
+				CA3D8B592076D83C006F3572 /* RCTOneSignalExtensionService.h in Headers */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXHeadersBuildPhase section */
+
 /* Begin PBXNativeTarget section */
 		3245CDEC1BFEE35C00EABF68 /* RCTOneSignal */ = {
 			isa = PBXNativeTarget;
@@ -101,7 +120,8 @@
 			buildPhases = (
 				3245CDE91BFEE35C00EABF68 /* Sources */,
 				3245CDEA1BFEE35C00EABF68 /* Frameworks */,
-				3245CDEB1BFEE35C00EABF68 /* CopyFiles */,
+				3245CDEB1BFEE35C00EABF68 /* Copy Headers */,
+				CA3D8B572076D824006F3572 /* Headers */,
 			);
 			buildRules = (
 			);

--- a/package.json
+++ b/package.json
@@ -9,6 +9,11 @@
   "dependencies": {
     "invariant": "^2.2.2"
   },
+  "rnpm": {
+     "ios": {
+        "sourceDir": "./ios"
+     }
+  },
   "keywords": [
     "react-component",
     "react-native",


### PR DESCRIPTION
• Developers previously had to manually add a header search path in order for the react native onesignal SDK to work
• Changed the SDK to be more like other react native packages that automatically copies necessary headers