### PR TITLE
Add External ID Support

### DIFF
--- a/android/src/main/java/com/geektime/rnonesignalandroid/RNOneSignal.java
+++ b/android/src/main/java/com/geektime/rnonesignalandroid/RNOneSignal.java
@@ -389,6 +389,16 @@ public class RNOneSignal extends ReactContextBaseJavaModule implements Lifecycle
       promise.resolve(OneSignal.userProvidedPrivacyConsent());
    }
 
+   @ReactMethod
+   public void setExternalUserId(String externalId) {
+      OneSignal.setExternalUserId(externalId);
+   }
+
+   @ReactMethod
+   public void removeExternalUserId() {
+      OneSignal.removeExternalUserId();
+   }
+
    private void registerNotificationsReceivedNotification() {
       IntentFilter intentFilter = new IntentFilter(NOTIFICATION_RECEIVED_INTENT_FILTER);
       mReactContext.registerReceiver(new BroadcastReceiver() {

--- a/index.js
+++ b/index.js
@@ -357,4 +357,15 @@ export default class OneSignal {
         return RNOneSignal.userProvidedPrivacyConsent();
     }
 
+    static setExternalUserId(externalId) {
+        if (!checkIfInitialized()) return;
+
+        RNOneSignal.setExternalUserId(externalId);
+    }
+
+    static removeExternalUserId() {
+        if (!checkIfInitialized()) return;
+
+        RNOneSignal.removeExternalUserId();
+    }
 }

--- a/ios/RCTOneSignal/RCTOneSignalEventEmitter.m
+++ b/ios/RCTOneSignal/RCTOneSignalEventEmitter.m
@@ -343,5 +343,12 @@ RCT_EXPORT_METHOD(setLogLevel:(int)logLevel visualLogLevel:(int)visualLogLevel) 
     [OneSignal setLogLevel:logLevel visualLevel:visualLogLevel];
 }
 
+RCT_EXPORT_METHOD(setExternalUserId:(NSString *)externalId) {
+    [OneSignal setExternalUserId:externalId];
+}
+
+RCT_EXPORT_METHOD(removeExternalUserId) {
+    [OneSignal removeExternalUserId];
+}
 
 @end


### PR DESCRIPTION
• Adds SDK support to allow developers to map their own system's user identifiers to OneSignal users, this way they don't have to save the user's OneSignal user ID
• This PR adds two new methods:

`setExternalUserId(String)`: Sets the external ID for the current user. OneSignal maintains separate account records internally for both Email and Push accounts, so if a device has a Push subscription and has also set an Email subscription, this method will generate two API requests.

`removeExternalUserId()`: This method is actually just a wrapper on top of setExternalUserId except that it sends an empty string as the external user ID. This is because our API requires an empty string instead of null to remove the external ID

• Adds tests to verify that the external ID methods generate correctly formatted API requests for both Push and Email players