### PR TITLE
Remove unnecessary `rnpm` config (fix for RN@v0.60.0)

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,11 +9,6 @@
   "dependencies": {
     "invariant": "^2.2.2"
   },
-  "rnpm": {
-     "ios": {
-        "sourceDir": "./ios"
-     }
-  },
   "keywords": [
     "react-component",
     "react-native",


### PR DESCRIPTION
"rnpm" was [deprecated in React Native 0.60.0](https://github.com/react-native-community/cli/blob/master/docs/configuration.md#migration-guide). Furthermore, even though it's still supported in legacy mode, apparently the config used in this library is invalid:

<img width="1631" alt="Screen Shot 2019-07-06 at 21 36 11" src="https://user-images.githubusercontent.com/10968765/60758794-2e322c00-a03d-11e9-86d3-8fd042cd2af2.png">
