### PR TITLE
Xcode12 compatibility: Remove VALID_ARCHS from User-Defined settings

### DIFF
--- a/ios/RCTOneSignal.xcodeproj/project.pbxproj
+++ b/ios/RCTOneSignal.xcodeproj/project.pbxproj
@@ -291,7 +291,6 @@
 				OTHER_LDFLAGS = "-ObjC";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SKIP_INSTALL = YES;
-				VALID_ARCHS = "arm64 armv7 armv7s";
 			};
 			name = Debug;
 		};
@@ -317,7 +316,6 @@
 				OTHER_LDFLAGS = "-ObjC";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SKIP_INSTALL = YES;
-				VALID_ARCHS = "arm64 armv7 armv7s";
 			};
 			name = Release;
 		};


### PR DESCRIPTION
Closes #1036 

## Description
This fixes the following issue: https://github.com/OneSignal/react-native-onesignal/issues/1036

The `RCTOneSignal` target has a `User-Defined` setting called `VALID_ARCHS`. This is not compatible anymore with Xcode12. So we should remove it.

