### PR TITLE
Fix iOS Missing Init with Launch

### DIFF
--- a/ios/RCTOneSignal/RCTOneSignal.h
+++ b/ios/RCTOneSignal/RCTOneSignal.h
@@ -13,6 +13,6 @@
 
 @property (nonatomic) BOOL didStartObserving;
 
-- (void)initOneSignal;
+- (void)initOneSignal:(NSDictionary *)launchOptions;
 
 @end

--- a/ios/RCTOneSignal/RCTOneSignal.m
+++ b/ios/RCTOneSignal/RCTOneSignal.m
@@ -41,11 +41,12 @@ OSNotificationOpenedResult* coldStartOSNotificationOpenedResult;
     return _sharedInstance;
 }
 
-- (void)initOneSignal {
+- (void)initOneSignal:(NSDictionary *)launchOptions {
 
     if (didInitialize)
         return;
 
+    [OneSignal initWithLaunchOptions:launchOptions];
     didInitialize = true;
 }
 

--- a/ios/RCTOneSignal/RCTOneSignalEventEmitter.m
+++ b/ios/RCTOneSignal/RCTOneSignalEventEmitter.m
@@ -131,12 +131,6 @@ RCT_REMAP_METHOD(userProvidedPrivacyConsent, resolver: (RCTPromiseResolveBlock)r
     resolve(@(!OneSignal.requiresUserPrivacyConsent));
 }
 
-RCT_EXPORT_METHOD(initialize) {
-    dispatch_async(dispatch_get_main_queue(), ^{
-        [[RCTOneSignal sharedInstance] initOneSignal];
-    });
-}
-
 RCT_EXPORT_METHOD(setAppId:(NSString* _Nonnull)newAppId) {
     [OneSignal setAppId:newAppId];
 }

--- a/ios/RCTOneSignal/UIApplication+RCTOnesignal.m
+++ b/ios/RCTOneSignal/UIApplication+RCTOnesignal.m
@@ -3,7 +3,7 @@
 
 @interface RCTOneSignal
 + (RCTOneSignal *) sharedInstance;
-- (void)initOneSignal;
+- (void)initOneSignal:(NSDictionary *)launchOptions;
 @end
 
 @implementation UIApplication(OneSignalReactNative)
@@ -56,7 +56,7 @@ static void injectSelector(Class newClass, SEL newSel, Class addToClass, SEL mak
 }
 
 - (BOOL)oneSignalApplication:(UIApplication*)application didFinishLaunchingWithOptions:(NSDictionary*)launchOptions {
-    [RCTOneSignal.sharedInstance initOneSignal];
+    [[RCTOneSignal sharedInstance] initOneSignal:launchOptions];
     if ([self respondsToSelector:@selector(oneSignalApplication:didFinishLaunchingWithOptions:)])
         return [self oneSignalApplication:application didFinishLaunchingWithOptions:launchOptions];
     return YES;


### PR DESCRIPTION
We were missing `initWithLaunchOptions` in the iOS bridge.

This small fix resolves this issue.

