### PR TITLE
Gdpr privacy

### DIFF
--- a/android/src/main/java/com/geektime/rnonesignalandroid/RNOneSignal.java
+++ b/android/src/main/java/com/geektime/rnonesignalandroid/RNOneSignal.java
@@ -20,6 +20,7 @@ import com.facebook.react.bridge.ReactMethod;
 import com.facebook.react.bridge.ReadableMap;
 import com.facebook.react.bridge.WritableMap;
 import com.facebook.react.modules.core.DeviceEventManagerModule;
+import com.facebook.react.bridge.Promise;
 import com.onesignal.OSPermissionState;
 import com.onesignal.OSPermissionSubscriptionState;
 import com.onesignal.OSSubscriptionState;
@@ -179,6 +180,10 @@ public class RNOneSignal extends ReactContextBaseJavaModule implements Lifecycle
    @ReactMethod
    public void getPermissionSubscriptionState(final Callback callback) {
       OSPermissionSubscriptionState state = OneSignal.getPermissionSubscriptionState();
+
+      if (state == null)
+         return;
+
       OSPermissionState permissionState = state.getPermissionStatus();
       OSSubscriptionState subscriptionState = state.getSubscriptionStatus();
       OSEmailSubscriptionState emailSubscriptionState = state.getEmailSubscriptionStatus();
@@ -300,6 +305,21 @@ public class RNOneSignal extends ReactContextBaseJavaModule implements Lifecycle
    @ReactMethod
    public void cancelNotification(int id) {
       OneSignal.cancelNotification(id);
+   }
+
+   @ReactMethod
+   public void setRequiresUserPrivacyConsent(Boolean required) {
+      OneSignal.setRequiresUserPrivacyConsent(required);
+   }
+
+   @ReactMethod 
+   public void provideUserConsent(Boolean granted) {
+      OneSignal.provideUserConsent(granted);
+   }
+
+   @ReactMethod
+   public void userProvidedPrivacyConsent(Promise promise) {
+      promise.resolve(OneSignal.userProvidedPrivacyConsent());
    }
 
    private void registerNotificationsReceivedNotification() {

--- a/index.js
+++ b/index.js
@@ -267,5 +267,18 @@ export default class OneSignal {
     static setLogLevel(nsLogLevel, visualLogLevel) {
         RNOneSignal.setLogLevel(nsLogLevel, visualLogLevel);
     }
+    
+    static setRequiresUserPrivacyConsent(required) {
+       RNOneSignal.setRequiresUserPrivacyConsent(required);
+    }
+
+    static provideUserConsent(granted) {
+       RNOneSignal.provideUserConsent(granted);
+    }
+
+    static userProvidedPrivacyConsent() {
+       //returns a promise
+       return RNOneSignal.userProvidedPrivacyConsent();
+    }
 
 }

--- a/ios/OneSignal.h
+++ b/ios/OneSignal.h
@@ -340,6 +340,11 @@ typedef NS_ENUM(NSUInteger, ONE_S_LOG_LEVEL) {
 + (id)initWithLaunchOptions:(NSDictionary*)launchOptions appId:(NSString*)appId handleNotificationAction:(OSHandleNotificationActionBlock)actionCallback settings:(NSDictionary*)settings;
 + (id)initWithLaunchOptions:(NSDictionary*)launchOptions appId:(NSString*)appId handleNotificationReceived:(OSHandleNotificationReceivedBlock)receivedCallback handleNotificationAction:(OSHandleNotificationActionBlock)actionCallback settings:(NSDictionary*)settings;
 
+// - Privacy
++ (void)consentGranted:(BOOL)granted;
++ (BOOL)requiresUserPrivacyConsent; // tells your application if privacy consent is still needed from the current user
++ (void)setRequiresUserPrivacyConsent:(BOOL)required; //used by wrapper SDK's to require user privacy consent
+
 @property (class) OSNotificationDisplayType inFocusDisplayType;
 
 + (NSString*)app_id;

--- a/ios/RCTOneSignal.xcodeproj/project.pbxproj
+++ b/ios/RCTOneSignal.xcodeproj/project.pbxproj
@@ -8,11 +8,12 @@
 
 /* Begin PBXBuildFile section */
 		CA1CC868200FE3C3005B66AA /* RCTOneSignalExtensionService.m in Sources */ = {isa = PBXBuildFile; fileRef = CA1CC867200FE3C3005B66AA /* RCTOneSignalExtensionService.m */; };
+		CA362AF7209927E20095B77A /* libOneSignal.a in Frameworks */ = {isa = PBXBuildFile; fileRef = CA362AF5209927E20095B77A /* libOneSignal.a */; };
+		CA362AF8209927E20095B77A /* OneSignal.h in Headers */ = {isa = PBXBuildFile; fileRef = CA362AF6209927E20095B77A /* OneSignal.h */; };
 		CA3D8B582076D83C006F3572 /* RCTOneSignal.h in Headers */ = {isa = PBXBuildFile; fileRef = FDB40CC21C5E4E5500CBF09B /* RCTOneSignal.h */; };
 		CA3D8B592076D83C006F3572 /* RCTOneSignalExtensionService.h in Headers */ = {isa = PBXBuildFile; fileRef = CA1CC866200FE3C3005B66AA /* RCTOneSignalExtensionService.h */; };
 		CA3D8B5A2076D84E006F3572 /* RCTOneSignal.h in Copy Headers */ = {isa = PBXBuildFile; fileRef = FDB40CC21C5E4E5500CBF09B /* RCTOneSignal.h */; };
 		CA3D8B5B2076D84E006F3572 /* RCTOneSignalExtensionService.h in Copy Headers */ = {isa = PBXBuildFile; fileRef = CA1CC866200FE3C3005B66AA /* RCTOneSignalExtensionService.h */; };
-		CA8BBC6E205881CB002CDF67 /* libOneSignal.a in Frameworks */ = {isa = PBXBuildFile; fileRef = CA8BBC6D205881CB002CDF67 /* libOneSignal.a */; };
 		CACB39D6202D232A00D86CD1 /* RCTOneSignalEventEmitter.m in Sources */ = {isa = PBXBuildFile; fileRef = CACB39D5202D232A00D86CD1 /* RCTOneSignalEventEmitter.m */; };
 		FD2CCC851C772B4200B2B24E /* SystemConfiguration.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = FD2CCC841C772B4200B2B24E /* SystemConfiguration.framework */; };
 		FDB40CC41C5E4E5500CBF09B /* RCTOneSignal.m in Sources */ = {isa = PBXBuildFile; fileRef = FDB40CC31C5E4E5500CBF09B /* RCTOneSignal.m */; };
@@ -37,8 +38,8 @@
 		3245CDED1BFEE35C00EABF68 /* libRCTOneSignal.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = libRCTOneSignal.a; sourceTree = BUILT_PRODUCTS_DIR; };
 		CA1CC866200FE3C3005B66AA /* RCTOneSignalExtensionService.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = RCTOneSignalExtensionService.h; sourceTree = "<group>"; };
 		CA1CC867200FE3C3005B66AA /* RCTOneSignalExtensionService.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = RCTOneSignalExtensionService.m; sourceTree = "<group>"; };
-		CA8BBC6D205881CB002CDF67 /* libOneSignal.a */ = {isa = PBXFileReference; lastKnownFileType = archive.ar; path = libOneSignal.a; sourceTree = "<group>"; };
-		CA8BBC6F205881DB002CDF67 /* OneSignal.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = OneSignal.h; sourceTree = "<group>"; };
+		CA362AF5209927E20095B77A /* libOneSignal.a */ = {isa = PBXFileReference; lastKnownFileType = archive.ar; path = libOneSignal.a; sourceTree = "<group>"; };
+		CA362AF6209927E20095B77A /* OneSignal.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = OneSignal.h; sourceTree = "<group>"; };
 		CACB39D4202D232A00D86CD1 /* RCTOneSignalEventEmitter.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = RCTOneSignalEventEmitter.h; sourceTree = "<group>"; };
 		CACB39D5202D232A00D86CD1 /* RCTOneSignalEventEmitter.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = RCTOneSignalEventEmitter.m; sourceTree = "<group>"; };
 		FD2CCC841C772B4200B2B24E /* SystemConfiguration.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = SystemConfiguration.framework; path = Platforms/iPhoneOS.platform/Developer/SDKs/iPhoneOS.sdk/System/Library/Frameworks/SystemConfiguration.framework; sourceTree = DEVELOPER_DIR; };
@@ -51,7 +52,7 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				CA8BBC6E205881CB002CDF67 /* libOneSignal.a in Frameworks */,
+				CA362AF7209927E20095B77A /* libOneSignal.a in Frameworks */,
 				FD2CCC851C772B4200B2B24E /* SystemConfiguration.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -93,8 +94,8 @@
 		CA1CC858200FDEFC005B66AA /* Frameworks */ = {
 			isa = PBXGroup;
 			children = (
-				CA8BBC6F205881DB002CDF67 /* OneSignal.h */,
-				CA8BBC6D205881CB002CDF67 /* libOneSignal.a */,
+				CA362AF5209927E20095B77A /* libOneSignal.a */,
+				CA362AF6209927E20095B77A /* OneSignal.h */,
 			);
 			name = Frameworks;
 			sourceTree = "<group>";
@@ -107,6 +108,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				CA3D8B582076D83C006F3572 /* RCTOneSignal.h in Headers */,
+				CA362AF8209927E20095B77A /* OneSignal.h in Headers */,
 				CA3D8B592076D83C006F3572 /* RCTOneSignalExtensionService.h in Headers */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/ios/RCTOneSignal/RCTOneSignalEventEmitter.m
+++ b/ios/RCTOneSignal/RCTOneSignalEventEmitter.m
@@ -94,12 +94,6 @@ RCT_EXPORT_MODULE(RCTOneSignal)
 
 #pragma mark Exported Methods
 
-RCT_EXPORT_METHOD(initWithAppId:(NSString *)appId settings:(NSDictionary *)settings) {
-    dispatch_async(dispatch_get_main_queue(), ^{
-        [[RCTOneSignal sharedInstance] configureWithAppId:appId settings:settings];
-    });
-}
-
 RCT_EXPORT_METHOD(setRequiresUserPrivacyConsent:(BOOL)required) {
     [OneSignal setRequiresUserPrivacyConsent:required];
 }
@@ -108,6 +102,11 @@ RCT_EXPORT_METHOD(provideUserConsent:(BOOL)granted) {
     dispatch_async(dispatch_get_main_queue(), ^{
         [OneSignal consentGranted:granted];
     });
+}
+
+RCT_REMAP_METHOD(userProvidedPrivacyConsent, resolver: (RCTPromiseResolveBlock)resolve
+                 rejecter:(RCTPromiseRejectBlock)reject) {
+    resolve(@(!OneSignal.requiresUserPrivacyConsent));
 }
 
 RCT_EXPORT_METHOD(promptForPushNotificationPermissions:(RCTResponseSenderBlock)callback) {

--- a/ios/RCTOneSignal/RCTOneSignalEventEmitter.m
+++ b/ios/RCTOneSignal/RCTOneSignalEventEmitter.m
@@ -94,6 +94,22 @@ RCT_EXPORT_MODULE(RCTOneSignal)
 
 #pragma mark Exported Methods
 
+RCT_EXPORT_METHOD(initWithAppId:(NSString *)appId settings:(NSDictionary *)settings) {
+    dispatch_async(dispatch_get_main_queue(), ^{
+        [[RCTOneSignal sharedInstance] configureWithAppId:appId settings:settings];
+    });
+}
+
+RCT_EXPORT_METHOD(setRequiresUserPrivacyConsent:(BOOL)required) {
+    [OneSignal setRequiresUserPrivacyConsent:required];
+}
+
+RCT_EXPORT_METHOD(provideUserConsent:(BOOL)granted) {
+    dispatch_async(dispatch_get_main_queue(), ^{
+        [OneSignal consentGranted:granted];
+    });
+}
+
 RCT_EXPORT_METHOD(promptForPushNotificationPermissions:(RCTResponseSenderBlock)callback) {
     [OneSignal promptForPushNotificationsWithUserResponse:^(BOOL accepted) {
         callback(@[@(accepted)]);


### PR DESCRIPTION
• Adds GDPR privacy consent methods to the SDK
• Developers can configure their application to require user consent in the following 3 ways:

1. In iOS by adding `OneSignal_require_privacy_consent = YES` in `Info.plist`
2. In Android by adding `com.onesignal.PrivacyConsent` = `ENABLE` in `AndroidManifest.xml`
3. Soon, once React-Native JS initialization is merged, by simply calling `OneSignal.setRequiresUserPrivacyConsent(true)` before they initialize the SDK

• If an application is set to require user privacy consent, SDK initialization will be automatically delayed until the user provides consent, when the developer calls `OneSignal.provideUserConsent(true)`
• Developers can check the status of the user's consent by calling `OneSignal.userProvidedPrivacyConsent()` which returns a boolean.