### PR TITLE
Make Android `getTriggerValueForKey` consistent with iOS

### DIFF
--- a/android/src/main/java/com/geektime/rnonesignalandroid/RNOneSignal.java
+++ b/android/src/main/java/com/geektime/rnonesignalandroid/RNOneSignal.java
@@ -594,7 +594,13 @@ public class RNOneSignal extends ReactContextBaseJavaModule
 
    @ReactMethod
    public void getTriggerValueForKey(String key, Promise promise) {
-      promise.resolve(OneSignal.getTriggerValueForKey(key));
+      Object val = OneSignal.getTriggerValueForKey(key);
+      if (val == null) {
+         Log.e("OneSignal", "getTriggerValueForKey: There was no value for the key: " + key);
+         promise.reject("No Value", "There was no value for the key: " + key);
+         return;
+      }
+      promise.resolve(val);
    }
 
    /* in app message click */


### PR DESCRIPTION
# Description
## One Line Summary

Minor change: make the returned value for method `getTriggerValueForKey` consistent over Android and iOS bridges.

## Details
### Motivation
I noticed during some testing that `getTriggerValueForKey` returns a rejected promise with error in the iOS bridge if there is NO value for the key specified but just returns the `null` value over the Android bridge with no error.

This PR makes the Android bridge behave the same way as iOS so users don't receive an error returned in iOS while receiving a returned value of `null` in Android.

I chose to make Android mimic iOS behavior and reject the promise instead of the other way around because both platforms currently reject when method `getDeviceState` is `null`.
 
### Scope
Shouldn't really affect users' existing implementations and makes a method more consistent across iOS and Android.

# Testing
## Manual Testing
[X] Tested behavior in iOS simulator and Android emulator
[X] Added triggers of different types (boolean, number, string) 
[X] Called `getTriggerValueForKey` for keys with and without values
[X] Tested also with `removeTriggerForKey`

# Affected code checklist
   - [ ] Notifications
      - [ ] Display
      - [ ] Open
      - [ ] Push Processing
      - [ ] Confirm Deliveries
   - [ ] Outcomes
   - [ ] Sessions
   - [X] In-App Messaging
   - [ ] REST API requests
   - [ ] Public API changes

# Checklist
## Overview
   - [X] I have filled out all **REQUIRED** sections above
   - [X] PR does one thing
   - [X] Any Public API changes are explained in the PR details and conform to existing APIs

## Testing
   - [X] I have included test coverage for these changes, or explained why they are not needed
   - [X] All automated tests pass, or I explained why that is not possible
   - [x] I have personally tested this on my device, or explained why that is not possible

## Final pass
   - [X] Code is as readable as possible.
   - [X] I have reviewed this PR myself, ensuring it meets each checklist item

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/onesignal/react-native-onesignal/1335)
<!-- Reviewable:end -->
