### PR TITLE
Podspecs: Error installing react-native-onesignal

### DIFF
--- a/react-native-onesignal.podspec
+++ b/react-native-onesignal.podspec
@@ -10,7 +10,7 @@ Pod::Spec.new do |s|
   s.license        = package_json["license"]
   s.author         = { package_json["author"] => package_json["author"] }
   s.platform       = :ios, "7.0"
-  s.source         = { :git => "#{package_json["repository"]["url"]}.git", :tag => "v#{s.version}" }
+  s.source         = { :git => "#{package_json["repository"]["url"]}.git", :tag => "#{s.version}" }
   s.source_files   = 'ios/RCTOneSignal/*.{h,m}'
   s.dependency 'React'
   s.dependency 'OneSignal', '2.8.2'


### PR DESCRIPTION
The branch names are misaligned with the version specified in the Podspecs. Hence, `pod install` fails. This corrects this issue.