### PR TITLE
Add InAppMessage event to iOS

### DIFF
--- a/ios/RCTOneSignal/RCTOneSignalEventEmitter.h
+++ b/ios/RCTOneSignal/RCTOneSignalEventEmitter.h
@@ -16,12 +16,12 @@ typedef NS_ENUM(NSInteger, OSNotificationEventTypes) {
     NotificationReceived,
     NotificationOpened,
     IdsAvailable,
-    EmailSubscriptionChanged
+    EmailSubscriptionChanged,
+    InAppMessageClicked
 };
 
-#define OSNotificationEventTypesArray @[@"OneSignal-remoteNotificationReceived",@"OneSignal-remoteNotificationOpened",@"OneSignal-idsAvailable",@"OneSignal-emailSubscription"]
+#define OSNotificationEventTypesArray @[@"OneSignal-remoteNotificationReceived",@"OneSignal-remoteNotificationOpened",@"OneSignal-idsAvailable",@"OneSignal-emailSubscription",@"OneSignal-inAppMessageClicked"]
 #define OSEventString(enum) [OSNotificationEventTypesArray objectAtIndex:enum]
-
 
 @interface RCTOneSignalEventEmitter : RCTEventEmitter <RCTBridgeModule>
 


### PR DESCRIPTION
This fix #812

But, still, the event is not being treated in iOS as it is handled in Android.


Android handles the event like:

https://github.com/geektimecoil/react-native-onesignal/blob/c161bf17bd62173f5da237525a2ab80c5ca49b55/android/src/main/java/com/geektime/rnonesignalandroid/RNOneSignal.java#L464-L471
