### PR TITLE
Outcome Event Null Check Fix

### DIFF
--- a/android/src/main/java/com/geektime/rnonesignalandroid/RNOneSignal.java
+++ b/android/src/main/java/com/geektime/rnonesignalandroid/RNOneSignal.java
@@ -536,7 +536,7 @@ public class RNOneSignal extends ReactContextBaseJavaModule
       OneSignal.sendOutcome(name, new OutcomeCallback() {
          @Override
          public void onSuccess(OSOutcomeEvent outcomeEvent) {
-            if (outcomeEvent) {
+            if (outcomeEvent != null) {
                try {
                   callback.invoke(RNUtils.jsonToWritableMap(outcomeEvent.toJSONObject()));
                } catch (JSONException e) {
@@ -555,7 +555,7 @@ public class RNOneSignal extends ReactContextBaseJavaModule
       OneSignal.sendUniqueOutcome(name, new OutcomeCallback() {
          @Override
          public void onSuccess(OSOutcomeEvent outcomeEvent) {
-            if (outcomeEvent) {
+            if (outcomeEvent != null) {
                try {
                   callback.invoke(RNUtils.jsonToWritableMap(outcomeEvent.toJSONObject()));
                } catch (JSONException e) {
@@ -574,7 +574,7 @@ public class RNOneSignal extends ReactContextBaseJavaModule
       OneSignal.sendOutcomeWithValue(name, value, new OutcomeCallback() {
          @Override
          public void onSuccess(OSOutcomeEvent outcomeEvent) {
-            if (outcomeEvent) {
+            if (outcomeEvent != null) {
                try {
                   callback.invoke(RNUtils.jsonToWritableMap(outcomeEvent.toJSONObject()));
                } catch (JSONException e) {


### PR DESCRIPTION
Motivation: in the Java bridge, there is a bug where the outcomeEvent must be checked to be non-null rather than the outcome event being passed in directly to the conditional