### PR TITLE
Fix runtime exception

### DIFF
--- a/index.js
+++ b/index.js
@@ -128,7 +128,9 @@ export default class OneSignal {
         if (!checkIfInitialized()) return;
 
         for(var i = 0; i < _eventNames.length; i++) {
-            _listeners[_eventNames].remove();
+            if (_listeners[_eventNames]) {
+                _listeners[_eventNames].remove();
+            }
         }
     }
 


### PR DESCRIPTION
```js
OneSignal.init(ONE_SIGNAL_APP_ID);
// ...
OneSignal.clearListeners(); // TypeError: Cannot read property 'remove' of undefined
```