### PR TITLE
Add `setLaunchURLsInApp` function

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -29,7 +29,7 @@ dependencies {
 
     // api is used instead of implementation so the parent :app project can access any of the OneSignal Java
     //   classes if needed. Such as com.onesignal.NotificationExtenderService
-    api 'com.onesignal:OneSignal:4.6.5'
+    api 'com.onesignal:OneSignal:4.6.6'
 
     testImplementation 'junit:junit:4.12'
 }

--- a/ios/RCTOneSignal/RCTOneSignalEventEmitter.m
+++ b/ios/RCTOneSignal/RCTOneSignalEventEmitter.m
@@ -394,6 +394,10 @@ RCT_EXPORT_METHOD(postNotification:(NSString *)jsonObjectString successCallback:
     }];
 }
 
+RCT_EXPORT_METHOD(setLaunchURLsInApp:(BOOL)isEnabled) {
+  [OneSignal setLaunchURLsInApp:isEnabled];
+}
+
 RCT_EXPORT_METHOD(setLogLevel:(int)logLevel visualLogLevel:(int)visualLogLevel) {
     [OneSignal setLogLevel:logLevel visualLevel:visualLogLevel];
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-native-onesignal",
-  "version": "4.3.5",
+  "version": "4.3.6",
   "description": "React Native OneSignal SDK",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/src/index.ts
+++ b/src/index.ts
@@ -505,6 +505,21 @@ export default class OneSignal {
         }
     }
 
+    /**
+     * This method can be used to set if launch URLs should be opened in safari or within the application.
+     * @param  {boolean} isEnabled
+     * @returns
+     */
+    static setLaunchURLsInApp(isEnabled: boolean): void {
+      if (!isNativeModuleLoaded(RNOneSignal)) return;
+
+      if (Platform.OS === 'ios') {
+        RNOneSignal.setLaunchURLsInApp(isEnabled);
+      } else {
+        console.log("setLaunchURLsInApp: this function is not supported on Android");
+      }
+    }
+
     /* E X T E R N A L  U S E R  I D */
 
     /**


### PR DESCRIPTION
## 1-line description
Adds the `setLaunchURLsInApp` function.

## Details
The function, previously only available via the native iOS SDK, does the following:

> This method can be used to set if launch URLs should be opened in safari or within the application

In an effort to simplify the modification of this behavior, the function should be made available across all wrapper SDKs.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/onesignal/react-native-onesignal/1353)
<!-- Reviewable:end -->
