### PR TITLE
3.6.1 Release

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -24,7 +24,7 @@ dependencies {
 
     // api is used instead of implementation so the parent :app project can access any of the OneSignal Java
     //   classes if needed. Such as com.onesignal.NotificationExtenderService
-    api 'com.onesignal:OneSignal:3.12.3'
+    api 'com.onesignal:OneSignal:3.12.4'
 
     testImplementation 'junit:junit:4.12'
 }

--- a/examples/RNOneSignal/package.json
+++ b/examples/RNOneSignal/package.json
@@ -10,7 +10,7 @@
   "dependencies": {
     "react": "16.9.0",
     "react-native": "^0.61.2",
-    "react-native-onesignal": "file:../../"
+    "react-native-onesignal": "3.6.1"
   },
   "devDependencies": {
     "@babel/core": "^7.5.5",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-native-onesignal",
-  "version": "3.6.0",
+  "version": "3.6.1",
   "description": "React Native OneSignal SDK",
   "main": "index",
   "scripts": {

--- a/react-native-onesignal.podspec
+++ b/react-native-onesignal.podspec
@@ -22,5 +22,5 @@ Pod::Spec.new do |s|
   # pod 'React', :path => '../node_modules/react-native/'
 
   # The Native OneSignal-iOS-SDK from cocoapods.
-  s.dependency 'OneSignal', '2.12.2'
+  s.dependency 'OneSignal', '2.12.3'
 end


### PR DESCRIPTION
### Updated native SDK versions:
- Android SDK: 3.12.4
   - Sending custom outcome from notification opened handler will use the previous session instead of current
   - Updated Unity Proxy file

- iOS: 2.12.3
   - Fixed Carthage build issue
   - Fixed missing i386 for 32 bit iOS simulators
   - Fixed Confirmed Deliveries not sending for those updating from an older SDK.

### Other changes
- Updated `libOneSignal.a` binary
- Updated version used in example app