### PR TITLE
Typings Fix: Make OSNotification optional to complete function

### DIFF
--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -73,7 +73,7 @@ declare module 'react-native-onesignal' {
 
     /* N O T I F I C A T I O N   &   I A M   E V E N T S */
     export interface NotificationReceivedEvent {
-        complete        : (notification: OSNotification) => void;
+        complete        : (notification?: OSNotification) => void;
         getNotification : () => OSNotification;
     };
 


### PR DESCRIPTION
OSNotification object is optional for the complete function as not passing it means the notification should be silenced

