### PR TITLE
iOS native has not yet released, but this is a fix for after 3.9.0

### DIFF
--- a/ios/RCTOneSignal/RCTOneSignalEventEmitter.m
+++ b/ios/RCTOneSignal/RCTOneSignalEventEmitter.m
@@ -405,13 +405,7 @@ RCT_EXPORT_METHOD(pauseInAppMessages:(BOOL)pause) {
 
 RCT_EXPORT_METHOD(setInAppMessageClickHandler) {
     [OneSignal setInAppMessageClickHandler:^(OSInAppMessageAction *action) {
-        NSDictionary *result = @{
-         @"clickName": action.clickName ?: [NSNull null],
-         @"clickUrl" : action.clickUrl.absoluteString ?: [NSNull null],
-         @"firstClick" : @(action.firstClick),
-         @"closesMessage" : @(action.closesMessage)
-        };
-        [RCTOneSignalEventEmitter sendEventWithName:@"OneSignal-inAppMessageClicked" withBody:result];
+        [RCTOneSignalEventEmitter sendEventWithName:@"OneSignal-inAppMessageClicked" withBody:[action jsonRepresentation]];
     }];
 }
 


### PR DESCRIPTION
* Fix is related to the `NSDictionary` param keys not matching Android
  * This is consistent now and determined not from the bridge method but the actual native code
  * `[action jsonRepresentation]` will be used to generate the `NSDictionary` and will be passed to react that way
* This should also be done across other wrappers no already doing this and it fixes the react native issue #1012

Linked to this native iOS PR
OneSignal/OneSignal-iOS-SDK#704

