### PR TITLE
Fix building for androidTest

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -58,7 +58,7 @@ class DefaultManifestPlaceHolders {
 }
 
 rootProject.childProjects.each { projName, proj ->
-    if (projName != 'app')
+    if (projName != 'app' && projName != 'react-native-onesignal')
         return
 
     if (proj.hasProperty('android')) {


### PR DESCRIPTION
Fixes building instrumented tests (`androidTest`) when running `./gradlew assembleAndroidTest`, for example. See https://github.com/geektimecoil/react-native-onesignal/issues/777 for a closer discussion of the issue.

Fixes #777.