### PR TITLE
getOneSignalNotificationsCount method added

### DIFF
--- a/android/src/main/java/com/geektime/rnonesignalandroid/RNOneSignal.java
+++ b/android/src/main/java/com/geektime/rnonesignalandroid/RNOneSignal.java
@@ -349,6 +349,16 @@ public class RNOneSignal extends ReactContextBaseJavaModule implements Lifecycle
          e.printStackTrace();
       }
    }
+   
+   @ReactMethod
+   public void getOneSignalNotificationsCount(final Callback callback) {
+      OneSignal.getOneSignalNotificationsCount(new OneSignal.GetNotificationsCountHandler() {
+         @Override
+         public void notificationsAvailable(int count) {
+            callback.invoke(count);
+         }
+      });
+   }
 
    @ReactMethod
    public void clearOneSignalNotifications() {

--- a/index.js
+++ b/index.js
@@ -382,6 +382,19 @@ export default class OneSignal {
         else
             RNOneSignal.postNotification(contents, data, player_id, otherParameters);
     }
+	
+	static getOneSignalNotificationsCount(callback) {
+        if (!checkIfInitialized()) return;
+
+        if (Platform.OS === 'android') {
+			if (callback === undefined)
+				callback = function(){};
+		
+            RNOneSignal.getOneSignalNotificationsCount(callback);
+        } else {
+            console.log("This function is not supported on iOS");
+        }
+    }
 
     static clearOneSignalNotifications() {
         if (!checkIfInitialized()) return;


### PR DESCRIPTION
getOneSignalNotificationsCount method added for Android (returns number of available notifications displayed on the app's badge).

Appropriate changes to OneSignal Android SDK are presented at https://github.com/OneSignal/OneSignal-Android-SDK/pull/1211

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/onesignal/react-native-onesignal/1090)
<!-- Reviewable:end -->
