### PR TITLE
Update Lock Files

### DIFF
--- a/examples/RNOneSignal/ios/Podfile.lock
+++ b/examples/RNOneSignal/ios/Podfile.lock
@@ -19,7 +19,7 @@ PODS:
     - DoubleConversion
     - glog
   - glog (0.3.5)
-  - OneSignal (2.12.1)
+  - OneSignal (3.0.0-beta2)
   - RCTRequired (0.61.5)
   - RCTTypeSafety (0.61.5):
     - FBLazyVector (= 0.61.5)
@@ -183,8 +183,8 @@ PODS:
     - React-cxxreact (= 0.61.5)
     - React-jsi (= 0.61.5)
   - React-jsinspector (0.61.5)
-  - react-native-onesignal (3.6.0):
-    - OneSignal (= 2.12.1)
+  - react-native-onesignal (4.0.0-beta.2):
+    - OneSignal (= 3.0.0-beta2)
     - React (< 1.0.0, >= 0.13.0)
   - React-RCTActionSheet (0.61.5):
     - React-Core/RCTActionSheetHeaders (= 0.61.5)
@@ -320,7 +320,7 @@ SPEC CHECKSUMS:
   FBReactNativeSpec: 118d0d177724c2d67f08a59136eb29ef5943ec75
   Folly: 30e7936e1c45c08d884aa59369ed951a8e68cf51
   glog: 1f3da668190260b06b429bb211bfbee5cd790c28
-  OneSignal: ffcd02077b835a96620cdeef11f87ad1136e56ee
+  OneSignal: d7e28427429b55b1d84a4281fd8fadb33275d7cf
   RCTRequired: b153add4da6e7dbc44aebf93f3cf4fcae392ddf1
   RCTTypeSafety: 9aa1b91d7f9310fc6eadc3cf95126ffe818af320
   React: b6a59ef847b2b40bb6e0180a97d0ca716969ac78
@@ -330,7 +330,7 @@ SPEC CHECKSUMS:
   React-jsi: cb2cd74d7ccf4cffb071a46833613edc79cdf8f7
   React-jsiexecutor: d5525f9ed5f782fdbacb64b9b01a43a9323d2386
   React-jsinspector: fa0ecc501688c3c4c34f28834a76302233e29dc0
-  react-native-onesignal: 08c721d49876950d303ab12948bdf1abb62e1f52
+  react-native-onesignal: c6cb86fd1a000d7b9ebcd93c2a90ad398200056a
   React-RCTActionSheet: 600b4d10e3aea0913b5a92256d2719c0cdd26d76
   React-RCTAnimation: 791a87558389c80908ed06cc5dfc5e7920dfa360
   React-RCTBlob: d89293cc0236d9cb0933d85e430b0bbe81ad1d72

--- a/examples/RNOneSignal/yarn.lock
+++ b/examples/RNOneSignal/yarn.lock
@@ -5186,8 +5186,10 @@ react-is@^16.8.1, react-is@^16.8.4, react-is@^16.9.0:
   resolved "https://registry.yarnpkg.com/react-is/-/react-is-16.12.0.tgz#2cc0fe0fba742d97fd527c42a13bec4eeb06241c"
   integrity sha512-rPCkf/mWBtKc97aLL9/txD8DZdemK0vkA3JMLShjlJB3Pj3s+lpf1KaBzMfQrAmhMQB0n1cU/SUGgKKBCe837Q==
 
-"react-native-onesignal@file:../..":
-  version "3.6.0"
+react-native-onesignal@^4.0.0-beta.2:
+  version "4.0.0-beta.2"
+  resolved "https://registry.yarnpkg.com/react-native-onesignal/-/react-native-onesignal-4.0.0-beta.2.tgz#25ac8b34d979ef2a54b4a4f6002d1afe0448ab8f"
+  integrity sha512-4cnr6ZYHO4p9BKsk4dwn9aHBng8sDsjlaHfKQonFf6DTFZyHrVRBdO9zC68MI/nOx6SgfOsZrmGMABnA8ev/rg==
   dependencies:
     invariant "^2.2.2"
 


### PR DESCRIPTION
Updates Example App lock files to use the npm package `4.0.0-beta.2` and the iOS pod `3.0.0-beta2`.