### PR TITLE
Add getInitialNotification() on iOS

### DIFF
--- a/index.js
+++ b/index.js
@@ -478,4 +478,15 @@ export default class OneSignal {
         }
     }
 
+    static getInitialNotification() {
+        if (!checkIfInitialized()) return;
+        
+        //returns a promise
+        if (Platform.OS === 'android') {
+            console.log("This function is not supported on Android");
+            return
+        }
+        return RNOneSignal.getInitialNotification();
+    }
+
 }

--- a/ios/RCTOneSignal/RCTOneSignal.m
+++ b/ios/RCTOneSignal/RCTOneSignal.m
@@ -76,8 +76,8 @@ OSNotificationOpenedResult* coldStartOSNotificationOpenedResult;
     
     dispatch_async(dispatch_get_main_queue(), ^{
         if (coldStartOSNotificationOpenedResult) {
-            [self handleRemoteNotificationOpened:[coldStartOSNotificationOpenedResult stringify]];
-            coldStartOSNotificationOpenedResult = nil;
+            NSDictionary *json = [self jsonObjectWithString:[coldStartOSNotificationOpenedResult stringify]];
+            [RCTOneSignalEventEmitter setInitialNotification:json];
         }
     });
 }

--- a/ios/RCTOneSignal/RCTOneSignalEventEmitter.h
+++ b/ios/RCTOneSignal/RCTOneSignalEventEmitter.h
@@ -26,6 +26,7 @@ typedef NS_ENUM(NSInteger, OSNotificationEventTypes) {
 @interface RCTOneSignalEventEmitter : RCTEventEmitter <RCTBridgeModule>
 
 + (void)sendEventWithName:(NSString *)name withBody:(NSDictionary *)body;
++ (void)setInitialNotification:(NSDictionary *)body;
 + (BOOL)hasSetBridge;
 
 @end

--- a/ios/RCTOneSignal/RCTOneSignalEventEmitter.m
+++ b/ios/RCTOneSignal/RCTOneSignalEventEmitter.m
@@ -33,6 +33,8 @@ static BOOL _didStartObserving = false;
 
 RCT_EXPORT_MODULE(RCTOneSignal)
 
+NSDictionary* initialNotification;
+
 #pragma mark RCTEventEmitter Subclass Methods
 
 -(instancetype)init {
@@ -85,6 +87,9 @@ RCT_EXPORT_MODULE(RCTOneSignal)
     [[NSNotificationCenter defaultCenter] postNotificationName:name object:nil userInfo:body];
 }
 
++ (void)setInitialNotification:(NSDictionary *)body {
+    initialNotification = body;
+}
 
 #pragma mark Exported Methods
 
@@ -349,6 +354,23 @@ RCT_EXPORT_METHOD(setLogLevel:(int)logLevel visualLogLevel:(int)visualLogLevel) 
 RCT_EXPORT_METHOD(setExternalUserId:(NSString *)externalId) {
     [OneSignal setExternalUserId:externalId];
 }
+
+RCT_REMAP_METHOD(getInitialNotification,
+                 getInitialNotificationWithResolver:(RCTPromiseResolveBlock)resolve
+                 rejecter:(RCTPromiseRejectBlock)reject)
+{
+    if (initialNotification) {
+        resolve(initialNotification);
+    } else {
+        NSDictionary *userInfo = @{
+                                   NSLocalizedDescriptionKey: NSLocalizedString(@"No initial notification", nil),
+                                   NSLocalizedFailureReasonErrorKey: NSLocalizedString(@"Initial notification not found", nil)
+                                   };
+        NSError *error = [NSError errorWithDomain:@"RCTOneSignal" code:1 userInfo:userInfo];
+        reject(@"no_initial_notification", @"There was no notification on app opening", error);
+    }
+}
+
 
 RCT_EXPORT_METHOD(removeExternalUserId) {
     [OneSignal removeExternalUserId];


### PR DESCRIPTION
# TL;DR
This PR adds the ability to call `getInitialNotification()` on react-native-onesignal.

## Description
The aim is to provide an API that is similar to React-Native's [Linking](https://facebook.github.io/react-native/docs/linking#getinitialurl) and [PushNotificationIOS](https://facebook.github.io/react-native/docs/pushnotificationios#getinitialnotification) modules.
Both of these stock modules allow to register event handlers, as well as providing the initial data that triggered the app launch.

From my point of view, triggering a `onOpened` event in the case of an app launch from a notification if flawed. You have to race to register your listener before the event is dispatched, and this means you're introducing a luck factor in your app initialization.

I cannot rely on luck nor do I wish to race in an already complicated Javascript-timed environment.

So this PR is a neat way of doing things. You can call `getInitialNotification()` and get the data from the notification that opened the app. You can call it soon, late, it doesn't matter, it's available **24/7**.

It also comes in handy in case you need to store the initial notification or need to deal with it at a later point. **No more redux** needed to _save_ your notification for later use.

This addresses #332, for real this time.

## Android notice
I'm no Android developer, and I did not implement the function in the native Android module. If someone feels like Android could benefit from this as well, don't hesitate to contribute!
Trying to call `getInitialNotification()` on Android will simply console.log a message saying it's iOS only.

# Usage
```js
import OneSignal from 'react-native-onesignal'

OneSignal.getInitialNotification().then((notification) => {
this.onNotificationOpened(notification)
}).catch((error) => { console.error(error) })

// or

OneSignal.getInitialNotification().then((notification) => {
  this.onNotificationOpened(notification)
})

// or

try {
  const notification = await OneSignal.getInitialNotification()
  console.log(notification)
} catch (error) {
  console.error(error)
}
```

# Breaking changes
If the iOS app is opened by a notification, the native module will no longer trigger the `onOpened` callback.
This choice has been made to prevent cases where the _old way_ was working [insert random number here]% of the time. A working event trigger AND using `getInitialNotification()` could make you handle the initial notification twice. So we're avoiding this right of the bat.

You can easily update your code by adding `getInitialNotification()` in addition to your listener, and basically give it the same callback. This ensures you handle the initial notification properly, and your listener handles any future notifications.

## <!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/onesignal/react-native-onesignal/626)
<!-- Reviewable:end -->

