### PR TITLE
Remove default callback function from `setExternalUserId`

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -254,7 +254,7 @@ export default class OneSignal {
             return;
         }
 
-        RNOneSignal.setExternalUserId(externalId, varArg1, varArg2 || function(){});
+        RNOneSignal.setExternalUserId(externalId, varArg1, varArg2);
     }
 
     static removeExternalUserId(handler) {


### PR DESCRIPTION
Motivation: this default callback isn't necessary because in the Java bridge the callback parameter is of type `final` which is `nullable`.

This was prompted by the need for a workaround for a crash caused by having the external id and email set. If both are set, currently the native SDK triggers the `onSuccess` of each setter method to fire independently which is causing the passed in callback to fire twice, which is prohibited by React Native (crashes).

