### PR TITLE
Update OneSignal Android to 3.10.8

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -22,7 +22,7 @@ dependencies {
     implementation fileTree(include: ['*.jar'], dir: 'libs')
     implementation "com.facebook.react:react-native:${safeExtGet('reactNativeVersion', '+')}"
 
-    implementation('com.onesignal:OneSignal:3.10.5') {
+    implementation('com.onesignal:OneSignal:3.10.8') {
         // Exclude com.android.support(Android Support library) as the version range starts at 26.0.0
         //    This is due to compileSdkVersion defaulting to 23 which cant' be lower than the support library version
         //    And the fact that the default root project is missing the Google Maven repo required to pull down 26.0.0+


### PR DESCRIPTION
Just updating to the latest native Android SDK to fix a few bugs that have been affecting my app and I'm sure are affecting others. https://github.com/OneSignal/OneSignal-Android-SDK/releases/tag/3.10.8