### PR TITLE
Platform.OS assign fix

### DIFF
--- a/src/OSNotification.js
+++ b/src/OSNotification.js
@@ -26,7 +26,7 @@ export default class OSNotification {
             this.androidNotificationId = receivedEvent.androidNotificationId;
         }
 
-        if (Platform.OS = 'ios') {
+        if (Platform.OS === 'ios') {
             this.badge = receivedEvent.badge;
             this.category = receivedEvent.category;
             this.threadId = receivedEvent.threadId;


### PR DESCRIPTION
Platform.OS is assigned to 'ios' in OSNotification.js and it affects all android settings in apps.

