### PR TITLE
Replace deprecated 'compile' gradle configuration with 'implementation' 

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -19,10 +19,10 @@ android {
 }
 
 dependencies {
-    compile fileTree(include: ['*.jar'], dir: 'libs')
-    compile "com.facebook.react:react-native:${safeExtGet('reactNativeVersion', '+')}"
+    implementation fileTree(include: ['*.jar'], dir: 'libs')
+    implementation "com.facebook.react:react-native:${safeExtGet('reactNativeVersion', '+')}"
 
-    compile('com.onesignal:OneSignal:3.10.5') {
+    implementation('com.onesignal:OneSignal:3.10.5') {
         // Exclude com.android.support(Android Support library) as the version range starts at 26.0.0
         //    This is due to compileSdkVersion defaulting to 23 which cant' be lower than the support library version
         //    And the fact that the default root project is missing the Google Maven repo required to pull down 26.0.0+
@@ -30,7 +30,7 @@ dependencies {
         // Keeping com.google.android.gms(Google Play services library) as this version range starts at 10.2.1
     }
 
-    testCompile 'junit:junit:4.12'
+    testImplementation 'junit:junit:4.12'
 }
 
 // Adds required manifestPlaceholders keys to allow mainifest merge gradle step to complete


### PR DESCRIPTION
According to [ReactNative@0.57](https://github.com/react-native-community/react-native-releases/blob/master/CHANGELOG.md#057) default gradle version is now `4.4`.