### PR TITLE
Update lock files of example projects

### DIFF
--- a/examples/CocoapodsDemo/yarn.lock
+++ b/examples/CocoapodsDemo/yarn.lock
@@ -3664,10 +3664,10 @@ react-native-maps@0.21.0:
     babel-plugin-module-resolver "^2.3.0"
     babel-preset-react-native "1.9.0"
 
-react-native-onesignal@3.2.13:
-  version "3.2.13"
-  resolved "https://registry.yarnpkg.com/react-native-onesignal/-/react-native-onesignal-3.2.13.tgz#02f10dbd9cfacd3dc2c8254200f824bf4ff92093"
-  integrity sha512-Vq8Bdav8Luwal8XtB2xulO82+pw/Xzfr4RnwFhJ+MJy+3fqsuUU+zkyokEEFz3mAWO34t4YqIUyfQ8Q+XaQDBg==
+react-native-onesignal@3.3.0:
+  version "3.3.0"
+  resolved "https://registry.yarnpkg.com/react-native-onesignal/-/react-native-onesignal-3.3.0.tgz#e7bd9a6b8313fabeaa8010c151e48af37bf32dd7"
+  integrity sha512-+9wQpMco+at7wE5e9u26xtuUUyI5VNho2BI5QTStZ2XIbme8jZ4WvaJgwd4uzMNke/+ACYYVkDB4ONhcoPHreA==
   dependencies:
     invariant "^2.2.2"
 

--- a/examples/RNOneSignal/yarn.lock
+++ b/examples/RNOneSignal/yarn.lock
@@ -4886,10 +4886,10 @@ react-is@^16.8.1, react-is@^16.8.3, react-is@^16.8.4:
   resolved "https://registry.yarnpkg.com/react-is/-/react-is-16.8.6.tgz#5bbc1e2d29141c9fbdfed456343fe2bc430a6a16"
   integrity sha512-aUk3bHfZ2bRSVFFbbeVS4i+lNPZr3/WM5jT2J5omUVV1zzcs1nAaf3l51ctA5FFvCRbhrH0bdAsRRQddFJZPtA==
 
-react-native-onesignal@^3.2.13:
-  version "3.2.14"
-  resolved "https://registry.yarnpkg.com/react-native-onesignal/-/react-native-onesignal-3.2.14.tgz#421a3b34c226e5b6ea9e801b7b3f914d8e3c0abb"
-  integrity sha512-pL5eSTUAPSeVZQcYJcuFhAUGA+Pl22WgBn4VXYGI93Dtmzklhpuzxtkdm4LZSu08tHkhbe3VzYuziconJ33AKw==
+react-native-onesignal@^3.3.0:
+  version "3.3.0"
+  resolved "https://registry.yarnpkg.com/react-native-onesignal/-/react-native-onesignal-3.3.0.tgz#e7bd9a6b8313fabeaa8010c151e48af37bf32dd7"
+  integrity sha512-+9wQpMco+at7wE5e9u26xtuUUyI5VNho2BI5QTStZ2XIbme8jZ4WvaJgwd4uzMNke/+ACYYVkDB4ONhcoPHreA==
   dependencies:
     invariant "^2.2.2"
 


### PR DESCRIPTION
In https://github.com/geektimecoil/react-native-onesignal/commit/c161bf17bd62173f5da237525a2ab80c5ca49b55, the react-native-onesignal dependency was updated in the `package.json` files of both example projects. However, the associated lock files (`yarn.lock`) were not updated.