### PR TITLE
Pass Potential external Id method errors to JS via bridge

### DIFF
--- a/android/src/main/java/com/geektime/rnonesignalandroid/RNOneSignal.java
+++ b/android/src/main/java/com/geektime/rnonesignalandroid/RNOneSignal.java
@@ -377,10 +377,17 @@ public class RNOneSignal extends ReactContextBaseJavaModule
    public void setExternalUserId(final String externalId, final Callback callback) {
       OneSignal.setExternalUserId(externalId, new OneSignal.OSExternalUserIdUpdateCompletionHandler() {
          @Override
-         public void onComplete(JSONObject results) {
+         public void onSuccess(JSONObject results) {
             Log.i("OneSignal", "Completed setting external user id: " + externalId + "with results: " + results.toString());
+
             if (callback != null)
                callback.invoke(RNUtils.jsonToWritableMap(results));
+         }
+
+         @Override
+         public void onFailure(OneSignal.ExternalIdError error) {
+            if (callback != null)
+               callback.invoke(error.getMessage());
          }
       });
    }
@@ -389,10 +396,17 @@ public class RNOneSignal extends ReactContextBaseJavaModule
    public void removeExternalUserId(final Callback callback) {
       OneSignal.removeExternalUserId(new OneSignal.OSExternalUserIdUpdateCompletionHandler() {
          @Override
-         public void onComplete(JSONObject results) {
+         public void onSuccess(JSONObject results) {
             Log.i("OneSignal", "Completed removing external user id with results: " + results.toString());
+
             if (callback != null)
                callback.invoke(RNUtils.jsonToWritableMap(results));
+         }
+
+         @Override
+         public void onFailure(OneSignal.ExternalIdError error) {
+            if (callback != null)
+               callback.invoke(error.getMessage());
          }
       });
    }

--- a/ios/RCTOneSignal/RCTOneSignalEventEmitter.m
+++ b/ios/RCTOneSignal/RCTOneSignalEventEmitter.m
@@ -314,7 +314,10 @@ RCT_EXPORT_METHOD(setExternalUserId:(NSString*)externalId withCompletion:(RCTRes
         if (callback) {
             callback(@[results]);
         }
-    } withFailure:^(NSError *error) {}];
+    } withFailure:^(NSError *error) {
+        [OneSignal onesignalLog:ONE_S_LL_VERBOSE message:[NSString stringWithFormat:@"OneSignal setExternalUserId error: %@", error]];
+        callback(@[error.userInfo[@"error"] ?: error.localizedDescription]);
+    }];
 }
 
 RCT_EXPORT_METHOD(removeExternalUserId) {
@@ -327,7 +330,10 @@ RCT_EXPORT_METHOD(removeExternalUserId:(RCTResponseSenderBlock)callback) {
         if (callback) {
             callback(@[results]);
         }
-    } withFailure:^(NSError *error) {}];
+    } withFailure:^(NSError *error) {
+        [OneSignal onesignalLog:ONE_S_LL_VERBOSE message:[NSString stringWithFormat:@"OneSignal removeExternalUserId error: %@", error]];
+        callback(@[error.userInfo[@"error"] ?: error.localizedDescription]);
+    }];
 }
 
 /*


### PR DESCRIPTION
Motivation: since we have added user verification to external id setting and modification, we want to surface the error via the function callback by passing it to the JS side in case the error has relevant details.

