### PR TITLE
Update RCTOneSignal.h

### DIFF
--- a/ios/RCTOneSignal/RCTOneSignal.h
+++ b/ios/RCTOneSignal/RCTOneSignal.h
@@ -2,7 +2,7 @@
 #if __has_include(<OneSignal/OneSignal.h>)
 #import <OneSignal/OneSignal.h>
 #else
-#import "OneSignal.h"
+#import "../OneSignal.h"
 #endif
 
 #define INIT_DEPRECATION_NOTICE "Objective-C Initialization of the OneSignal SDK has been deprecated. Use JavaScript init instead."


### PR DESCRIPTION
I stumbled across this while integrating react-native-app-auth.

`OneSignal.h` does not exist in the same directory as `RCTOneSignal.h`, but rather in its parent directory.

When react-native-app-auth attempts to use my AppDelegate, I was unable to resolve using the normal `<>` method (which trolls header paths to find the files), and so I fell into trying to resolve via a relative pathname.