### PR TITLE
Add relevance score interruption level

### DIFF
--- a/react-native-onesignal.podspec
+++ b/react-native-onesignal.podspec
@@ -22,5 +22,5 @@ Pod::Spec.new do |s|
   # pod 'React', :path => '../node_modules/react-native/'
 
   # The Native OneSignal-iOS-SDK XCFramework from cocoapods.
-  s.dependency 'OneSignalXCFramework', '3.6.1'
+  s.dependency 'OneSignalXCFramework', '3.8.0'
 end

--- a/src/OSNotification.js
+++ b/src/OSNotification.js
@@ -37,6 +37,8 @@ export default class OSNotification {
             this.mutableContent = receivedEvent.mutableContent;
             this.badgeIncrement = receivedEvent.badgeIncrement;
             this.contentAvailable = receivedEvent.contentAvailable;
+            this.relevanceScore = receivedEvent.relevanceScore;
+            this.interruptionLevel = receivedEvent.interruptionLevel;
         }
     }
 }

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -75,6 +75,8 @@ declare module 'react-native-onesignal' {
         attachments         ?: object;
         mutableContent      ?: boolean;
         contentAvailable    ?: string;
+        relevanceScore      ?: number;
+        interruptionLevel   ?: string;
     }
 
     /* N O T I F I C A T I O N   &   I A M   E V E N T S */


### PR DESCRIPTION
iOS 15 notification properties are now available in the iOS native SDK. This PR adds them to RN's OSNotification object

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/onesignal/react-native-onesignal/1282)
<!-- Reviewable:end -->
