### PR TITLE
Cleanup - iOS misc RCTOneSignal (Needs testing)

### DIFF
--- a/ios/RCTOneSignal/RCTOneSignal.h
+++ b/ios/RCTOneSignal/RCTOneSignal.h
@@ -11,8 +11,6 @@
 
 + (RCTOneSignal *) sharedInstance;
 
-@property (nonatomic) BOOL didStartObserving;
-
 - (void)initOneSignal:(NSDictionary *)launchOptions;
 
 @end

--- a/ios/RCTOneSignal/RCTOneSignal.m
+++ b/ios/RCTOneSignal/RCTOneSignal.m
@@ -13,16 +13,6 @@
 #import "RCTOneSignal.h"
 #import "RCTOneSignalEventEmitter.h"
 
-#if __IPHONE_OS_VERSION_MIN_REQUIRED < __IPHONE_8_0
-
-#define UIUserNotificationTypeAlert UIRemoteNotificationTypeAlert
-#define UIUserNotificationTypeBadge UIRemoteNotificationTypeBadge
-#define UIUserNotificationTypeSound UIRemoteNotificationTypeSound
-#define UIUserNotificationTypeNone  UIRemoteNotificationTypeNone
-#define UIUserNotificationType      UIRemoteNotificationType
-
-#endif
-
 @interface RCTOneSignal ()
 @end
 

--- a/ios/RCTOneSignal/RCTOneSignal.m
+++ b/ios/RCTOneSignal/RCTOneSignal.m
@@ -54,8 +54,4 @@
     [self sendEvent:OSEventString(PermissionChanged) withBody:stateChanges.toDictionary];
 }
 
-- (void)dealloc {
-    [[NSNotificationCenter defaultCenter] removeObserver:self];
-}
-
 @end

--- a/ios/RCTOneSignal/RCTOneSignal.m
+++ b/ios/RCTOneSignal/RCTOneSignal.m
@@ -20,8 +20,6 @@
     BOOL didInitialize;
 }
 
-OSNotificationOpenedResult* coldStartOSNotificationOpenedResult;
-
 + (RCTOneSignal *) sharedInstance {
     static dispatch_once_t token = 0;
     static id _sharedInstance = nil;
@@ -38,26 +36,6 @@ OSNotificationOpenedResult* coldStartOSNotificationOpenedResult;
 
     [OneSignal initWithLaunchOptions:launchOptions];
     didInitialize = true;
-}
-
-- (void)handleRemoteNotificationOpened:(NSString *)result {
-    NSDictionary *json = [self jsonObjectWithString:result];
-
-    if (json)
-        [self sendEvent:OSEventString(NotificationOpened) withBody:json];
-}
-
-- (NSDictionary *)jsonObjectWithString:(NSString *)jsonString {
-    NSError *jsonError;
-    NSData *data = [jsonString dataUsingEncoding:NSUTF8StringEncoding];
-    NSDictionary *json = [NSJSONSerialization JSONObjectWithData:data options:NSJSONReadingMutableContainers error:&jsonError];
-
-    if (jsonError) {
-        [OneSignal onesignalLog:ONE_S_LL_ERROR message:[NSString stringWithFormat:@"Unable to serialize JSON string into an object: %@", jsonError]];
-        return nil;
-    }
-
-    return json;
 }
 
 - (void)sendEvent:(NSString *)eventName withBody:(NSDictionary *)body {


### PR DESCRIPTION
## Motivation
This is to clean up some iOS dead code in RCTOneSignal that was moved to OneSignalEventEmitter. This was confusing when looking at this SDK a reference of how it handles notification opens from cold start. Noticed a few other things while in this file.

## Testing
I have not tested this. Before merging we this needs to be done. The next time I run react native I will test a notification open cold start.

## <!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/onesignal/react-native-onesignal/1196)
<!-- Reviewable:end -->

