### PR TITLE
`getDeviceState` is null fix

### DIFF
--- a/android/src/main/java/com/geektime/rnonesignalandroid/RNOneSignal.java
+++ b/android/src/main/java/com/geektime/rnonesignalandroid/RNOneSignal.java
@@ -236,6 +236,11 @@ public class RNOneSignal extends ReactContextBaseJavaModule
    @ReactMethod
    public void getDeviceState(Promise promise) {
       OSDeviceState state = OneSignal.getDeviceState();
+      if (state == null) {
+         Log.e("OneSignal", "getDeviceState: OSDeviceState is null");
+         promise.reject("Null OSDeviceState", "OSDeviceState is null");
+         return;
+      }
       promise.resolve(RNUtils.jsonToWritableMap(state.toJSONObject()));
    }
 


### PR DESCRIPTION
Fixes #1159 

ReactNative sometimes appears to run the user's code such as `getDeviceState` prior to calling `initWithContext` which is done automatically for the user. Reports indicate this happens while the app is in background.

This PR adds a check to reject the promise in the case that the state returns null.

Relevant native code: https://github.com/OneSignal/OneSignal-Android-SDK/blob/31a4d1d7894f55d361d4d94b881149bfbb8f7efe/OneSignalSDK/onesignal/src/main/java/com/onesignal/OneSignal.java#L611

## <!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/onesignal/react-native-onesignal/1193)
<!-- Reviewable:end -->

