### PR TITLE
Give more detailed iOS error for callback to log

### DIFF
--- a/ios/RCTOneSignal/RCTOneSignalEventEmitter.m
+++ b/ios/RCTOneSignal/RCTOneSignalEventEmitter.m
@@ -77,6 +77,16 @@ RCT_EXPORT_MODULE(RCTOneSignal)
     return events;
 }
 
+- (NSArray<NSString *> *)processNSError:(NSError *)error {
+    if (error.userInfo[@"error"]) {
+        return @[error.userInfo[@"error"]];
+    } else if (error.userInfo[@"returned"]) {
+        return @[error.userInfo[@"returned"]];
+    } else {
+        return @[error.localizedDescription];
+    }
+}
+
 
 #pragma mark Send Event Methods
 
@@ -247,7 +257,7 @@ RCT_EXPORT_METHOD(setEmail:(NSString *)email withAuthHash:(NSString *)authHash w
     [OneSignal setEmail:email withEmailAuthHashToken:authHash withSuccess:^{
         callback(@[]);
     } withFailure:^(NSError *error) {
-        callback(@[error.userInfo[@"error"] ?: error.localizedDescription]);
+        callback([self processNSError:error]);
     }];
 }
 
@@ -255,7 +265,7 @@ RCT_EXPORT_METHOD(logoutEmail:(RCTResponseSenderBlock)callback) {
     [OneSignal logoutEmailWithSuccess:^{
         callback(@[]);
     } withFailure:^(NSError *error) {
-        callback(@[error.userInfo[@"error"] ?: error.localizedDescription]);
+        callback([self processNSError:error]);
     }];
 }
 
@@ -264,7 +274,7 @@ RCT_EXPORT_METHOD(setSMSNumber:(NSString *)smsNumber withAuthHash:(NSString *)au
     [OneSignal setSMSNumber:smsNumber withSMSAuthHashToken:authHash withSuccess:^(NSDictionary *results) {
         callback(@[results]);
     } withFailure:^(NSError *error) {
-        callback(@[error.userInfo[@"error"] ?: error.localizedDescription]);
+        callback([self processNSError:error]);
     }];
 }
 
@@ -272,7 +282,7 @@ RCT_EXPORT_METHOD(logoutSMSNumber:(RCTResponseSenderBlock)callback) {
     [OneSignal logoutSMSNumberWithSuccess:^(NSDictionary *results) {
         callback(@[results]);
     } withFailure:^(NSError *error) {
-        callback(@[error.userInfo[@"error"] ?: error.localizedDescription]);
+        callback([self processNSError:error]);
     }];
 }
 
@@ -344,7 +354,7 @@ RCT_EXPORT_METHOD(postNotification:(NSString *)jsonObjectString successCallback:
         successCallback(@[success]);
     } onFailure:^(NSError *error) {
         [OneSignal onesignalLog:ONE_S_LL_ERROR message:[NSString stringWithFormat:@"Notification Send Failure with Error: %@", error]];
-        failureCallback(@[error.userInfo[@"error"] ?: error.localizedDescription]);
+        failureCallback([self processNSError:error]);
     }];
 }
 
@@ -365,7 +375,7 @@ RCT_EXPORT_METHOD(setExternalUserId:(NSString*)externalId withAuthHash:(NSString
     } withFailure:^(NSError *error) {
         [OneSignal onesignalLog:ONE_S_LL_VERBOSE message:[NSString stringWithFormat:@"OneSignal setExternalUserId error: %@", error]];
         if (callback) {
-            callback(@[error.userInfo[@"error"] ?: error.localizedDescription]);
+            callback([self processNSError:error]);
         }
     }];
 }
@@ -382,7 +392,7 @@ RCT_EXPORT_METHOD(removeExternalUserId:(RCTResponseSenderBlock)callback) {
         }
     } withFailure:^(NSError *error) {
         [OneSignal onesignalLog:ONE_S_LL_VERBOSE message:[NSString stringWithFormat:@"OneSignal removeExternalUserId error: %@", error]];
-        callback(@[error.userInfo[@"error"] ?: error.localizedDescription]);
+        callback([self processNSError:error]);
     }];
 }
 


### PR DESCRIPTION
- A request may not have an explicit error in the response meaning there is no `error.userInfo[@"error"]` when there actually really is an error
- So we will also check for `error.userInfo[@"returned"]` before defaulting to `error.localizedDescription`

This PR was made after a customer reported that:

> When using setEmail or any method that takes the user auth key required for identity verification and that auth hash is invalid we log the error like this:
> 
> 2021-07-06 17:59:48.656224-0700 ReactNativeDemo[39809:2132550] [javascript] 'Email Error setting email: ', 'The operation couldn't be completed. (OneSignalError error 400.)'
> 
> This error is unhelpful to know that a bad user auth hash key is provided

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/onesignal/react-native-onesignal/1299)
<!-- Reviewable:end -->
