### PR TITLE
Fix External ID Android Implementation

### DIFF
--- a/android/src/main/java/com/geektime/rnonesignalandroid/RNOneSignal.java
+++ b/android/src/main/java/com/geektime/rnonesignalandroid/RNOneSignal.java
@@ -387,6 +387,16 @@ public class RNOneSignal extends ReactContextBaseJavaModule implements Lifecycle
       promise.resolve(OneSignal.userProvidedPrivacyConsent());
    }
 
+   @ReactMethod
+   public void setExternalUserId(String externalId) {
+      OneSignal.setExternalUserId(externalId);
+   }
+
+   @ReactMethod
+   public void removeExternalUserId() {
+      OneSignal.removeExternalUserId();
+   }
+
    @Override
    public void notificationReceived(OSNotification notification) {
       this.sendEvent("OneSignal-remoteNotificationReceived", RNUtils.jsonToWritableMap(notification.toJSONObject()));


### PR DESCRIPTION
• A recent PR merge mistakenly removed the android wrapper implementation for setExternalUserId and removeExternalUserId - this branch fixes the issue.
• No reviewer available due to holidays - will merge and create a new release immediately.