### PR TITLE
Null checks outcomes android

### DIFF
--- a/android/src/main/java/com/geektime/rnonesignalandroid/RNOneSignal.java
+++ b/android/src/main/java/com/geektime/rnonesignalandroid/RNOneSignal.java
@@ -538,6 +538,7 @@ public class RNOneSignal extends ReactContextBaseJavaModule
          public void onSuccess(OSOutcomeEvent outcomeEvent) {
             if (outcomeEvent == null)
                callback.invoke(new WritableNativeMap());
+               Log.e("OneSignal", "sendOutcome OSOutcomeEvent is null");
             else {
                try {
                   callback.invoke(RNUtils.jsonToWritableMap(outcomeEvent.toJSONObject()));
@@ -556,6 +557,7 @@ public class RNOneSignal extends ReactContextBaseJavaModule
          public void onSuccess(OSOutcomeEvent outcomeEvent) {
             if (outcomeEvent == null)
                callback.invoke(new WritableNativeMap());
+               Log.e("OneSignal", "sendUniqueOutcome OSOutcomeEvent is null");
             else {
                try {
                   callback.invoke(RNUtils.jsonToWritableMap(outcomeEvent.toJSONObject()));
@@ -574,6 +576,7 @@ public class RNOneSignal extends ReactContextBaseJavaModule
          public void onSuccess(OSOutcomeEvent outcomeEvent) {
             if (outcomeEvent == null)
                callback.invoke(new WritableNativeMap());
+               Log.e("OneSignal", "sendOutcomeWithValue OSOutcomeEvent is null");
             else {
                try {
                   callback.invoke(RNUtils.jsonToWritableMap(outcomeEvent.toJSONObject()));

--- a/android/src/main/java/com/geektime/rnonesignalandroid/RNOneSignal.java
+++ b/android/src/main/java/com/geektime/rnonesignalandroid/RNOneSignal.java
@@ -536,16 +536,16 @@ public class RNOneSignal extends ReactContextBaseJavaModule
       OneSignal.sendOutcome(name, new OutcomeCallback() {
          @Override
          public void onSuccess(OSOutcomeEvent outcomeEvent) {
-            if (outcomeEvent == null)
-               callback.invoke(new WritableNativeMap());
-               Log.e("OneSignal", "sendOutcome OSOutcomeEvent is null");
-            else {
+            if (outcomeEvent) {
                try {
                   callback.invoke(RNUtils.jsonToWritableMap(outcomeEvent.toJSONObject()));
                } catch (JSONException e) {
                   Log.e("OneSignal", "sendOutcome with name: " + name + ", failed with message: " + e.getMessage());
                }
+               return;
             }
+
+            Log.e("OneSignal", "sendOutcome OSOutcomeEvent is null");
          }
       });
    }
@@ -555,16 +555,16 @@ public class RNOneSignal extends ReactContextBaseJavaModule
       OneSignal.sendUniqueOutcome(name, new OutcomeCallback() {
          @Override
          public void onSuccess(OSOutcomeEvent outcomeEvent) {
-            if (outcomeEvent == null)
-               callback.invoke(new WritableNativeMap());
-               Log.e("OneSignal", "sendUniqueOutcome OSOutcomeEvent is null");
-            else {
+            if (outcomeEvent) {
                try {
                   callback.invoke(RNUtils.jsonToWritableMap(outcomeEvent.toJSONObject()));
                } catch (JSONException e) {
                   Log.e("OneSignal", "sendUniqueOutcome with name: " + name + ", failed with message: " + e.getMessage());
                }
+               return;
             }
+
+            Log.e("OneSignal", "sendUniqueOutcome OSOutcomeEvent is null");
          }
       });
    }
@@ -574,16 +574,16 @@ public class RNOneSignal extends ReactContextBaseJavaModule
       OneSignal.sendOutcomeWithValue(name, value, new OutcomeCallback() {
          @Override
          public void onSuccess(OSOutcomeEvent outcomeEvent) {
-            if (outcomeEvent == null)
-               callback.invoke(new WritableNativeMap());
-               Log.e("OneSignal", "sendOutcomeWithValue OSOutcomeEvent is null");
-            else {
+            if (outcomeEvent) {
                try {
                   callback.invoke(RNUtils.jsonToWritableMap(outcomeEvent.toJSONObject()));
                } catch (JSONException e) {
                   Log.e("OneSignal", "sendOutcomeWithValue with name: " + name + " and value: " + value + ", failed with message: " + e.getMessage());
                }
+               return;
             }
+
+            Log.e("OneSignal", "sendOutcomeWithValue OSOutcomeEvent is null");
          }
       });
    }


### PR DESCRIPTION
Motivation: Add logging in Android bridge for cases where outcome object is null to establish consistency with iOS (PR: #1129 )

