### PR TITLE
Restore android functions for setExternalUserId

### DIFF
--- a/android/src/main/java/com/geektime/rnonesignalandroid/RNOneSignal.java
+++ b/android/src/main/java/com/geektime/rnonesignalandroid/RNOneSignal.java
@@ -387,6 +387,16 @@ public class RNOneSignal extends ReactContextBaseJavaModule implements Lifecycle
       promise.resolve(OneSignal.userProvidedPrivacyConsent());
    }
 
+   @ReactMethod
+   public void setExternalUserId(String externalId) {
+      OneSignal.setExternalUserId(externalId);
+   }
+
+   @ReactMethod
+   public void removeExternalUserId() {
+      OneSignal.removeExternalUserId();
+   }
+
    @Override
    public void notificationReceived(OSNotification notification) {
       this.sendEvent("OneSignal-remoteNotificationReceived", RNUtils.jsonToWritableMap(notification.toJSONObject()));


### PR DESCRIPTION
This addresses comment left in https://github.com/geektimecoil/react-native-onesignal/commit/44b665056aa862cbbdb20a5f9e87c59fee3daaba

As well as issue raised here: https://github.com/geektimecoil/react-native-onesignal/issues/687


The problem comes from the commit history of master:
![screenshot 2018-12-18 at 15 36 28](https://user-images.githubusercontent.com/1262737/50157665-b5ef5d80-02da-11e9-89fa-000fe23184ca.png)

We can observe that  [#680](https://github.com/geektimecoil/react-native-onesignal/pull/680) got merged into master after [#681](https://github.com/geektimecoil/react-native-onesignal/pull/681), while the master was not merged into [#680](https://github.com/geektimecoil/react-native-onesignal/pull/680) causing an override RNOnesignal.java, that was changed by both pull requests
