### PR TITLE
3.9.1 Release Commit

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -24,7 +24,7 @@ dependencies {
 
     // api is used instead of implementation so the parent :app project can access any of the OneSignal Java
     //   classes if needed. Such as com.onesignal.NotificationExtenderService
-    api 'com.onesignal:OneSignal:3.15.1'
+    api 'com.onesignal:OneSignal:3.15.3'
 
     testImplementation 'junit:junit:4.12'
 }

--- a/examples/RNOneSignal/package.json
+++ b/examples/RNOneSignal/package.json
@@ -10,7 +10,7 @@
   "dependencies": {
     "react": "16.9.0",
     "react-native": "^0.61.2",
-    "react-native-onesignal": "^3.6.1"
+    "react-native-onesignal": "^3.9.1"
   },
   "devDependencies": {
     "@babel/core": "^7.5.5",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-native-onesignal",
-  "version": "3.9.0",
+  "version": "3.9.1",
   "description": "React Native OneSignal SDK",
   "main": "index",
   "scripts": {

--- a/react-native-onesignal.podspec
+++ b/react-native-onesignal.podspec
@@ -22,5 +22,5 @@ Pod::Spec.new do |s|
   # pod 'React', :path => '../node_modules/react-native/'
 
   # The Native OneSignal-iOS-SDK from cocoapods.
-  s.dependency 'OneSignal', '2.14.3'
+  s.dependency 'OneSignal', '2.15.2'
 end


### PR DESCRIPTION
## Release Notes
### Updated Native Android (`3.15.3`) and iOS (`2.15.2`) SDKs
* Android Native SDK Update `3.15.3`
  - [Release Notes 3.15.3](https://github.com/OneSignal/OneSignal-Android-SDK/releases/tag/3.15.3)
  - [Release Notes 3.15.2](https://github.com/OneSignal/OneSignal-Android-SDK/releases/tag/3.15.2)
* iOS Native SDK Update `2.15.2`
   - [Release Notes 2.15.2](https://github.com/OneSignal/OneSignal-iOS-SDK/releases/tag/2.15.2)