### PR TITLE
Release for 3.6.3

### DIFF
--- a/examples/RNOneSignal/.yarnclean
+++ b/examples/RNOneSignal/.yarnclean
@@ -1,0 +1,44 @@
+# test directories
+__tests__
+test
+tests
+powered-test
+
+# asset directories
+docs
+doc
+website
+images
+
+# examples
+example
+examples
+
+# code coverage directories
+coverage
+.nyc_output
+
+# build scripts
+Makefile
+Gulpfile.js
+Gruntfile.js
+
+# configs
+appveyor.yml
+circle.yml
+codeship-services.yml
+codeship-steps.yml
+wercker.yml
+.tern-project
+.gitattributes
+.editorconfig
+.*ignore
+.eslintrc
+.jshintrc
+.flowconfig
+.documentup.json
+.yarn-metadata.json
+.travis.yml
+
+# misc
+*.md

--- a/examples/RNOneSignal/App.js
+++ b/examples/RNOneSignal/App.js
@@ -128,12 +128,21 @@ export default class App extends Component {
     // Create a set of triggers in a map and add them all at once
     var triggers = {
       trigger2: '2',
-      trigger3: '3',
+      trigger3: true,
     };
     OneSignal.addTriggers(triggers);
 
+    // Get trigger value for the key
+    OneSignal.getTriggerValueForKey('trigger3')
+          .then(response => {
+            console.log('trigger3 value: ' + response);
+          })
+          .catch(e => {
+            console.error(e);
+          });
+
     // Create an array of keys to remove triggers for
-    var removeTriggers = ['trigger2', 'trigger3'];
+    var removeTriggers = ['trigger1', 'trigger2'];
     OneSignal.removeTriggersForKeys(removeTriggers);
   }
 

--- a/examples/RNOneSignal/ios/RNOneSignal.xcodeproj/project.pbxproj
+++ b/examples/RNOneSignal/ios/RNOneSignal.xcodeproj/project.pbxproj
@@ -326,7 +326,7 @@
 					"-ObjC",
 					"-lc++",
 				);
-				PRODUCT_BUNDLE_IDENTIFIER = com.testapp.rodrigo;
+				PRODUCT_BUNDLE_IDENTIFIER = com.onesignal.example;
 				PRODUCT_NAME = RNOneSignal;
 				SUPPORTS_MACCATALYST = YES;
 				TARGETED_DEVICE_FAMILY = "1,2";
@@ -350,7 +350,7 @@
 					"-ObjC",
 					"-lc++",
 				);
-				PRODUCT_BUNDLE_IDENTIFIER = com.testapp.rodrigo;
+				PRODUCT_BUNDLE_IDENTIFIER = com.onesignal.example;
 				PRODUCT_NAME = RNOneSignal;
 				SUPPORTS_MACCATALYST = YES;
 				TARGETED_DEVICE_FAMILY = "1,2";

--- a/examples/RNOneSignal/ios/RNOneSignal.xcodeproj/project.pbxproj
+++ b/examples/RNOneSignal/ios/RNOneSignal.xcodeproj/project.pbxproj
@@ -326,7 +326,7 @@
 					"-ObjC",
 					"-lc++",
 				);
-				PRODUCT_BUNDLE_IDENTIFIER = com.onesignal.example;
+				PRODUCT_BUNDLE_IDENTIFIER = com.testapp.rodrigo;
 				PRODUCT_NAME = RNOneSignal;
 				SUPPORTS_MACCATALYST = YES;
 				TARGETED_DEVICE_FAMILY = "1,2";
@@ -350,7 +350,7 @@
 					"-ObjC",
 					"-lc++",
 				);
-				PRODUCT_BUNDLE_IDENTIFIER = com.onesignal.example;
+				PRODUCT_BUNDLE_IDENTIFIER = com.testapp.rodrigo;
 				PRODUCT_NAME = RNOneSignal;
 				SUPPORTS_MACCATALYST = YES;
 				TARGETED_DEVICE_FAMILY = "1,2";

--- a/index.js
+++ b/index.js
@@ -351,7 +351,10 @@ export default class OneSignal {
     static postNotification(contents, data, player_id, otherParameters) {
         if (!checkIfInitialized()) return;
 
-        RNOneSignal.postNotification(contents, data, player_id, otherParameters);
+        if (Platform.OS === 'android')
+            RNOneSignal.postNotification(JSON.stringify(contents), JSON.stringify(data), JSON.stringify(player_id), JSON.stringify(otherParameters));
+        else
+            RNOneSignal.postNotification(contents, data, player_id, otherParameters);
     }
 
     static clearOneSignalNotifications() {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-native-onesignal",
-  "version": "3.6.2",
+  "version": "3.6.3",
   "description": "React Native OneSignal SDK",
   "main": "index",
   "scripts": {

--- a/react-native-onesignal.podspec
+++ b/react-native-onesignal.podspec
@@ -22,5 +22,5 @@ Pod::Spec.new do |s|
   # pod 'React', :path => '../node_modules/react-native/'
 
   # The Native OneSignal-iOS-SDK from cocoapods.
-  s.dependency 'OneSignal', '2.12.4'
+  s.dependency 'OneSignal', '2.12.5'
 end


### PR DESCRIPTION
* iOS native SDK is now on 2.12.5
* Android native SDK is now on 3.12.5
* Adding `.yarnclean` file to prevent recursive `node_modules` being added from example app (easier for type conversion to JSONObject and JSONArray)
* Strings to Android for postNotification and normal JS JSON and Array to iOS SDK (1-1 type conversions from JS top Objective-C)