### PR TITLE
Example App: Small logic bug fix

### DIFF
--- a/examples/RNOneSignalTS/src/OSButtons.tsx
+++ b/examples/RNOneSignalTS/src/OSButtons.tsx
@@ -352,12 +352,14 @@ class OSButtons extends React.Component<Props, State> {
             "Send Outcome 'my_outcome' with value",
             color,
             () => {
-                loggingFunction("Sending outcome of name 'my_outcome' with value: ", this.props.inputFieldValue);
-                if (typeof this.props.inputFieldValue !== 'number') {
+                const value = Number(this.props.inputFieldValue);
+                loggingFunction("Sending outcome of name 'my_outcome' with value: ", value);
+
+                if (Number.isNaN(value)) {
                     console.error("Outcome with value should be a number");
                     return;
                 }
-                OneSignal.sendOutcomeWithValue('my_outcome', this.props.inputFieldValue, (event: OutcomeEvent) => {
+                OneSignal.sendOutcomeWithValue('my_outcome', value, (event: OutcomeEvent) => {
                     loggingFunction("Outcome With Value Event: ", event);
                 });
             }


### PR DESCRIPTION
Motivation: was previously crashing due to passing a string (even though it is a string of a number) to the `sendOutcomeWithValue` function. This change first converts it to a Number type and then checks that it is not NaN which results from trying to cast any non-digit string to a JS Number.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/onesignal/react-native-onesignal/1135)
<!-- Reviewable:end -->
