### PR TITLE
Deprecated the configure method 

### DIFF
--- a/index.js
+++ b/index.js
@@ -144,9 +144,18 @@ export default class OneSignal {
         }
     }
 
+    // deprecating configure method in favor of idsAvailable
     static configure() {
+        console.warn("OneSignal: the `configure` method is being deprecated, use `idsAvailable` instead...read more: https://bit.ly/2ErcQm6");
         if (!checkIfInitialized()) return;
 
+        RNOneSignal.configure();
+    }
+
+    // idsAvailable triggers the 'ids' event
+    static idsAvailable() {
+        if (!checkIfInitialized()) return;
+        
         RNOneSignal.configure();
     }
 

--- a/index.js
+++ b/index.js
@@ -17,7 +17,7 @@ var oneSignalEventEmitter;
 
 var _eventNames = [ "received", "opened", "ids", "emailSubscription"];
 
-var _notificationHandler = new Map();
+var _eventTypeHandler = new Map();
 var _notificationCache = new Map();
 var _listeners = [];
 
@@ -37,7 +37,7 @@ function handleEventBroadcast(type, broadcast) {
         broadcast, (notification) => {
             // Check if we have added listener for this type yet
             // Cache the result first if we have not.
-            var handler = _notificationHandler.get(type);
+            var handler = _eventTypeHandler.get(type);
 
             if (handler) {
                 handler(notification);
@@ -63,10 +63,14 @@ export default class OneSignal {
             'OneSignal only supports `received`, `opened`, and `ids` events'
         );
 
-        _notificationHandler.set(type, handler);
+        _eventTypeHandler.set(type, handler);
 
         if (type == 'opened') {
             RNOneSignal.didSetNotificationOpenedHandler();
+        }
+
+        if (type == 'ids') {
+            this.idsAvailable();
         }
 
         // Check if there is a cache for this type of event
@@ -85,7 +89,7 @@ export default class OneSignal {
             'OneSignal only supports `received`, `opened`, and `ids` events'
         );
 
-        _notificationHandler.delete(type);
+        _eventTypeHandler.delete(type);
     }
 
     static clearListeners() {
@@ -144,19 +148,9 @@ export default class OneSignal {
         }
     }
 
-    // deprecating configure method in favor of idsAvailable
+    /* deprecated */
     static configure() {
-        console.warn("OneSignal: the `configure` method is being deprecated, use `idsAvailable` instead...read more: https://bit.ly/2ErcQm6");
-        if (!checkIfInitialized()) return;
-
-        RNOneSignal.configure();
-    }
-
-    // idsAvailable triggers the 'ids' event
-    static idsAvailable() {
-        if (!checkIfInitialized()) return;
-        
-        RNOneSignal.configure();
+        console.warn("OneSignal: the `configure` method has been deprecated. The `ids` event is now triggered automatically.");
     }
 
     static init(appId, iOSSettings) {

--- a/index.js
+++ b/index.js
@@ -69,8 +69,9 @@ export default class OneSignal {
             RNOneSignal.didSetNotificationOpenedHandler();
         }
 
+        // triggers ids event
         if (type == 'ids') {
-            this.idsAvailable();
+            RNOneSignal.configure();
         }
 
         // Check if there is a cache for this type of event


### PR DESCRIPTION
* the naming of the configure method (which fires the ids event) was confusing folks
* deprecated the `configure` method 
* added a warning to `configure` that displays a YellowBox warning in RN saying its deprecated
* added the `ids` event to the `addEventListener` so that it fires automatically

**Note:** ended up removing the `idsAvailable` method we initially added in favor of firing the ids event automatically within the `addEventListener` method