### PR TITLE
Workaround for duplicate callback invocation issue

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -381,7 +381,8 @@ export default class OneSignal {
         if (emailAuthCode === undefined)
             emailAuthCode = null;
 
-        if (handler === undefined)
+        // Android workaround for the current issue of callback fired more than once
+        if (!handler && Platform.OS === 'ios')
             handler = function(){};
 
         RNOneSignal.setEmail(email, emailAuthCode, handler);
@@ -394,7 +395,8 @@ export default class OneSignal {
     static logoutEmail(handler?: Function): void {
         if (!isNativeModuleLoaded(RNOneSignal)) return;
 
-        if (!handler)
+        // Android workaround for the current issue of callback fired more than once
+        if (!handler && Platform.OS === 'ios')
             handler = function(){};
 
         RNOneSignal.logoutEmail(handler);
@@ -415,7 +417,8 @@ export default class OneSignal {
         if (smsAuthCode === undefined)
             smsAuthCode = null;
 
-        if (handler === undefined)
+        // Android workaround for the current issue of callback fired more than once
+        if (!handler && Platform.OS === 'ios')
             handler = function(){};
 
         RNOneSignal.setSMSNumber(smsNumber, smsAuthCode, handler);
@@ -428,7 +431,8 @@ export default class OneSignal {
     static logoutSMSNumber(handler?: Function): void {
         if (!isNativeModuleLoaded(RNOneSignal)) return;
 
-        if (!handler)
+        // Android workaround for the current issue of callback fired more than once
+        if (!handler && Platform.OS === 'ios')
             handler = function(){};
 
         RNOneSignal.logoutSMSNumber(handler);


### PR DESCRIPTION
Temporary Workaround for #1015 (see issue for more info)

**Note:** this is not a fix as it only serves as a workaround if the callback is not passed in altogether. For those who need to pass a callback, this workaround won't work.

Once a permanent fix is done, we should clean up these changes.

Should be merged to main _after_ #1312 is merged.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/onesignal/react-native-onesignal/1334)
<!-- Reviewable:end -->
