### PR TITLE
Remove arrow functions

### DIFF
--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -257,7 +257,7 @@ declare module 'react-native-onesignal' {
          * @param  {(failure:object)=>void} onFailure
          * @returns void
          */
-        postNotification(notificationObjectString: string, onSuccess: (success: object) => void, onFailure: (failure: object) => void): void;
+        postNotification(notificationObjectString: string, onSuccess?: (success: object) => void, onFailure?: (failure: object) => void): void;
 
         /**
          * Android Only. iOS provides a standard way to clear notifications by clearing badge count.

--- a/src/index.js
+++ b/src/index.js
@@ -209,8 +209,15 @@ export default class OneSignal {
 
     /* N O T I F I C A T I O N S */
 
-    static postNotification(notificationObjectString, onSuccess=()=>{}, onFailure=()=>{}) {
+    static postNotification(notificationObjectString, onSuccess, onFailure) {
         if (!checkIfInitialized(RNOneSignal)) return;
+
+        if (!onSuccess)
+            onSuccess = function(){};
+
+        if (!onFailure)
+            onFailure = function(){};
+
         RNOneSignal.postNotification(notificationObjectString, onSuccess, onFailure);
     }
 


### PR DESCRIPTION
Motivation: older devices may have older versions of Chrome which don't have support for ES6 syntax

