### PR TITLE
Fix Double Event Calls

### DIFF
--- a/android/src/main/java/com/geektime/rnonesignalandroid/RNOneSignal.java
+++ b/android/src/main/java/com/geektime/rnonesignalandroid/RNOneSignal.java
@@ -48,6 +48,7 @@ public class RNOneSignal extends ReactContextBaseJavaModule implements Lifecycle
    private ReactApplicationContext mReactApplicationContext;
    private ReactContext mReactContext;
    private boolean oneSignalInitDone;
+   private static boolean registeredEvents = false;
 
    public RNOneSignal(ReactApplicationContext reactContext) {
       super(reactContext);
@@ -78,8 +79,11 @@ public class RNOneSignal extends ReactContextBaseJavaModule implements Lifecycle
       // Uncomment to debug init issues.
       // OneSignal.setLogLevel(OneSignal.LOG_LEVEL.VERBOSE, OneSignal.LOG_LEVEL.ERROR);
 
-      registerNotificationsOpenedNotification();
-      registerNotificationsReceivedNotification();
+      if (!registeredEvents) {
+         registeredEvents = true;
+         registerNotificationsOpenedNotification();
+         registerNotificationsReceivedNotification();
+      }
 
       OneSignal.sdkType = "react";
 


### PR DESCRIPTION
• Fixes an android bug introduced in 3.2.0 that causes the notification opened and notification received events to get fired twice.
• This was caused because we recently added JS initialization, and the RNOneSignal.java method initOneSignal() method gets called twice, which caused the event to get registered twice