### PR TITLE
Remove duplicate parameter from OSNotification

### DIFF
--- a/src/OSNotification.js
+++ b/src/OSNotification.js
@@ -34,7 +34,6 @@ export default class OSNotification {
             this.templateId = receivedEvent.templateId;
             this.attachments = receivedEvent.attachments;
             this.templateName = receivedEvent.templateName;
-            this.actionButtons = receivedEvent.actionButtons;
             this.mutableContent = receivedEvent.mutableContent;
             this.badgeIncrement = receivedEvent.badgeIncrement;
             this.contentAvailable = receivedEvent.contentAvailable;


### PR DESCRIPTION
Removed `actionButtons` from the "ios" specific section in the `OSNotification` constructor as this parameter is shared across Android & iOS platforms.