### PR TITLE
Auto Prompt Fix

### DIFF
--- a/ios/RCTOneSignal/RCTOneSignal.m
+++ b/ios/RCTOneSignal/RCTOneSignal.m
@@ -61,7 +61,7 @@ OSNotificationOpenedResult* coldStartOSNotificationOpenedResult;
         else
             [self handleRemoteNotificationOpened:[result stringify]];
         
-    } settings:@{@"kOSSettingsKeyInOmitNoAppIdLogging" : @true}];
+    } settings:@{@"kOSSettingsKeyInOmitNoAppIdLogging" : @true, kOSSettingsKeyAutoPrompt : @false}]; //default autoPrompt to false since init will be called again
     didInitialize = false;
 }
 


### PR DESCRIPTION
• Fixes an issue where the SDK would always prompt users for push permissions regardless of what setting the developer used.
• Caused by recent initialization changes