### PR TITLE
Fix Android Params

### DIFF
--- a/android/src/main/java/com/geektime/rnonesignalandroid/RNOneSignal.java
+++ b/android/src/main/java/com/geektime/rnonesignalandroid/RNOneSignal.java
@@ -251,9 +251,9 @@ public class RNOneSignal extends ReactContextBaseJavaModule implements Lifecycle
       try {
          JSONObject result = new JSONObject();
 
-         result.put("notificationsEnabled", String.valueOf(notificationsEnabled))
-                 .put("subscriptionEnabled", String.valueOf(subscriptionEnabled))
-                 .put("userSubscriptionEnabled", String.valueOf(userSubscriptionEnabled))
+         result.put("notificationsEnabled", notificationsEnabled)
+                 .put("subscriptionEnabled", subscriptionEnabled)
+                 .put("userSubscriptionEnabled", userSubscriptionEnabled)
                  .put("pushToken", subscriptionState.getPushToken())
                  .put("userId", subscriptionState.getUserId())
                  .put("emailUserId", emailSubscriptionState.getEmailUserId())

--- a/examples/CocoapodsDemo/App.js
+++ b/examples/CocoapodsDemo/App.js
@@ -29,7 +29,7 @@ export default class RNOneSignal extends Component {
     constructor(properties) {
         super(properties);
 
-        OneSignal.setLogLevel(7, 0);
+        OneSignal.setLogLevel(6, 0);
 
         let requiresConsent = false;
        

--- a/examples/RNOneSignal/index.js
+++ b/examples/RNOneSignal/index.js
@@ -29,7 +29,7 @@ export default class RNOneSignal extends Component {
     constructor(properties) {
         super(properties);
 
-        OneSignal.setLogLevel(7, 0);
+        OneSignal.setLogLevel(6, 0);
 
         let requiresConsent = false;
        


### PR DESCRIPTION
• Fixes an issue where our Android implementation was setting OSPermissionSubscriptionState boolean variables as strings.
• Fixes an issue in the example projects where the log level was being set to 7 (the highest is 6)