### PR TITLE
iOS null callback fix for `setExternalUserId`

### DIFF
--- a/examples/RNOneSignalTS/package.json
+++ b/examples/RNOneSignalTS/package.json
@@ -12,7 +12,7 @@
   "dependencies": {
     "react": "16.13.1",
     "react-native": "0.63.3",
-    "react-native-onesignal": "4.0.2"
+    "react-native-onesignal": "4.0.3"
   },
   "devDependencies": {
     "@babel/core": "^7.8.4",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-native-onesignal",
-  "version": "4.0.2",
+  "version": "4.0.3",
   "description": "React Native OneSignal SDK",
   "main": "src/index",
   "typings": "src/index.d.ts",

--- a/src/index.js
+++ b/src/index.js
@@ -254,6 +254,10 @@ export default class OneSignal {
             return;
         }
 
+        if (!varArg2 && Platform.OS === 'ios') {
+            varArg2 = function(){};
+        }
+
         RNOneSignal.setExternalUserId(externalId, varArg1, varArg2);
     }
 


### PR DESCRIPTION
Motivation: we want to make sure that the `setExternalUserId` works for iOS even if no callback is passed. Thus, we are re-adding the default callback but for iOS only. 

Note: for Android we want it to be nullable temporarily as a workaround for the current issue of the same callback firing multiple times (crashes) due to the `onSuccess` triggering once per channel.

Note: in the future, we intend to make argument non-nullability or nullability consistent across both platforms.

