### PR TITLE
Initialization Race Condition Fix

### DIFF
--- a/ios/RCTOneSignal.xcodeproj/project.pbxproj
+++ b/ios/RCTOneSignal.xcodeproj/project.pbxproj
@@ -14,6 +14,7 @@
 		CA3D8B592076D83C006F3572 /* RCTOneSignalExtensionService.h in Headers */ = {isa = PBXBuildFile; fileRef = CA1CC866200FE3C3005B66AA /* RCTOneSignalExtensionService.h */; };
 		CA3D8B5A2076D84E006F3572 /* RCTOneSignal.h in Copy Headers */ = {isa = PBXBuildFile; fileRef = FDB40CC21C5E4E5500CBF09B /* RCTOneSignal.h */; };
 		CA3D8B5B2076D84E006F3572 /* RCTOneSignalExtensionService.h in Copy Headers */ = {isa = PBXBuildFile; fileRef = CA1CC866200FE3C3005B66AA /* RCTOneSignalExtensionService.h */; };
+		CA63F32E20ACFD60009AE90F /* UIApplication+RCTOnesignal.m in Sources */ = {isa = PBXBuildFile; fileRef = CA63F32C20ACFD60009AE90F /* UIApplication+RCTOnesignal.m */; };
 		CACB39D6202D232A00D86CD1 /* RCTOneSignalEventEmitter.m in Sources */ = {isa = PBXBuildFile; fileRef = CACB39D5202D232A00D86CD1 /* RCTOneSignalEventEmitter.m */; };
 		FD2CCC851C772B4200B2B24E /* SystemConfiguration.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = FD2CCC841C772B4200B2B24E /* SystemConfiguration.framework */; };
 		FDB40CC41C5E4E5500CBF09B /* RCTOneSignal.m in Sources */ = {isa = PBXBuildFile; fileRef = FDB40CC31C5E4E5500CBF09B /* RCTOneSignal.m */; };
@@ -40,6 +41,7 @@
 		CA1CC867200FE3C3005B66AA /* RCTOneSignalExtensionService.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = RCTOneSignalExtensionService.m; sourceTree = "<group>"; };
 		CA362AF5209927E20095B77A /* libOneSignal.a */ = {isa = PBXFileReference; lastKnownFileType = archive.ar; path = libOneSignal.a; sourceTree = "<group>"; };
 		CA362AF6209927E20095B77A /* OneSignal.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = OneSignal.h; sourceTree = "<group>"; };
+		CA63F32C20ACFD60009AE90F /* UIApplication+RCTOnesignal.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = "UIApplication+RCTOnesignal.m"; sourceTree = "<group>"; };
 		CACB39D4202D232A00D86CD1 /* RCTOneSignalEventEmitter.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = RCTOneSignalEventEmitter.h; sourceTree = "<group>"; };
 		CACB39D5202D232A00D86CD1 /* RCTOneSignalEventEmitter.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = RCTOneSignalEventEmitter.m; sourceTree = "<group>"; };
 		FD2CCC841C772B4200B2B24E /* SystemConfiguration.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = SystemConfiguration.framework; path = Platforms/iPhoneOS.platform/Developer/SDKs/iPhoneOS.sdk/System/Library/Frameworks/SystemConfiguration.framework; sourceTree = DEVELOPER_DIR; };
@@ -87,6 +89,7 @@
 				CACB39D5202D232A00D86CD1 /* RCTOneSignalEventEmitter.m */,
 				CA1CC866200FE3C3005B66AA /* RCTOneSignalExtensionService.h */,
 				CA1CC867200FE3C3005B66AA /* RCTOneSignalExtensionService.m */,
+				CA63F32C20ACFD60009AE90F /* UIApplication+RCTOnesignal.m */,
 			);
 			path = RCTOneSignal;
 			sourceTree = "<group>";
@@ -171,6 +174,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				CACB39D6202D232A00D86CD1 /* RCTOneSignalEventEmitter.m in Sources */,
+				CA63F32E20ACFD60009AE90F /* UIApplication+RCTOnesignal.m in Sources */,
 				CA1CC868200FE3C3005B66AA /* RCTOneSignalExtensionService.m in Sources */,
 				FDB40CC41C5E4E5500CBF09B /* RCTOneSignal.m in Sources */,
 			);

--- a/ios/RCTOneSignal/RCTOneSignal.m
+++ b/ios/RCTOneSignal/RCTOneSignal.m
@@ -31,13 +31,6 @@
     BOOL didInitialize;
 }
 
-+(void)load {
-    static dispatch_once_t onceToken;
-    dispatch_once(&onceToken, ^{
-        [[RCTOneSignal sharedInstance] initOneSignal];
-    });
-}
-
 OSNotificationOpenedResult* coldStartOSNotificationOpenedResult;
 
 + (RCTOneSignal *) sharedInstance {

--- a/ios/RCTOneSignal/RCTOneSignalEventEmitter.m
+++ b/ios/RCTOneSignal/RCTOneSignalEventEmitter.m
@@ -1,10 +1,3 @@
-//
-//  RCTOneSignalEventEmitter.m
-//  RCTOneSignal
-//
-//  Created by Brad Hesse on 2/8/18.
-//
-
 #import "RCTOneSignalEventEmitter.h"
 #if __has_include(<OneSignal/OneSignal.h>)
 #import <OneSignal/OneSignal.h>

--- a/ios/RCTOneSignal/RCTOneSignalExtensionService.h
+++ b/ios/RCTOneSignal/RCTOneSignalExtensionService.h
@@ -1,10 +1,3 @@
-//
-//  RCTOneSignalExtensionService.h
-//  RCTOneSignal
-//
-//  Created by Brad Hesse on 1/17/18.
-//
-
 #import <Foundation/Foundation.h>
 #import <UserNotifications/UserNotifications.h>
 

--- a/ios/RCTOneSignal/RCTOneSignalExtensionService.m
+++ b/ios/RCTOneSignal/RCTOneSignalExtensionService.m
@@ -1,10 +1,3 @@
-//
-//  RCTOneSignalExtensionService.m
-//  RCTOneSignal
-//
-//  Created by Brad Hesse on 1/17/18.
-//
-
 #if __has_include(<OneSignal/OneSignal.h>)
 #import <OneSignal/OneSignal.h>
 #else

--- a/ios/RCTOneSignal/UIApplication+RCTOnesignal.m
+++ b/ios/RCTOneSignal/UIApplication+RCTOnesignal.m
@@ -1,0 +1,67 @@
+#import <UIKit/UIKit.h>
+#import <objc/runtime.h>
+
+@interface RCTOneSignal
++ (RCTOneSignal *) sharedInstance;
+- (void)initOneSignal;
+@end
+
+@implementation UIApplication(OneSignalReactNative)
+
+/*
+    This UIApplication category ensures that OneSignal init() gets called at least one time
+ 
+    If this did not occur, cold-start notifications would not trigger the React-Native 'opened'
+    event and other miscellaneous problems would occur.
+ 
+    First, we swizzle UIApplication's setDelegate method, to get notified when the app delegate
+    is assigned. Then we swizzle UIApplication's didFinishLaunchingWithOptions() method. When
+    this method gets called, it initializes the OneSignal SDK with a nil app ID.
+*/
+
+//helper method to swizzle instance methods
+static void injectSelector(Class newClass, SEL newSel, Class addToClass, SEL makeLikeSel) {
+    Method newMeth = class_getInstanceMethod(newClass, newSel);
+    IMP imp = method_getImplementation(newMeth);
+    const char* methodTypeEncoding = method_getTypeEncoding(newMeth);
+    
+    BOOL successful = class_addMethod(addToClass, makeLikeSel, imp, methodTypeEncoding);
+    if (!successful) {
+        class_addMethod(addToClass, newSel, imp, methodTypeEncoding);
+        newMeth = class_getInstanceMethod(addToClass, newSel);
+        
+        Method orgMeth = class_getInstanceMethod(addToClass, makeLikeSel);
+        
+        method_exchangeImplementations(orgMeth, newMeth);
+    }
+}
+
+//gets called by the ObjC runtime early in the app lifecycle
++ (void)load {
+    static dispatch_once_t onceToken;
+    dispatch_once(&onceToken, ^{
+        method_exchangeImplementations(class_getInstanceMethod(self, @selector(setDelegate:)), class_getInstanceMethod(self, @selector(setOneSignalReactNativeDelegate:)));
+    });
+}
+
+
+- (void) setOneSignalReactNativeDelegate:(id<UIApplicationDelegate>)delegate {
+    static dispatch_once_t onceToken;
+    dispatch_once(&onceToken, ^{
+        Class delegateClass = [delegate class];
+        
+        injectSelector(self.class, @selector(oneSignalApplication:didFinishLaunchingWithOptions:),
+                       delegateClass, @selector(application:didFinishLaunchingWithOptions:));
+        [self setOneSignalReactNativeDelegate:delegate];
+    });
+}
+
+- (BOOL)oneSignalApplication:(UIApplication*)application didFinishLaunchingWithOptions:(NSDictionary*)launchOptions {
+    [RCTOneSignal.sharedInstance initOneSignal];
+    
+    if ([self respondsToSelector:@selector(oneSignalApplication:didFinishLaunchingWithOptions:)])
+        return [self oneSignalApplication:application didFinishLaunchingWithOptions:launchOptions];
+    return YES;
+}
+
+@end


### PR DESCRIPTION
• Fixes an issue where the OneSignal iOS native SDK was being initialized too early in the iOS application lifecycle, causing a race condition.
• This race condition, in some cases, would cause an issue where users would not get subscribed to OneSignal, they'd have a null push token/userId, could not receive notifications, etc.
• Fixed by swizzling UIApplication.didFinishLaunchingWithOptions. This swizzled method gets called before the AppDelegate's own implementation of this method, and this lets the SDK ensure that the OneSignal iOS sdk is initialized. This is how Onesignal's Cordova SDK (as well as others) perform initialization.
• Removed some unnecessary header files