### PR TITLE
Removed ES6 arrow functions to support older devices

### DIFF
--- a/index.js
+++ b/index.js
@@ -472,7 +472,7 @@ export default class OneSignal {
      * Outcomes
      */
 
-    static sendOutcome(name, callback=()=>{}) {
+    static sendOutcome(name, callback=function(){}) {
         if (!checkIfInitialized()) return;
 
         if (Platform.OS === "ios") {
@@ -488,7 +488,7 @@ export default class OneSignal {
         RNOneSignal.sendOutcome(name, callback);
     }
 
-    static sendUniqueOutcome(name, callback=()=>{}) {
+    static sendUniqueOutcome(name, callback=function(){}) {
         if (!checkIfInitialized()) return;
 
         if (Platform.OS === "ios") {
@@ -504,7 +504,7 @@ export default class OneSignal {
         RNOneSignal.sendUniqueOutcome(name, callback);
     }
 
-    static sendOutcomeWithValue(name, value, callback=()=>{}) {
+    static sendOutcomeWithValue(name, value, callback=function(){}) {
         if (!checkIfInitialized()) return;
 
         if (Platform.OS === "ios") {


### PR DESCRIPTION
Older devices may have older versions of Chrome which don't have support for ES6 syntax