### PR TITLE
Use Major Release Native SDK Versions

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -24,7 +24,7 @@ dependencies {
 
     // api is used instead of implementation so the parent :app project can access any of the OneSignal Java
     //   classes if needed. Such as com.onesignal.NotificationExtenderService
-    api 'com.onesignal:OneSignal:4.0.0-beta2'
+    api 'com.onesignal:OneSignal:4.0.0'
 
     testImplementation 'junit:junit:4.12'
 }

--- a/react-native-onesignal.podspec
+++ b/react-native-onesignal.podspec
@@ -22,5 +22,5 @@ Pod::Spec.new do |s|
   # pod 'React', :path => '../node_modules/react-native/'
 
   # The Native OneSignal-iOS-SDK from cocoapods.
-  s.dependency 'OneSignal', '3.0.0-beta2'
+  s.dependency 'OneSignal', '3.0.0'
 end


### PR DESCRIPTION
Upgrade to use version 4 of the Android SDK, version 3 of the iOS SDK.

Closes #1029

