### PR TITLE
Fix React Native Null Activity

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -5,8 +5,8 @@ def safeExtGet(prop, fallback) {
 }
 
 android {
-    compileSdkVersion safeExtGet('compileSdkVersion', 23)
-    buildToolsVersion safeExtGet('buildToolsVersion', '23.0.1')
+    compileSdkVersion safeExtGet('compileSdkVersion', 26)
+    buildToolsVersion safeExtGet('buildToolsVersion', '26.0.2')
 
     defaultConfig {
         minSdkVersion safeExtGet('minSdkVersion', 16)

--- a/android/src/main/java/com/geektime/rnonesignalandroid/RNOneSignal.java
+++ b/android/src/main/java/com/geektime/rnonesignalandroid/RNOneSignal.java
@@ -105,7 +105,7 @@ public class RNOneSignal extends ReactContextBaseJavaModule implements Lifecycle
 
    @ReactMethod 
    public void init(String appId) {
-      Activity activity = getCurrentActivity();
+      Activity activity = mReactApplicationContext.getCurrentActivity();
       
       if (activity == null) {
          // in some cases, especially with react-native-navigation, it can take a while for the Activity to be created

--- a/android/src/main/java/com/geektime/rnonesignalandroid/RNOneSignal.java
+++ b/android/src/main/java/com/geektime/rnonesignalandroid/RNOneSignal.java
@@ -106,37 +106,33 @@ public class RNOneSignal extends ReactContextBaseJavaModule implements Lifecycle
    @ReactMethod 
    public void init(String appId) {
       Activity activity = mReactApplicationContext.getCurrentActivity();
-      
-      if (activity == null) {
-         // in some cases, especially with react-native-navigation, it can take a while for the Activity to be created
-         // if null, we should re-attempt initialization after 50 milliseconds.
-         final String currentAppId = appId;
-         Timer timer = new Timer();
-         timer.schedule(new TimerTask() {
-            @Override
-            public void run() {
-               init(currentAppId);
-            }
-         }, 50);
-         return;
-      }
 
       if (oneSignalInitDone) {
-         Log.w("onesignal", "The OneSignal SDK has already been initialized");
+         Log.w("onesignal", "Already initialized the OneSignal React-Native SDK");
          return;
       }
 
       oneSignalInitDone = true;
-      
 
       OneSignal.sdkType = "react";
       
-      OneSignal.init(activity,
-         null,
-         appId,
-         new NotificationOpenedHandler(mReactContext),
-         new NotificationReceivedHandler(mReactContext)
-      );
+      if (activity == null) {
+         // in some cases, especially when react-native-navigation is installed,
+         // the activity can be null, so we can initialize with the context instead
+         OneSignal.init(mReactApplicationContext.getApplicationContext(),
+                 null,
+                 appId,
+                 new NotificationOpenedHandler(mReactContext),
+                 new NotificationReceivedHandler(mReactContext)
+         );
+      } else {
+         OneSignal.init(activity,
+                 null,
+                 appId,
+                 new NotificationOpenedHandler(mReactContext),
+                 new NotificationReceivedHandler(mReactContext)
+         );
+      }
    }
 
    @ReactMethod

--- a/android/src/main/java/com/geektime/rnonesignalandroid/RNOneSignal.java
+++ b/android/src/main/java/com/geektime/rnonesignalandroid/RNOneSignal.java
@@ -105,10 +105,10 @@ public class RNOneSignal extends ReactContextBaseJavaModule implements Lifecycle
 
    @ReactMethod 
    public void init(String appId) {
-      Activity activity = mReactApplicationContext.getCurrentActivity();
+      Context context = mReactApplicationContext.getCurrentActivity();
 
       if (oneSignalInitDone) {
-         Log.w("onesignal", "Already initialized the OneSignal React-Native SDK");
+         Log.e("onesignal", "Already initialized the OneSignal React-Native SDK");
          return;
       }
 
@@ -116,23 +116,18 @@ public class RNOneSignal extends ReactContextBaseJavaModule implements Lifecycle
 
       OneSignal.sdkType = "react";
       
-      if (activity == null) {
+      if (context == null) {
          // in some cases, especially when react-native-navigation is installed,
          // the activity can be null, so we can initialize with the context instead
-         OneSignal.init(mReactApplicationContext.getApplicationContext(),
-                 null,
-                 appId,
-                 new NotificationOpenedHandler(mReactContext),
-                 new NotificationReceivedHandler(mReactContext)
-         );
-      } else {
-         OneSignal.init(activity,
-                 null,
-                 appId,
-                 new NotificationOpenedHandler(mReactContext),
-                 new NotificationReceivedHandler(mReactContext)
-         );
+         context = mReactApplicationContext.getApplicationContext();
       }
+
+      OneSignal.init(context,
+              null,
+              appId,
+              new NotificationOpenedHandler(mReactContext),
+              new NotificationReceivedHandler(mReactContext)
+      );
    }
 
    @ReactMethod


### PR DESCRIPTION
• In some cases, especially with projects using the react-native-navigation dependency, the initial Activity would be null, preventing the SDK from initializing.
• Added a check that will launch a re-attempt timer if this occurs.
• Updated build.gradle to use a newer version (26.0.2)
• Fixes #516, #547 