### PR TITLE
Remove VALID_ARCHS as User-Defined setting on RCTOneSignal

### DIFF
--- a/ios/RCTOneSignal.xcodeproj/project.pbxproj
+++ b/ios/RCTOneSignal.xcodeproj/project.pbxproj
@@ -291,7 +291,6 @@
 				OTHER_LDFLAGS = "-ObjC";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SKIP_INSTALL = YES;
-				VALID_ARCHS = "arm64 armv7 armv7s";
 			};
 			name = Debug;
 		};
@@ -317,7 +316,6 @@
 				OTHER_LDFLAGS = "-ObjC";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SKIP_INSTALL = YES;
-				VALID_ARCHS = "arm64 armv7 armv7s";
 			};
 			name = Release;
 		};


### PR DESCRIPTION
Duplicating the PR for removing valid architectures build setting into the Major Release branch

