### PR TITLE
Fix NativeEventEmitter warnings for react-native 0.65

### DIFF
--- a/android/src/main/java/com/geektime/rnonesignalandroid/RNOneSignal.java
+++ b/android/src/main/java/com/geektime/rnonesignalandroid/RNOneSignal.java
@@ -726,4 +726,18 @@ public class RNOneSignal extends ReactContextBaseJavaModule
       removeHandlers();
       removeObservers();
    }
+
+   /**
+    * Added for NativeEventEmitter
+    */
+
+   @ReactMethod
+   public void addListener(String eventName) {
+      // Keep: Required for RN built in Event Emitter Calls.
+   }
+
+   @ReactMethod
+   public void removeListeners(int count) {
+      // Keep: Required for RN built in Event Emitter Calls.
+   }
 }


### PR DESCRIPTION
# Description
## One Line Summary
Added `addListener` and `removeListeners` stubs into **Android only** to address new react-native 0.65 warnings.

## Details
### Motivation
Addresses this Issue: https://github.com/OneSignal/react-native-onesignal/issues/1303

>  WARN  `new NativeEventEmitter()` was called with a non-null argument without the required `addListener` method.
>  WARN  `new NativeEventEmitter()` was called with a non-null argument without the required `removeListeners` method.
> 

These warnings only appear for Android, so I decided **not** to add the stubs to iOS as well, to minimize changes.

### Background Context
Relevant react-native commits: [f5502fb](https://github.com/facebook/react-native/commit/f5502fbda9fe271ff6e1d0da773a3a8ee206a453) and [114be1d](https://github.com/facebook/react-native/commit/114be1d2170bae2d29da749c07b45acf931e51e2)

### Scope
We don't use these methods, so currently they are stubs for sole purpose of dismissing the warning.

# Testing
## Manual Testing
- Ran example app on Android API 30 Emulator with:
  - react: 17.0.2
  - react-native: 0.66.1

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/onesignal/react-native-onesignal/1314)
<!-- Reviewable:end -->
