### PR TITLE
clear subscription observers

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 
 ---
 
-[OneSignal](https://onesignal.com/) is a free push notification service for mobile apps. This SDK makes it easy to integrate your native React-Native iOS and/or Android apps with OneSignal.
+[OneSignal](https://onesignal.com/) is a free email, sms, push notification, and in-app message service for mobile apps. This SDK makes it easy to integrate your native React-Native iOS and/or Android apps with OneSignal.
 
 #### Installation
 See the [Setup Guide](https://documentation.onesignal.com/docs/react-native-sdk-setup) for setup instructions.

--- a/android/src/main/java/com/geektime/rnonesignalandroid/RNOneSignal.java
+++ b/android/src/main/java/com/geektime/rnonesignalandroid/RNOneSignal.java
@@ -269,7 +269,7 @@ public class RNOneSignal extends ReactContextBaseJavaModule
    public void removeSMSSubscriptionObserver() {
       if (hasSetSMSSubscriptionObserver) {
          OneSignal.removeSMSSubscriptionObserver(this);
-         hasSetSMSSubscriptionObserver = true;
+         hasSetSMSSubscriptionObserver = false;
       }
    }
 

--- a/android/src/main/java/com/geektime/rnonesignalandroid/RNOneSignal.java
+++ b/android/src/main/java/com/geektime/rnonesignalandroid/RNOneSignal.java
@@ -218,10 +218,26 @@ public class RNOneSignal extends ReactContextBaseJavaModule
    }
 
    @ReactMethod
+   public void removePermissionObserver() {
+      if (hasSetPermissionObserver) {
+         OneSignal.removePermissionObserver(this);
+         hasSetPermissionObserver = false;
+      }
+   }
+
+   @ReactMethod
    public void addSubscriptionObserver() {
       if (!hasSetSubscriptionObserver) {
          OneSignal.addSubscriptionObserver(this);
          hasSetSubscriptionObserver = true;
+      }
+   }
+
+   @ReactMethod
+   public void removeSubscriptionObserver() {
+      if (hasSetSubscriptionObserver) {
+         OneSignal.removeSubscriptionObserver(this);
+         hasSetSubscriptionObserver = false;
       }
    }
 
@@ -234,9 +250,25 @@ public class RNOneSignal extends ReactContextBaseJavaModule
    }
 
    @ReactMethod
+   public void removeEmailSubscriptionObserver() {
+      if (hasSetEmailSubscriptionObserver) {
+         OneSignal.removeEmailSubscriptionObserver(this);
+         hasSetEmailSubscriptionObserver = false;
+      }
+   }
+
+   @ReactMethod
    public void addSMSSubscriptionObserver() {
       if (!hasSetSMSSubscriptionObserver) {
          OneSignal.addSMSSubscriptionObserver(this);
+         hasSetSMSSubscriptionObserver = true;
+      }
+   }
+
+   @ReactMethod
+   public void removeSMSSubscriptionObserver() {
+      if (hasSetSMSSubscriptionObserver) {
+         OneSignal.removeSMSSubscriptionObserver(this);
          hasSetSMSSubscriptionObserver = true;
       }
    }

--- a/android/src/main/java/com/geektime/rnonesignalandroid/RNOneSignal.java
+++ b/android/src/main/java/com/geektime/rnonesignalandroid/RNOneSignal.java
@@ -120,12 +120,9 @@ public class RNOneSignal extends ReactContextBaseJavaModule
    }
 
    private void removeObservers() {
-      OneSignal.removeEmailSubscriptionObserver(this);
-      OneSignal.removePermissionObserver(this);
-      OneSignal.removeSubscriptionObserver(this);
-      hasSetEmailSubscriptionObserver = false;
-      hasSetPermissionObserver = false;
-      hasSetSubscriptionObserver = false;
+      this.removeEmailSubscriptionObserver();
+      this.removePermissionObserver();
+      this.removeSubscriptionObserver();
    }
 
    private void removeHandlers() {

--- a/ios/RCTOneSignal/RCTOneSignalEventEmitter.m
+++ b/ios/RCTOneSignal/RCTOneSignalEventEmitter.m
@@ -103,10 +103,24 @@ RCT_EXPORT_METHOD(addPermissionObserver) {
     }
 }
 
+RCT_EXPORT_METHOD(removePermissionObserver) {
+    if (_hasSetPermissionObserver) {
+        [OneSignal removePermissionObserver:[RCTOneSignal sharedInstance]];
+        _hasSetPermissionObserver = false;
+    }
+}
+
 RCT_EXPORT_METHOD(addSubscriptionObserver) {
     if (!_hasSetSubscriptionObserver) {
         [OneSignal addSubscriptionObserver:[RCTOneSignal sharedInstance]];
         _hasSetSubscriptionObserver = true;
+    }
+}
+
+RCT_EXPORT_METHOD(removeSubscriptionObserver) {
+    if (_hasSetSubscriptionObserver) {
+        [OneSignal removeSubscriptionObserver:[RCTOneSignal sharedInstance]];
+        _hasSetSubscriptionObserver = false;
     }
 }
 
@@ -117,10 +131,24 @@ RCT_EXPORT_METHOD(addEmailSubscriptionObserver) {
     }
 }
 
+RCT_EXPORT_METHOD(removeEmailSubscriptionObserver) {
+    if (_hasSetEmailSubscriptionObserver) {
+        [OneSignal removeEmailSubscriptionObserver:[RCTOneSignal sharedInstance]];
+        _hasSetEmailSubscriptionObserver = false;
+    }
+}
+
 RCT_EXPORT_METHOD(addSMSSubscriptionObserver) {
     if (!_hasSetSMSSubscriptionObserver) {
         [OneSignal addSMSSubscriptionObserver:[RCTOneSignal sharedInstance]];
         _hasSetSMSSubscriptionObserver = true;
+    }
+}
+
+RCT_EXPORT_METHOD(removeSMSSubscriptionObserver) {
+    if (_hasSetSMSSubscriptionObserver) {
+        [OneSignal addSMSSubscriptionObserver:[RCTOneSignal sharedInstance]];
+        _hasSetSMSSubscriptionObserver = false;
     }
 }
 

--- a/ios/RCTOneSignal/RCTOneSignalEventEmitter.m
+++ b/ios/RCTOneSignal/RCTOneSignalEventEmitter.m
@@ -147,7 +147,7 @@ RCT_EXPORT_METHOD(addSMSSubscriptionObserver) {
 
 RCT_EXPORT_METHOD(removeSMSSubscriptionObserver) {
     if (_hasSetSMSSubscriptionObserver) {
-        [OneSignal addSMSSubscriptionObserver:[RCTOneSignal sharedInstance]];
+        [OneSignal removeSMSSubscriptionObserver:[RCTOneSignal sharedInstance]];
         _hasSetSMSSubscriptionObserver = false;
     }
 }

--- a/src/EventManager.js
+++ b/src/EventManager.js
@@ -70,16 +70,6 @@ export default class EventManager {
     }
 
     /**
-     * Adds the event handler to the corresponding handler array on the JS side of the bridge
-     * @param  {string} eventName
-     * @param  {function} handler
-     */
-    addEventHandler(eventName, handler) {
-        let handlerArray = this.eventHandlerArrayMap.get(eventName);
-        handlerArray && handlerArray.length > 0 ? handlerArray.push(handler) : this.eventHandlerArrayMap.set(eventName, [handler]);
-    }
-
-    /**
      * clears the event handler(s) for the event name
      * @param  {string} eventName
      * @param  {function} handler

--- a/src/EventManager.js
+++ b/src/EventManager.js
@@ -69,6 +69,25 @@ export default class EventManager {
         handlerArray && handlerArray.length > 0 ? handlerArray.push(handler) : this.eventHandlerArrayMap.set(eventName, [handler]);
     }
 
+    /**
+     * Adds the event handler to the corresponding handler array on the JS side of the bridge
+     * @param  {string} eventName
+     * @param  {function} handler
+     */
+    addEventHandler(eventName, handler) {
+        let handlerArray = this.eventHandlerArrayMap.get(eventName);
+        handlerArray && handlerArray.length > 0 ? handlerArray.push(handler) : this.eventHandlerArrayMap.set(eventName, [handler]);
+    }
+
+    /**
+     * clears the event handler(s) for the event name
+     * @param  {string} eventName
+     * @param  {function} handler
+     */
+    clearEventHandler(eventName) {
+        this.eventHandlerArrayMap.delete(eventName);
+    }
+
     // returns an event listener with the js to native mapping
     generateEventListener(eventName) {
         const addListenerCallback = (payload) => {

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -121,7 +121,7 @@ declare module 'react-native-onesignal' {
         isPushDisabled                  : boolean;
         isEmailSubscribed               : boolean;
         isSMSSubscribed                 : boolean;
-        hasNotificationPermission       ?: boolean; // ios only
+        hasNotificationPermission       ?: boolean; // is areNotificationsEnabled on android
         notificationPermissionStatus    ?: IosPermissionStatus;  // ios only
         // areNotificationsEnabled (android) not included since it is converted to hasNotificationPermission in bridge
     }

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -143,11 +143,23 @@ declare module 'react-native-onesignal' {
         addPermissionObserver(observer: (event: ChangeEvent<PermissionChange>) => void): void;
 
         /**
+         * Clears current permission observers.
+         * @returns void
+         */
+        clearPermissionObservers(): void;
+
+        /**
          * Add a callback that fires when the OneSignal subscription state changes.
          * @param  {(event:ChangeEvent<SubscriptionChange>)=>void} observer
          * @returns void
          */
         addSubscriptionObserver(observer: (event: ChangeEvent<SubscriptionChange>) => void): void;
+
+        /**
+         * Clears current subscription observers.
+         * @returns void
+         */
+        clearSubscriptionObservers(): void;
 
         /**
          * Add a callback that fires when the OneSignal email subscription changes.
@@ -157,11 +169,23 @@ declare module 'react-native-onesignal' {
         addEmailSubscriptionObserver(observer: (event: ChangeEvent<EmailSubscriptionChange>) => void): void;
 
         /**
+         * Clears current email subscription observers.
+         * @returns void
+         */
+        clearEmailSubscriptionObservers(): void;
+
+        /**
          * Add a callback that fires when the OneSignal sms subscription changes.
          * @param  {(event:ChangeEvent<SMSSubscriptionChange>)=>void} observer
          * @returns void
          */
         addSMSSubscriptionObserver(observer: (event: ChangeEvent<SMSSubscriptionChange>) => void): void;
+
+        /**
+         * Clears current SMS subscription observers.
+         * @returns void
+         */
+         clearSMSSubscriptionObservers(): void;
 
         /**
          * Set the callback to run just before displaying a notification while the app is in focus.

--- a/src/index.js
+++ b/src/index.js
@@ -78,8 +78,8 @@ export default class OneSignal {
 
     static clearSMSSubscriptionObservers() {
         if (!isObjectNonNull(RNOneSignal)) return;
-        RNOneSignal.addSMSSubscriptionObserver();
-        eventManager.addEventHandler(SMS_SUBSCRIPTION_CHANGED, observer);
+        RNOneSignal.removeSMSSubscriptionObserver();
+        eventManager.clearEventHandler(SMS_SUBSCRIPTION_CHANGED);
     }
 
     /* H A N D L E R S */

--- a/src/index.js
+++ b/src/index.js
@@ -37,6 +37,12 @@ export default class OneSignal {
         eventManager.addEventHandler(PERMISSION_CHANGED, observer);
     }
 
+    static clearPermissionObservers() {
+        if (!isObjectNonNull(RNOneSignal)) return;
+        RNOneSignal.removePermissionObserver();
+        eventManager.clearEventHandler(PERMISSION_CHANGED);
+    }
+    
     static addSubscriptionObserver(observer) {
         if (!isObjectNonNull(RNOneSignal)) return;
         isValidCallback(observer);
@@ -44,6 +50,12 @@ export default class OneSignal {
         eventManager.addEventHandler(SUBSCRIPTION_CHANGED, observer);
     }
 
+    static clearSubscriptionObservers() {
+        if (!isObjectNonNull(RNOneSignal)) return;
+        RNOneSignal.removeSubscriptionObserver();
+        eventManager.clearEventHandler(SUBSCRIPTION_CHANGED);
+    }
+    
     static addEmailSubscriptionObserver(observer) {
         if (!isObjectNonNull(RNOneSignal)) return;
         isValidCallback(observer);
@@ -51,9 +63,21 @@ export default class OneSignal {
         eventManager.addEventHandler(EMAIL_SUBSCRIPTION_CHANGED, observer);
     }
 
+    static clearEmailSubscriptionObservers() {
+        if (!isObjectNonNull(RNOneSignal)) return;
+        RNOneSignal.removeEmailSubscriptionObserver();
+        eventManager.clearEventHandler(EMAIL_SUBSCRIPTION_CHANGED);
+    }
+    
     static addSMSSubscriptionObserver(observer) {
         if (!isObjectNonNull(RNOneSignal)) return;
         isValidCallback(observer);
+        RNOneSignal.addSMSSubscriptionObserver();
+        eventManager.addEventHandler(SMS_SUBSCRIPTION_CHANGED, observer);
+    }
+
+    static clearSMSSubscriptionObservers() {
+        if (!isObjectNonNull(RNOneSignal)) return;
         RNOneSignal.addSMSSubscriptionObserver();
         eventManager.addEventHandler(SMS_SUBSCRIPTION_CHANGED, observer);
     }


### PR DESCRIPTION
need a way to remove event observers the way we were able to `OneSignal.removeEventListener`

any thoughts would be greatly appreciated y'all

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/onesignal/react-native-onesignal/1278)
<!-- Reviewable:end -->
