### PR TITLE
Upgrade OneSignal iOS SDK to 3.2.1

### DIFF
--- a/react-native-onesignal.podspec
+++ b/react-native-onesignal.podspec
@@ -22,5 +22,5 @@ Pod::Spec.new do |s|
   # pod 'React', :path => '../node_modules/react-native/'
 
   # The Native OneSignal-iOS-SDK from cocoapods.
-  s.dependency 'OneSignal', '3.1.0'
+  s.dependency 'OneSignal', '3.2.1'
 end


### PR DESCRIPTION
Upgrading the iOS SDK from 3.1.0 to 3.2.1

Closes #1163 

Fixes issues on https://github.com/OneSignal/OneSignal-iOS-SDK/issues/777

## <!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/onesignal/react-native-onesignal/1168)
<!-- Reviewable:end -->

