### PR TITLE
Renamed configure method to idsAvailable

### DIFF
--- a/android/src/main/java/com/geektime/rnonesignalandroid/RNOneSignal.java
+++ b/android/src/main/java/com/geektime/rnonesignalandroid/RNOneSignal.java
@@ -217,7 +217,7 @@ public class RNOneSignal extends ReactContextBaseJavaModule implements Lifecycle
    }
 
    @ReactMethod
-   public void configure() {
+   public void idsAvailable() {
       OneSignal.idsAvailable(new OneSignal.IdsAvailableHandler() {
          public void idsAvailable(String userId, String registrationId) {
             final WritableMap params = Arguments.createMap();

--- a/index.js
+++ b/index.js
@@ -94,7 +94,7 @@ export default class OneSignal {
 
         // triggers ids event
         if (type === IDS_AVAILABLE_EVENT) {
-            RNOneSignal.configure();
+            RNOneSignal.idsAvailable();
         }
 
         if (type === IN_APP_MESSAGE_CLICKED_EVENT) {

--- a/ios/RCTOneSignal/RCTOneSignalEventEmitter.m
+++ b/ios/RCTOneSignal/RCTOneSignalEventEmitter.m
@@ -261,7 +261,7 @@ RCT_EXPORT_METHOD(sendTag:(NSString *)key value:(NSString*)value) {
     [OneSignal sendTag:key value:value];
 }
 
-RCT_EXPORT_METHOD(configure) {
+RCT_EXPORT_METHOD(idsAvailable) {
     [OneSignal IdsAvailable:^(NSString* userId, NSString* pushToken) {
 
         NSDictionary *params = @{


### PR DESCRIPTION
Configure name was confusing. Renamed to `idsAvailable` (which is what it really does)