### PR TITLE
Fix build error related to outcome event callback

### DIFF
--- a/android/src/main/java/com/geektime/rnonesignalandroid/RNOneSignal.java
+++ b/android/src/main/java/com/geektime/rnonesignalandroid/RNOneSignal.java
@@ -490,7 +490,6 @@ public class RNOneSignal extends ReactContextBaseJavaModule implements Lifecycle
                   callback.invoke(RNUtils.jsonToWritableMap(outcomeEvent.toJSONObject()));
                } catch (JSONException e) {
                   Log.e("OneSignal", "sendOutcome with name: " + name + ", failed with message: " + e.getMessage());
-                  e.printStackTrace();
                }
             }
          }
@@ -509,7 +508,6 @@ public class RNOneSignal extends ReactContextBaseJavaModule implements Lifecycle
                   callback.invoke(RNUtils.jsonToWritableMap(outcomeEvent.toJSONObject()));
                } catch (JSONException e) {
                   Log.e("OneSignal", "sendUniqueOutcome with name: " + name + ", failed with message: " + e.getMessage());
-                  e.printStackTrace();
                }
             }
          }
@@ -528,7 +526,6 @@ public class RNOneSignal extends ReactContextBaseJavaModule implements Lifecycle
                   callback.invoke(RNUtils.jsonToWritableMap(outcomeEvent.toJSONObject()));
                } catch (JSONException e) {
                   Log.e("OneSignal", "sendOutcomeWithValue with name: " + name + " and value: " + value + ", failed with message: " + e.getMessage());
-                  e.printStackTrace();
                }
             }
          }

--- a/android/src/main/java/com/geektime/rnonesignalandroid/RNOneSignal.java
+++ b/android/src/main/java/com/geektime/rnonesignalandroid/RNOneSignal.java
@@ -479,40 +479,58 @@ public class RNOneSignal extends ReactContextBaseJavaModule implements Lifecycle
     */
 
    @ReactMethod
-   public void sendOutcome(String name, final Callback callback) {
+   public void sendOutcome(final String name, final Callback callback) {
       OneSignal.sendOutcome(name, new OutcomeCallback() {
          @Override
          public void onSuccess(OutcomeEvent outcomeEvent) {
             if (outcomeEvent == null)
                callback.invoke(new WritableNativeMap());
-            else
-               callback.invoke(RNUtils.jsonToWritableMap(outcomeEvent.toJSONObject()));
+            else {
+               try {
+                  callback.invoke(RNUtils.jsonToWritableMap(outcomeEvent.toJSONObject()));
+               } catch (JSONException e) {
+                  Log.e("OneSignal", "sendOutcome with name: " + name + ", failed with message: " + e.getMessage());
+                  e.printStackTrace();
+               }
+            }
          }
       });
    }
 
    @ReactMethod
-   public void sendUniqueOutcome(String name, final Callback callback) {
+   public void sendUniqueOutcome(final String name, final Callback callback) {
       OneSignal.sendUniqueOutcome(name, new OutcomeCallback() {
          @Override
          public void onSuccess(OutcomeEvent outcomeEvent) {
             if (outcomeEvent == null)
                callback.invoke(new WritableNativeMap());
-            else
-               callback.invoke(RNUtils.jsonToWritableMap(outcomeEvent.toJSONObject()));
+            else {
+               try {
+                  callback.invoke(RNUtils.jsonToWritableMap(outcomeEvent.toJSONObject()));
+               } catch (JSONException e) {
+                  Log.e("OneSignal", "sendUniqueOutcome with name: " + name + ", failed with message: " + e.getMessage());
+                  e.printStackTrace();
+               }
+            }
          }
       });
    }
 
    @ReactMethod
-   public void sendOutcomeWithValue(String name, float value, final Callback callback) {
+   public void sendOutcomeWithValue(final String name, final float value, final Callback callback) {
       OneSignal.sendOutcomeWithValue(name, value, new OutcomeCallback() {
          @Override
          public void onSuccess(OutcomeEvent outcomeEvent) {
             if (outcomeEvent == null)
                callback.invoke(new WritableNativeMap());
-            else
-               callback.invoke(RNUtils.jsonToWritableMap(outcomeEvent.toJSONObject()));
+            else {
+               try {
+                  callback.invoke(RNUtils.jsonToWritableMap(outcomeEvent.toJSONObject()));
+               } catch (JSONException e) {
+                  Log.e("OneSignal", "sendOutcomeWithValue with name: " + name + " and value: " + value + ", failed with message: " + e.getMessage());
+                  e.printStackTrace();
+               }
+            }
          }
       });
    }


### PR DESCRIPTION
* `OutcomeEvent.java` class in native SDK has a `toJSONObject` method
  * The `toJSONObject` used to have  try-catch built into it, but this was removed so that the native controllers could take responsibility for error logging
  * Adding try-catch to the wrapper bridge now so that the error logging is handle from the wrapper bridge

Fixes #1003 