### PR TITLE
Fix sendEvent fired before React was fully set up

### DIFF
--- a/android/src/main/java/com/geektime/rnonesignalandroid/RNOneSignal.java
+++ b/android/src/main/java/com/geektime/rnonesignalandroid/RNOneSignal.java
@@ -100,6 +100,10 @@ public class RNOneSignal extends ReactContextBaseJavaModule implements Lifecycle
    }
 
    private void sendEvent(String eventName, Object params) {
+      if(!mReactContext.hasActiveCatalystInstance()) {
+         return;
+      }
+      
       mReactContext
               .getJSModule(DeviceEventManagerModule.RCTDeviceEventEmitter.class)
               .emit(eventName, params);


### PR DESCRIPTION
**Bug**

The application crashed after received notification when application is still starting up (the React instance had not been fully set up)

```
Caused by java.lang.RuntimeException
Tried to access a JS module before the React instance was fully set up. Calls to ReactContext#getJSModule should only happen once initialize() has been called on your native module.
```

**Resolved By**

Add react instance checker before emit event. Only emit event, when react instance was active

Fixes #877

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/onesignal/react-native-onesignal/906)
<!-- Reviewable:end -->
