### PR TITLE
Add OneSignal with api instead of implementation

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -22,15 +22,9 @@ dependencies {
     implementation fileTree(include: ['*.jar'], dir: 'libs')
     implementation "com.facebook.react:react-native:${safeExtGet('reactNativeVersion', '+')}"
 
-    implementation('com.onesignal:OneSignal:3.11.1') {
-        // Exclude com.android.support(Android Support library) as the version range starts at 26.0.0
-        //    This is due to compileSdkVersion defaulting to 23 which cant' be lower than the support library version
-        //    And the fact that the default root project is missing the Google Maven repo required to pull down 26.0.0+
-        exclude group: 'com.android.support'
-        // Keeping com.google.android.gms(Google Play services library) as this version range starts at 10.2.1
-    }
-
-    implementation 'com.android.support:cardview-v7:27.1.1'
+    // api is used instead of implementation so the parent :app project can access any of the OneSignal Java
+    //   classes if needed. Such as com.onesignal.NotificationExtenderService
+    api 'com.onesignal:OneSignal:3.11.1'
 
     testImplementation 'junit:junit:4.12'
 }


### PR DESCRIPTION
* Using api allows the parent :app project can access any of the OneSignal Java if the app dev needs them.
  - Such as com.onesignal.NotificationExtenderService
* Removed the omission of com.android.support, this is required by the OneSignal SDK.
  - React requires this library too but it's omission isn't necessary.
  - cardview-v7 entry was also removed as this will now be automatically added as the "com.android.support" group is no longer being excluded.
* Fixes #764 