### PR TITLE
iOS bridge for Outcomes

### DIFF
--- a/examples/RNOneSignal/App.js
+++ b/examples/RNOneSignal/App.js
@@ -111,6 +111,9 @@ export default class App extends Component {
 
   oneSignalInAppMessagingExamples() {
     // Add a single trigger with a value associated with it
+    OneSignal.addTrigger('trigger1', 'one');
+
+    // Get trigger value for the key
     OneSignal.getTriggerValueForKey('trigger1')
       .then(response => {
         console.log('trigger1 value: ' + response);

--- a/index.js
+++ b/index.js
@@ -475,11 +475,6 @@ export default class OneSignal {
     static sendOutcome(name, callback=()=>{}) {
         if (!checkIfInitialized()) return;
 
-        if (Platform.OS === "ios") {
-            console.warn("OneSignal.sendOutcome is not yet supported on iOS");
-            return;
-        }
-
         invariant(
             typeof callback === 'function',
             'Must provide a valid callback'
@@ -491,11 +486,6 @@ export default class OneSignal {
     static sendUniqueOutcome(name, callback=()=>{}) {
         if (!checkIfInitialized()) return;
 
-        if (Platform.OS === "ios") {
-            console.warn("OneSignal.sendUniqueOutcome is not yet supported on iOS");
-            return;
-        }
-
         invariant(
             typeof callback === 'function',
             'Must provide a valid callback'
@@ -506,11 +496,6 @@ export default class OneSignal {
 
     static sendOutcomeWithValue(name, value, callback=()=>{}) {
         if (!checkIfInitialized()) return;
-
-        if (Platform.OS === "ios") {
-            console.warn("OneSignal.sendOutcomeWithValue is not yet supported on iOS");
-            return;
-        }
 
         invariant(
             typeof callback === 'function',

--- a/ios/RCTOneSignal/RCTOneSignalEventEmitter.m
+++ b/ios/RCTOneSignal/RCTOneSignalEventEmitter.m
@@ -413,33 +413,21 @@ RCT_EXPORT_METHOD(setInAppMessageClickHandler) {
  * Outcomes
  */
 RCT_EXPORT_METHOD(sendOutcome:(NSString *)name withCallback:(RCTResponseSenderBlock)callback) {
-    [OneSignal onesignal_Log:ONE_S_LL_ERROR message:@"Not implemented for iOS"];
-
-    //  [OneSignal sendUniqueOutcome:name onSuccess:^(NSDictionary *result) {
-    //      callback(@[result]);
-    //  } onFailure:^(NSError *error){
-    //      callback(@[error.userInfo[@"error"] ?: error.localizedDescription]);
-    //  }];
+    [OneSignal sendOutcome:name onSuccess:^(OSOutcomeEvent *outcome){
+        callback(@[[outcome jsonRepresentation]]);
+    }];
 }
 
 RCT_EXPORT_METHOD(sendUniqueOutcome:(NSString *)name withCallback:(RCTResponseSenderBlock)callback) {
-    [OneSignal onesignal_Log:ONE_S_LL_ERROR message:@"Not implemented for iOS"];
-
-    //  [OneSignal sendUniqueOutcome:name onSuccess:^(NSDictionary *result) {
-    //      callback(@[result]);
-    //  } onFailure:^(NSError *error){
-    //      callback(@[error.userInfo[@"error"] ?: error.localizedDescription]);
-    //  }];
+    [OneSignal sendUniqueOutcome:name onSuccess:^(OSOutcomeEvent *outcome){
+        callback(@[[outcome jsonRepresentation]]);
+    }];
 }
 
 RCT_EXPORT_METHOD(sendOutcomeWithValue:(NSString *)name withValue:(float)value withCallback:(RCTResponseSenderBlock)callback) {
-    [OneSignal onesignal_Log:ONE_S_LL_ERROR message:@"Not implemented for iOS"];
-
-    //  [OneSignal sendOutcomeWithValue:name  onSuccess:^(NSDictionary *result) {
-    //      callback(@[result]);
-    //  } onFailure:^(NSError *error){
-    //      callback(@[error.userInfo[@"error"] ?: error.localizedDescription]);
-    //  }];
+    [OneSignal sendOutcomeWithValue:name value:value onSuccess:^(OSOutcomeEvent *outcome){
+        callback(@[[outcome jsonRepresentation]]);
+    }];
 }
 
 @end

--- a/ios/RCTOneSignal/RCTOneSignalEventEmitter.m
+++ b/ios/RCTOneSignal/RCTOneSignalEventEmitter.m
@@ -377,8 +377,8 @@ RCT_EXPORT_METHOD(removeTriggerForKey:(NSString *)key) {
     [OneSignal removeTriggerForKey:key];
 }
 
-RCT_REMAP_METHOD(getTriggerValueForKey, 
-                key:(NSString *)key 
+RCT_REMAP_METHOD(getTriggerValueForKey,
+                key:(NSString *)key
                 getTriggerValueForKeyResolver:(RCTPromiseResolveBlock)resolve
                 rejecter:(RCTPromiseRejectBlock)reject) {
 
@@ -404,7 +404,7 @@ RCT_EXPORT_METHOD(setInAppMessageClickHandler) {
          @"clickUrl" : action.clickUrl.absoluteString ?: [NSNull null],
          @"firstClick" : @(action.firstClick),
          @"closesMessage" : @(action.closesMessage)
-        }; 
+        };
         [RCTOneSignalEventEmitter sendEventWithName:@"OneSignal-inAppMessageClicked" withBody:result];
     }];
 }
@@ -412,19 +412,19 @@ RCT_EXPORT_METHOD(setInAppMessageClickHandler) {
 /*
  * Outcomes
  */
-RCT_EXPORT_METHOD(sendOutcome:(NSString *)name withCallback:(RCTResponseSenderBlock)callback) {
+RCT_EXPORT_METHOD(sendOutcome:(NSString *)name :(RCTResponseSenderBlock)callback) {
     [OneSignal sendOutcome:name onSuccess:^(OSOutcomeEvent *outcome){
         callback(@[[outcome jsonRepresentation]]);
     }];
 }
 
-RCT_EXPORT_METHOD(sendUniqueOutcome:(NSString *)name withCallback:(RCTResponseSenderBlock)callback) {
+RCT_EXPORT_METHOD(sendUniqueOutcome:(NSString *)name :(RCTResponseSenderBlock)callback) {
     [OneSignal sendUniqueOutcome:name onSuccess:^(OSOutcomeEvent *outcome){
         callback(@[[outcome jsonRepresentation]]);
     }];
 }
 
-RCT_EXPORT_METHOD(sendOutcomeWithValue:(NSString *)name withValue:(float)value withCallback:(RCTResponseSenderBlock)callback) {
+RCT_EXPORT_METHOD(sendOutcomeWithValue:(NSString *)name :(NSNumber * _Nonnull)value :(RCTResponseSenderBlock)callback) {
     [OneSignal sendOutcomeWithValue:name value:value onSuccess:^(OSOutcomeEvent *outcome){
         callback(@[[outcome jsonRepresentation]]);
     }];

--- a/react-native-onesignal.podspec
+++ b/react-native-onesignal.podspec
@@ -22,5 +22,5 @@ Pod::Spec.new do |s|
   # pod 'React', :path => '../node_modules/react-native/'
 
   # The Native OneSignal-iOS-SDK from cocoapods.
-  s.dependency 'OneSignal', '2.11.2'
+  s.dependency 'OneSignal', '2.12.2'
 end


### PR DESCRIPTION
Added iOS implementation for Outcomes in bridge

### New Methods
- `sendUniqueOutcome`
- `sendOutcome`
- `sendOutcomeWithValue`

Use `[outcome jsonRepresentation]` to convert the `OSOutcomeEvent` to `NSDictionary` (must be implemented on native side)