### PR TITLE
Fix: duplicate callback invocation error

### DIFF
--- a/android/src/main/java/com/geektime/rnonesignalandroid/RNOneSignal.java
+++ b/android/src/main/java/com/geektime/rnonesignalandroid/RNOneSignal.java
@@ -338,13 +338,21 @@ public class RNOneSignal extends ReactContextBaseJavaModule
       OneSignal.setEmail(email, emailAuthToken, new EmailUpdateHandler() {
          @Override
          public void onSuccess() {
-            callback.invoke();
+            Callback callbackCopy = callback;
+            if (callbackCopy != null) {
+              callbackCopy.invoke();
+              callbackCopy = null;
+           }
          }
 
          @Override
          public void onFailure(EmailUpdateError error) {
             try {
-               callback.invoke(RNUtils.jsonToWritableMap(jsonFromErrorMessageString(error.getMessage())));
+              Callback callbackCopy = callback;
+              if (callbackCopy != null) {
+                callbackCopy.invoke(RNUtils.jsonToWritableMap(jsonFromErrorMessageString(error.getMessage())));
+                callbackCopy = null;
+              }
             } catch (JSONException exception) {
                exception.printStackTrace();
             }
@@ -357,13 +365,21 @@ public class RNOneSignal extends ReactContextBaseJavaModule
       OneSignal.logoutEmail(new EmailUpdateHandler() {
          @Override
          public void onSuccess() {
-            callback.invoke();
+           Callback callbackCopy = callback;
+           if (callbackCopy != null) {
+            callbackCopy.invoke();
+            callbackCopy = null;
+           }
          }
 
          @Override
          public void onFailure(EmailUpdateError error) {
             try {
-               callback.invoke(RNUtils.jsonToWritableMap(jsonFromErrorMessageString(error.getMessage())));
+              Callback callbackCopy = callback;
+              if (callbackCopy != null) {
+                callbackCopy.invoke(RNUtils.jsonToWritableMap(jsonFromErrorMessageString(error.getMessage())));
+                callbackCopy = null;
+              }
             } catch (JSONException exception) {
                exception.printStackTrace();
             }
@@ -376,13 +392,21 @@ public class RNOneSignal extends ReactContextBaseJavaModule
       OneSignal.setSMSNumber(smsNumber, smsAuthToken, new OneSignal.OSSMSUpdateHandler() {
          @Override
          public void onSuccess(JSONObject result) {
-            callback.invoke(RNUtils.jsonToWritableMap(result));
+           Callback callbackCopy = callback;
+           if (callbackCopy != null) {
+            callbackCopy.invoke(RNUtils.jsonToWritableMap(result));
+            callbackCopy = null;
+           }
          }
 
          @Override
          public void onFailure(OneSignal.OSSMSUpdateError error) {
             try {
-               callback.invoke(RNUtils.jsonToWritableMap(jsonFromErrorMessageString(error.getMessage())));
+              Callback callbackCopy = callback;
+              if (callbackCopy != null) {
+                callbackCopy.invoke(RNUtils.jsonToWritableMap(jsonFromErrorMessageString(error.getMessage())));
+                callbackCopy = null;
+              }
             } catch (JSONException exception) {
                exception.printStackTrace();
             }
@@ -395,13 +419,21 @@ public class RNOneSignal extends ReactContextBaseJavaModule
       OneSignal.logoutSMSNumber(new OneSignal.OSSMSUpdateHandler() {
          @Override
          public void onSuccess(JSONObject result) {
-            callback.invoke(RNUtils.jsonToWritableMap(result));
+            Callback callbackCopy = callback;
+            if (callbackCopy != null) {
+              callbackCopy.invoke(RNUtils.jsonToWritableMap(result));
+              callbackCopy = null;
+           }
          }
 
          @Override
          public void onFailure(OneSignal.OSSMSUpdateError error) {
             try {
-               callback.invoke(RNUtils.jsonToWritableMap(jsonFromErrorMessageString(error.getMessage())));
+              Callback callbackCopy = callback;
+              if (callbackCopy != null) {
+                callbackCopy.invoke(RNUtils.jsonToWritableMap(jsonFromErrorMessageString(error.getMessage())));
+                callbackCopy = null;
+              }
             } catch (JSONException exception) {
                exception.printStackTrace();
             }
@@ -491,14 +523,20 @@ public class RNOneSignal extends ReactContextBaseJavaModule
          public void onSuccess(JSONObject results) {
             Log.i("OneSignal", "Completed setting external user id: " + externalId + "with results: " + results.toString());
 
-            if (callback != null)
-               callback.invoke(RNUtils.jsonToWritableMap(results));
+            Callback callbackCopy = callback;
+            if (callbackCopy != null) {
+               callbackCopy.invoke(RNUtils.jsonToWritableMap(results));
+               callbackCopy = null;
+            }
          }
 
          @Override
          public void onFailure(OneSignal.ExternalIdError error) {
-            if (callback != null)
-               callback.invoke(error.getMessage());
+            Callback callbackCopy = callback;
+            if (callbackCopy != null) {
+               callbackCopy.invoke(error.getMessage());
+               callbackCopy = null;
+            }
          }
       });
    }
@@ -510,14 +548,20 @@ public class RNOneSignal extends ReactContextBaseJavaModule
          public void onSuccess(JSONObject results) {
             Log.i("OneSignal", "Completed removing external user id with results: " + results.toString());
 
-            if (callback != null)
-               callback.invoke(RNUtils.jsonToWritableMap(results));
+            Callback callbackCopy = callback;
+            if (callbackCopy != null) {
+              callbackCopy.invoke(RNUtils.jsonToWritableMap(results));
+              callbackCopy = null;
+            }
          }
 
          @Override
          public void onFailure(OneSignal.ExternalIdError error) {
-            if (callback != null)
-               callback.invoke(error.getMessage());
+            Callback callbackCopy = callback;
+            if (callbackCopy != null) {
+              callbackCopy.invoke(error.getMessage());
+              callbackCopy = null;
+            }
          }
       });
    }
@@ -636,7 +680,7 @@ public class RNOneSignal extends ReactContextBaseJavaModule
       }
       this.sendEvent("OneSignal-inAppMessageClicked", RNUtils.jsonToWritableMap(result.toJSONObject()));
    }
-   
+
    /* in app message lifecycle */
 
    @ReactMethod

--- a/examples/RNOneSignalTS/package.json
+++ b/examples/RNOneSignalTS/package.json
@@ -12,7 +12,7 @@
   "dependencies": {
     "react": "16.13.1",
     "react-native": "0.64.1",
-    "react-native-onesignal": "4.3.3"
+    "react-native-onesignal": "4.3.4"
   },
   "devDependencies": {
     "@babel/core": "^7.8.4",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-native-onesignal",
-  "version": "4.3.3",
+  "version": "4.3.4",
   "description": "React Native OneSignal SDK",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/react-native-onesignal.podspec
+++ b/react-native-onesignal.podspec
@@ -22,5 +22,5 @@ Pod::Spec.new do |s|
   # pod 'React', :path => '../node_modules/react-native/'
 
   # The Native OneSignal-iOS-SDK XCFramework from cocoapods.
-  s.dependency 'OneSignalXCFramework', '3.9.1'
+  s.dependency 'OneSignalXCFramework', '3.10.0'
 end


### PR DESCRIPTION
# Description
## One Line Summary
Fixes duplicate callback invocation error by checking if callback is null, and then setting it to null after invocation.

## Details

### Motivation
RN places a restriction on callbacks invoked through the bridge in that they should only be single-use. Due to the native-side channel synchronizer (currently only applies to Android), updating external ID, email, OR SMS will invoke the `onSuccess` / `onFailure` of all channels, leading to previously invoked callbacks potentially being re-invoked.

Here, we can protect duplicate invocations by null-checking the callback value before invocation and nullifying the value after invocation.

More details in issue thread: #1015

### Note
Because the callback variable is required to be `final`, we have to save it into a copy from within the override function and invoke the copy. If there is a better solution, please let me know.

### Scope
Only changes in Android - React Native bridge.

# Testing
## Unit testing
No unit tests in the wrapper.

## Manual testing
Test that functions still work. Since we have not been able to consistently reproduce the issue, we cannot easily test these changes for a fix.

# Affected code checklist
   - [ ] Notifications
      - [ ] Display
      - [ ] Open
      - [ ] Push Processing
      - [ ] Confirm Deliveries
   - [ ] Outcomes
   - [ ] Sessions
   - [ ] REST API requests
   - [ ] Public API changes
   - [ ] TODO: Others depending on SDK

# Checklist
## Overview
   - [x] I have filled out all REPLACE sections above
   - [x] PR does one thing
     - If it is hard to explain how any codes changes are related to each other then it most likely needs to be more than one PR
   - [ ] Public API changes are intended and conform to existing APIs (N/A)

## Testing
   - [x] I have included test coverage for these changes, or explained why they are not needed
   - [x] All automated tests pass, or I explained why that is not possible
   - [x] I have personally tested this on my device, or explained why that is not possible

## Final pass
   - [X] Code is as readable as possible.
      - Simplify with less code, followed by splitting up code into well-named functions and variables, followed by adding comments to the code.
   - [X] I have reviewed this PR myself, ensuring it meets each checklist item
      - WIP (Work In Progress) is ok, but explain what is still in progress and what you would like feedback on. Start the PR title with "WIP" to indicate this.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/onesignal/react-native-onesignal/1341)
<!-- Reviewable:end -->

Fixes #1015 