### PR TITLE
Nil checks in iOS bridge for outcomes methods

### DIFF
--- a/ios/RCTOneSignal/RCTOneSignalEventEmitter.m
+++ b/ios/RCTOneSignal/RCTOneSignalEventEmitter.m
@@ -389,19 +389,25 @@ RCT_EXPORT_METHOD(initInAppMessageClickHandlerParams) {
  */
 RCT_EXPORT_METHOD(sendOutcome:(NSString *)name :(RCTResponseSenderBlock)callback) {
     [OneSignal sendOutcome:name onSuccess:^(OSOutcomeEvent *outcome){
-        callback(@[[outcome jsonRepresentation]]);
+        if (outcome) {
+            callback(@[[outcome jsonRepresentation]]);
+        }
     }];
 }
 
 RCT_EXPORT_METHOD(sendUniqueOutcome:(NSString *)name :(RCTResponseSenderBlock)callback) {
     [OneSignal sendUniqueOutcome:name onSuccess:^(OSOutcomeEvent *outcome){
-        callback(@[[outcome jsonRepresentation]]);
+        if (outcome) {
+            callback(@[[outcome jsonRepresentation]]);
+        }
     }];
 }
 
 RCT_EXPORT_METHOD(sendOutcomeWithValue:(NSString *)name :(NSNumber * _Nonnull)value :(RCTResponseSenderBlock)callback) {
     [OneSignal sendOutcomeWithValue:name value:value onSuccess:^(OSOutcomeEvent *outcome){
-        callback(@[[outcome jsonRepresentation]]);
+        if (outcome) {
+            callback(@[[outcome jsonRepresentation]]);
+        }
     }];
 }
 

--- a/ios/RCTOneSignal/RCTOneSignalEventEmitter.m
+++ b/ios/RCTOneSignal/RCTOneSignalEventEmitter.m
@@ -391,7 +391,10 @@ RCT_EXPORT_METHOD(sendOutcome:(NSString *)name :(RCTResponseSenderBlock)callback
     [OneSignal sendOutcome:name onSuccess:^(OSOutcomeEvent *outcome){
         if (outcome) {
             callback(@[[outcome jsonRepresentation]]);
+            return;
         }
+
+        [OneSignal onesignalLog:ONE_S_LL_VERBOSE message:[NSString stringWithFormat:@"sendOutcome OSOutcomeEvent is nil."]];
     }];
 }
 
@@ -399,7 +402,10 @@ RCT_EXPORT_METHOD(sendUniqueOutcome:(NSString *)name :(RCTResponseSenderBlock)ca
     [OneSignal sendUniqueOutcome:name onSuccess:^(OSOutcomeEvent *outcome){
         if (outcome) {
             callback(@[[outcome jsonRepresentation]]);
+            return;
         }
+
+        [OneSignal onesignalLog:ONE_S_LL_VERBOSE message:[NSString stringWithFormat:@"sendUniqueOutcome OSOutcomeEvent is nil."]];
     }];
 }
 
@@ -407,7 +413,10 @@ RCT_EXPORT_METHOD(sendOutcomeWithValue:(NSString *)name :(NSNumber * _Nonnull)va
     [OneSignal sendOutcomeWithValue:name value:value onSuccess:^(OSOutcomeEvent *outcome){
         if (outcome) {
             callback(@[[outcome jsonRepresentation]]);
+            return;
         }
+
+        [OneSignal onesignalLog:ONE_S_LL_VERBOSE message:[NSString stringWithFormat:@"sendOutcomeWithValue OSOutcomeEvent is nil."]];
     }];
 }
 


### PR DESCRIPTION
Motivation: there are multiple places in native `OneSignalOutcomeEventsController` where we call `success(nil)`. One example is calling `sendUniqueOutcome` multiple times. We should check that the `outcome` object is non-nil before passing it back to JS with the `jsonRepresentation` native method.

