### PR TITLE
Only inject manifest placeholders if there are no defaults

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -45,12 +45,13 @@ class DefaultManifestPlaceHolders {
     static void addManifestToAppProject(Project proj) {
         def androidApp = proj.android
         MANIFEST_PLACEHOLDERS_DEFAULTS.each { defKey, defValue ->
-            if (!androidApp.defaultConfig.manifestPlaceholders.containsKey(defKey))
+            if (!androidApp.defaultConfig.manifestPlaceholders.containsKey(defKey)) {
                 androidApp.defaultConfig.manifestPlaceholders[defKey] = defValue
 
-            androidApp.buildTypes.each { buildType ->
-                if (!buildType.manifestPlaceholders.containsKey(defKey))
-                    buildType.manifestPlaceholders[defKey] = defValue
+                androidApp.buildTypes.each { buildType ->
+                    if (!buildType.manifestPlaceholders.containsKey(defKey))
+                        buildType.manifestPlaceholders[defKey] = defValue
+                }
             }
         }
     }


### PR DESCRIPTION
If `defaultConfig` would have manifest placeholders, it would still have overridden the defaults by injecting the manifest placeholders into all build types.

For example, if I define `manifestPlaceholders = [onesignal_app_id: "foo"]` in `defaultConfig` and run `assembleDebug`, the resulting `AndroidManifest.xml` contains an empty `onesignal_app_id` (taken from [`MANIFEST_PLACEHOLDERS_DEFAULTS`](https://github.com/geektimecoil/react-native-onesignal/blob/c8cf6555fb2d0d51500e12b7e40f0633b818c293/android/build.gradle#L40-L43)).

With this change, `onesignal_app_id` in `AndroidManifest.xml` would correctly contain `foo`.