### PR TITLE
Remove default callback function from `removeExternalUserId`

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -356,6 +356,7 @@ export default class OneSignal {
     static removeExternalUserId(handler) {
         if (!isObjectNonNull(RNOneSignal)) return;
 
+        // Android workaround for the current issue of callback fired more than once
         if (handler === undefined && Platform.OS === 'ios')
             handler = function(){};
 

--- a/src/index.js
+++ b/src/index.js
@@ -356,7 +356,7 @@ export default class OneSignal {
     static removeExternalUserId(handler) {
         if (!isObjectNonNull(RNOneSignal)) return;
 
-        if (handler === undefined)
+        if (handler === undefined && Platform.OS === 'ios')
             handler = function(){};
 
         RNOneSignal.removeExternalUserId(handler);


### PR DESCRIPTION
I'm having [this issue](https://github.com/OneSignal/react-native-onesignal/issues/1015) even in version `4.1.0`. I looked into the code and probably found out the cause of the crash.

To address the workaround for the above issue the below PRs are created before, but I guess it should also be applied to `removeExternalUserId` as it also defines the default empty callback function in it and it just calls the `setExternalUserId` with an empty user ID internally.
https://github.com/OneSignal/react-native-onesignal/pull/1136 https://github.com/OneSignal/react-native-onesignal/pull/1141

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/onesignal/react-native-onesignal/1291)
<!-- Reviewable:end -->
