### PR TITLE
Fix Bridge Reload Issue

### DIFF
--- a/android/src/main/java/com/geektime/rnonesignalandroid/RNOneSignal.java
+++ b/android/src/main/java/com/geektime/rnonesignalandroid/RNOneSignal.java
@@ -48,7 +48,7 @@ public class RNOneSignal extends ReactContextBaseJavaModule implements Lifecycle
    private ReactApplicationContext mReactApplicationContext;
    private ReactContext mReactContext;
    private boolean oneSignalInitDone;
-   private static boolean registeredEvents = false;
+   private boolean registeredEvents = false;
 
    //ensure only one callback exists at a given time due to react-native restriction
    private Callback pendingGetTagsCallback;
@@ -434,7 +434,8 @@ public class RNOneSignal extends ReactContextBaseJavaModule implements Lifecycle
 
    @Override
    public void onHostDestroy() {
-
+      OneSignal.removeNotificationOpenedHandler();
+      OneSignal.removeNotificationReceivedHandler();
    }
 
    @Override


### PR DESCRIPTION
• When react-native apps get reloaded, the existing bridge is destroyed and a new bridge is created.
• Our SDK was not properly registering the new bridge to receive onReceived and onOpened events for notifications
• Changes the 'registeredEvents' boolean to be an instance variable instead of a static variable.
• Also adds code to remove event listeners when the bridge gets destroyed.