### PR TITLE
Android: on destroy, set this.registeredEvents = false;

### DIFF
--- a/android/src/main/java/com/geektime/rnonesignalandroid/RNOneSignal.java
+++ b/android/src/main/java/com/geektime/rnonesignalandroid/RNOneSignal.java
@@ -436,6 +436,7 @@ public class RNOneSignal extends ReactContextBaseJavaModule implements Lifecycle
    public void onHostDestroy() {
       OneSignal.removeNotificationOpenedHandler();
       OneSignal.removeNotificationReceivedHandler();
+      this.registeredEvents = false;
    }
 
    @Override


### PR DESCRIPTION
for android RN restart issue: https://github.com/geektimecoil/react-native-onesignal/issues/583

## <!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/onesignal/react-native-onesignal/593)
<!-- Reviewable:end -->

