### PR TITLE
Send tag type fix

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -136,7 +136,7 @@ export default class OneSignal {
     static sendTag(key, value) {
         if (!checkIfInitialized(RNOneSignal)) return;
 
-        if (!key || !value) {
+        if (!key || (!value && value !== "")) {
             console.error("OneSignal: sendTag: must include a key and a value");
         }
 


### PR DESCRIPTION
Motivation: tags can be removed by sending a blank string. Here we're updating the logic to allow for that

