### PR TITLE
Enabled Desugaring of Java 8 bytecode for Android

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -16,6 +16,11 @@ android {
             proguardFiles getDefaultProguardFile('proguard-android.txt'), 'proguard-rules.pro'
         }
     }
+
+    compileOptions {
+        sourceCompatibility JavaVersion.VERSION_1_8
+        targetCompatibility JavaVersion.VERSION_1_8
+    }
 }
 
 dependencies {


### PR DESCRIPTION
Added the following missing compile options to android build.gradle:
```gradle
    compileOptions {
        sourceCompatibility JavaVersion.VERSION_1_8
        targetCompatibility JavaVersion.VERSION_1_8
    }
```

The missing options caused detox build command to fail.

Resolved #1235

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/onesignal/react-native-onesignal/1240)
<!-- Reviewable:end -->
