### PR TITLE
Json formatting

### DIFF
--- a/android/src/main/java/com/geektime/rnonesignalandroid/RNOneSignal.java
+++ b/android/src/main/java/com/geektime/rnonesignalandroid/RNOneSignal.java
@@ -33,6 +33,7 @@ import com.onesignal.OneSignal.EmailUpdateHandler;
 import com.onesignal.OneSignal.EmailUpdateError;
 
 import org.json.JSONObject;
+import org.json.JSONArray;
 import org.json.JSONException;
 
 
@@ -231,15 +232,15 @@ public class RNOneSignal extends ReactContextBaseJavaModule implements Lifecycle
       boolean userSubscriptionEnabled = subscriptionState.getUserSubscriptionSetting();
 
       try {
-         JSONObject result = new JSONObject("{" +
-               "'notificationsEnabled': " + String.valueOf(notificationsEnabled) + "," +
-               "'subscriptionEnabled': " + String.valueOf(subscriptionEnabled) + "," +
-               "'userSubscriptionEnabled': " + String.valueOf(userSubscriptionEnabled) + "," +
-               "'pushToken': " + subscriptionState.getPushToken() + "," +
-               "'userId': " + subscriptionState.getUserId() + "," +
-               "'emailUserId' : " + emailSubscriptionState.getEmailUserId() + "," +
-               "'emailAddress' : " + emailSubscriptionState.getEmailAddress() +
-         "}");
+         JSONObject result = new JSONObject();
+
+         result.put("notificationsEnabled", String.valueOf(notificationsEnabled))
+                 .put("subscriptionEnabled", String.valueOf(subscriptionEnabled))
+                 .put("userSubscriptionEnabled", String.valueOf(userSubscriptionEnabled))
+                 .put("pushToken", subscriptionState.getPushToken())
+                 .put("userId", subscriptionState.getUserId())
+                 .put("emailUserId", emailSubscriptionState.getEmailUserId())
+                 .put("emailAddress", emailSubscriptionState.getEmailAddress());
 
          Log.d("onesignal", "permission subscription state: " + result.toString());
 
@@ -297,7 +298,21 @@ public class RNOneSignal extends ReactContextBaseJavaModule implements Lifecycle
    @ReactMethod
    public void postNotification(String contents, String data, String playerId, String otherParameters) {
       try {
-         JSONObject postNotification = new JSONObject("{'contents': " + contents + ", 'data': {'p2p_notification': " + data + "}, 'include_player_ids': ['" + playerId + "']}");
+         JSONObject postNotification = new JSONObject();
+         postNotification.put("contents", contents);
+
+         if (playerId != null) {
+            JSONArray playerIds = new JSONArray();
+            playerIds.put(playerId);
+            postNotification.put("include_player_ids", playerIds);
+         }
+
+         if (data != null) {
+            JSONObject additionalData = new JSONObject();
+            additionalData.put("p2p_notification", data);
+            postNotification.put("data", additionalData);
+         }
+
          if (otherParameters != null && !otherParameters.trim().isEmpty()) {
                JSONObject parametersJson = new JSONObject(otherParameters.trim());
                Iterator<String> keys = parametersJson.keys();

--- a/android/src/main/java/com/geektime/rnonesignalandroid/RNOneSignal.java
+++ b/android/src/main/java/com/geektime/rnonesignalandroid/RNOneSignal.java
@@ -97,8 +97,7 @@ public class RNOneSignal extends ReactContextBaseJavaModule implements Lifecycle
    }
 
    private JSONObject jsonFromErrorMessageString(String errorMessage) throws JSONException {
-      JSONObject errorObject = new JSONObject();
-      errorObject.put("error", errorMessage);
+      JSONObject errorObject = new JSONObject().put("error", errorMessage);
       return errorObject;
    }
 

--- a/android/src/main/java/com/geektime/rnonesignalandroid/RNOneSignal.java
+++ b/android/src/main/java/com/geektime/rnonesignalandroid/RNOneSignal.java
@@ -97,8 +97,7 @@ public class RNOneSignal extends ReactContextBaseJavaModule implements Lifecycle
    }
 
    private JSONObject jsonFromErrorMessageString(String errorMessage) throws JSONException {
-      JSONObject errorObject = new JSONObject().put("error", errorMessage);
-      return errorObject;
+      return new JSONObject().put("error", errorMessage);
    }
 
    @ReactMethod 

--- a/android/src/main/java/com/geektime/rnonesignalandroid/RNOneSignal.java
+++ b/android/src/main/java/com/geektime/rnonesignalandroid/RNOneSignal.java
@@ -96,6 +96,12 @@ public class RNOneSignal extends ReactContextBaseJavaModule implements Lifecycle
                .emit(eventName, params);
    }
 
+   private JSONObject jsonFromErrorMessageString(String errorMessage) throws JSONException {
+      JSONObject errorObject = new JSONObject();
+      errorObject.put("error", errorMessage);
+      return errorObject;
+   }
+
    @ReactMethod 
    public void init(String appId) {
       Activity activity = getCurrentActivity();
@@ -148,8 +154,7 @@ public class RNOneSignal extends ReactContextBaseJavaModule implements Lifecycle
          @Override
          public void onFailure(EmailUpdateError error) {
                try {
-                  JSONObject errorObject = new JSONObject("{'error' : '" + error.getMessage() + "'}");
-                  callback.invoke(RNUtils.jsonToWritableMap(errorObject));
+                  callback.invoke(RNUtils.jsonToWritableMap(jsonFromErrorMessageString(error.getMessage())));
                } catch (JSONException exception) {
                   exception.printStackTrace();
                }
@@ -168,8 +173,7 @@ public class RNOneSignal extends ReactContextBaseJavaModule implements Lifecycle
          @Override
          public void onFailure(EmailUpdateError error) {
                try {
-                  JSONObject errorObject = new JSONObject("{'error' : '" + error.getMessage() + "'}");
-                  callback.invoke(RNUtils.jsonToWritableMap(errorObject));
+                  callback.invoke(RNUtils.jsonToWritableMap(jsonFromErrorMessageString(error.getMessage())));
                } catch (JSONException exception) {
                   exception.printStackTrace();
                }
@@ -188,8 +192,7 @@ public class RNOneSignal extends ReactContextBaseJavaModule implements Lifecycle
          @Override
          public void onFailure(EmailUpdateError error) {
                try {
-                  JSONObject errorObject = new JSONObject("{'error' : '" + error.getMessage() + "'}");
-                  callback.invoke(RNUtils.jsonToWritableMap(errorObject));
+                  callback.invoke(RNUtils.jsonToWritableMap(jsonFromErrorMessageString(error.getMessage())));
                } catch (JSONException exception) {
                   exception.printStackTrace();
                }


### PR DESCRIPTION
• Previously, when calling `postNotification()` or `getPermissionSubscriptionState()`, or when building errors, the Java wrapper was building JSON objects by converting from strings.
• This left the potential to have invalid JSON, which became apparent when we switched to FCM. The FCM push tokens have a colon in them which caused failures when parsing the JSON strings.
• Switched to using JSONObject's builder methods, which handles serializing invalid characters and null values.