### PR TITLE
[ISSUE #1310] updated android sdk dependency to 4.6.2

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -29,7 +29,7 @@ dependencies {
 
     // api is used instead of implementation so the parent :app project can access any of the OneSignal Java
     //   classes if needed. Such as com.onesignal.NotificationExtenderService
-    api 'com.onesignal:OneSignal:4.6.0'
+    api 'com.onesignal:OneSignal:4.6.2'
 
     testImplementation 'junit:junit:4.12'
 }


### PR DESCRIPTION
As the current sdk is crashing for Android 12, this PR updates the Android SDK to the latest dependency.
Related to [issue](https://github.com/OneSignal/react-native-onesignal/issues/1310).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/onesignal/react-native-onesignal/1315)
<!-- Reviewable:end -->
