### PR TITLE
Fix Android Create Notification Issue

### DIFF
--- a/android/src/main/java/com/geektime/rnonesignalandroid/RNOneSignal.java
+++ b/android/src/main/java/com/geektime/rnonesignalandroid/RNOneSignal.java
@@ -304,7 +304,7 @@ public class RNOneSignal extends ReactContextBaseJavaModule implements Lifecycle
    public void postNotification(String contents, String data, String playerId, String otherParameters) {
       try {
          JSONObject postNotification = new JSONObject();
-         postNotification.put("contents", contents);
+         postNotification.put("contents", new JSONObject(contents));
 
          if (playerId != null) {
             JSONArray playerIds = new JSONArray();
@@ -314,7 +314,7 @@ public class RNOneSignal extends ReactContextBaseJavaModule implements Lifecycle
 
          if (data != null) {
             JSONObject additionalData = new JSONObject();
-            additionalData.put("p2p_notification", data);
+            additionalData.put("p2p_notification", new JSONObject(data));
             postNotification.put("data", additionalData);
          }
 

--- a/ios/RCTOneSignal.xcodeproj/project.pbxproj
+++ b/ios/RCTOneSignal.xcodeproj/project.pbxproj
@@ -16,6 +16,7 @@
 		CA3D8B5B2076D84E006F3572 /* RCTOneSignalExtensionService.h in Copy Headers */ = {isa = PBXBuildFile; fileRef = CA1CC866200FE3C3005B66AA /* RCTOneSignalExtensionService.h */; };
 		CA63F32E20ACFD60009AE90F /* UIApplication+RCTOnesignal.m in Sources */ = {isa = PBXBuildFile; fileRef = CA63F32C20ACFD60009AE90F /* UIApplication+RCTOnesignal.m */; };
 		CACB39D6202D232A00D86CD1 /* RCTOneSignalEventEmitter.m in Sources */ = {isa = PBXBuildFile; fileRef = CACB39D5202D232A00D86CD1 /* RCTOneSignalEventEmitter.m */; };
+		CACDD98820B3448B002A6C38 /* OneSignal.h in Copy Headers */ = {isa = PBXBuildFile; fileRef = CA362AF6209927E20095B77A /* OneSignal.h */; };
 		FD2CCC851C772B4200B2B24E /* SystemConfiguration.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = FD2CCC841C772B4200B2B24E /* SystemConfiguration.framework */; };
 		FDB40CC41C5E4E5500CBF09B /* RCTOneSignal.m in Sources */ = {isa = PBXBuildFile; fileRef = FDB40CC31C5E4E5500CBF09B /* RCTOneSignal.m */; };
 /* End PBXBuildFile section */
@@ -27,6 +28,7 @@
 			dstPath = "include/$(PRODUCT_NAME)";
 			dstSubfolderSpec = 16;
 			files = (
+				CACDD98820B3448B002A6C38 /* OneSignal.h in Copy Headers */,
 				CA3D8B5A2076D84E006F3572 /* RCTOneSignal.h in Copy Headers */,
 				CA3D8B5B2076D84E006F3572 /* RCTOneSignalExtensionService.h in Copy Headers */,
 			);

--- a/ios/RCTOneSignal/RCTOneSignal.h
+++ b/ios/RCTOneSignal/RCTOneSignal.h
@@ -11,6 +11,8 @@
 
 + (RCTOneSignal *) sharedInstance;
 
+@property (nonatomic) BOOL didStartObserving;
+
 - (void)configureWithAppId:(NSString *)appId;
 - (void)configureWithAppId:(NSString *)appId settings:(NSDictionary*)settings;
 


### PR DESCRIPTION
• Fixes an issue (#519) that prevented Android devices from being able to use `postNotification()` due to a JSON parsing issue
• Fixes an issue (#512) with the deprecated native initialization method in iOS, where the `opened` event was not getting fired. This issue did not occur with the new JS initialization function
   • This was an issue because the old initialization method creates a new instance of `RCTOneSignal`, while the new JS init method uses a static singleton.
• Fixes an issue where `OneSignal.h` was not found for some developers using native initialization