### PR TITLE
[IOS] Fix didStartObserving never being called

### DIFF
--- a/ios/RCTOneSignal/RCTOneSignal.m
+++ b/ios/RCTOneSignal/RCTOneSignal.m
@@ -52,7 +52,7 @@ OSNotificationOpenedResult* coldStartOSNotificationOpenedResult;
 }
 
 - (id)initWithLaunchOptions:(NSDictionary *)launchOptions appId:(NSString *)appId settings:(NSDictionary*)settings {
-    [[NSNotificationCenter defaultCenter] addObserver:self selector:@selector(didStartObserving) name:@"didSetBridge" object:nil];
+    [[NSNotificationCenter defaultCenter] addObserver:self selector:@selector(didStartObserving) name:nil object:nil];
     [OneSignal addSubscriptionObserver:self];
     [OneSignal addEmailSubscriptionObserver:self];
     [OneSignal setValue:@"react" forKey:@"mSDKType"];


### PR DESCRIPTION
I recently had the issue that `opened` on iOS wasn't being called when you tapped a push notification.

After some debugging in Xcode I noticed that the code in [`didStartObserving`](https://github.com/geektimecoil/react-native-onesignal/blob/master/ios/RCTOneSignal/RCTOneSignal.m#L35) was never being called. Since the code with the `@"didSetBridge"` string seemed to be fine, I just tried without notification name as described [here](https://developer.apple.com/documentation/foundation/nsnotificationcenter/1415360-addobserver?language=objc) and suddenly the code in didStartObserving was being called.

I still have no clue why the `@"didSetBridge"` string didn't work, so if anyone has a clue, just shoot.