### PR TITLE
Added a min React version of 0.13.0 for iOS

### DIFF
--- a/react-native-onesignal.podspec
+++ b/react-native-onesignal.podspec
@@ -2,7 +2,6 @@ require 'json'
 package_json = JSON.parse(File.read('package.json'))
 
 Pod::Spec.new do |s|
-
   s.name           = "react-native-onesignal"
   s.version        = package_json["version"]
   s.summary        = package_json["description"]
@@ -12,8 +11,16 @@ Pod::Spec.new do |s|
   s.platform       = :ios, "7.0"
   s.source         = { :git => "#{package_json["repository"]["url"]}.git", :tag => "#{s.version}" }
   s.source_files   = 'ios/RCTOneSignal/*.{h,m}'
+  
+  # The "React" pod is required due to the use of RCTBridgeModule, RCTEventEmitter, etc
+  # Ensuring we have version 0.13.0 or greater to avoid a cocoapods issue noted in React Native's release notes
+  #   https://github.com/facebook/react-native/releases/tag/v0.13.0
+  #   The last stable version on Cocapod's repo is 0.11.0 as we want to ignore it to always use the local copy.
+  s.dependency 'React',  '>= 0.13.0', '< 1.0.0'
 
-  s.dependency 'React'
+  # REQUIRED: Ensure you have the following in your project's Podfile
+  # pod 'React', :path => '../node_modules/react-native/'
+
+  # The Native OneSignal-iOS-SDK from cocoapods.
   s.dependency 'OneSignal', '2.10.0'
-
 end


### PR DESCRIPTION
* This is to prevent a 2nd copy being pull from Cocoapods and instead will always use a local copy