### PR TITLE
Update `DeviceState` Typings: `notificationPermissionStatus`

### DIFF
--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -113,7 +113,7 @@ declare module 'react-native-onesignal' {
         isPushDisabled                  : boolean;
         isEmailSubscribed               : boolean;
         hasNotificationPermission       ?: boolean; // ios only
-        notificationPermissionStatus    ?: number;  // ios only
+        notificationPermissionStatus    ?: IosPermissionStatus;  // ios only
         // areNotificationsEnabled (android) not included since it is converted to hasNotificationPermission in bridge
     }
 


### PR DESCRIPTION
Motivation: make `notificationPermissionStatus` type more strict by typing to only permitted permission values defined by `IosPermissionStatus`

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/onesignal/react-native-onesignal/1142)
<!-- Reviewable:end -->
