### PR TITLE
Fix Undefined Function Error

### DIFF
--- a/ios/RCTOneSignal/RCTOneSignalEventEmitter.m
+++ b/ios/RCTOneSignal/RCTOneSignalEventEmitter.m
@@ -351,4 +351,8 @@ RCT_EXPORT_METHOD(removeExternalUserId) {
     [OneSignal removeExternalUserId];
 }
 
+RCT_EXPORT_METHOD(didSetNotificationOpenedHandler) {
+    //unimplemented in iOS
+}
+
 @end


### PR DESCRIPTION
• A new bridge function (didSetNotificationOpenedHandler) was recently added to the Android native implementation of the SDK, but a corresponding iOS implementation was not added
• Fixes #682