### PR TITLE
Fix: send outcome functions when no handler is set -> pass empty function

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -676,6 +676,11 @@ export default class OneSignal {
      */
     static sendOutcome(name: string, handler?: (event: OutcomeEvent) => void): void {
         if (!isNativeModuleLoaded(RNOneSignal)) return;
+
+        if (!handler) {
+            handler = function(){};
+        }
+
         RNOneSignal.sendOutcome(name, handler);
     }
 
@@ -687,6 +692,11 @@ export default class OneSignal {
      */
     static sendUniqueOutcome(name: string, handler?: (event: OutcomeEvent) => void): void {
         if (!isNativeModuleLoaded(RNOneSignal)) return;
+
+        if (!handler) {
+            handler = function(){};
+        }
+
         RNOneSignal.sendUniqueOutcome(name, handler);
     }
 
@@ -700,6 +710,11 @@ export default class OneSignal {
      */
     static sendOutcomeWithValue(name: string, value: string | number, handler?: (event: OutcomeEvent) => void): void {
         if (!isNativeModuleLoaded(RNOneSignal)) return;
+
+        if (!handler) {
+            handler = function(){};
+        }
+
         RNOneSignal.sendOutcomeWithValue(name, Number(value), handler);
     }
 


### PR DESCRIPTION
## One Line Description
Pass empty function handler over the bridge for send outcome functions if user doesn't set handlers.

## Details
Fixes https://github.com/OneSignal/react-native-onesignal/issues/1348. The 3 functions related to sending outcomes used to have a default `handler=function(){}` in the function definition if a user does not pass a handler in (`sendOutcome`, `sendUniqueOutcome`, `sendOutcomeWithValue`).

This was removed from the function definition when the SDK was converted to TypeScript in #1312, but the body of the function didn't check and set the handler to an empty function before passing it over the bridge, leading to crashes.

```
static sendOutcome(name, handler=function(){})

static sendOutcome(name: string, handler?: (event: OutcomeEvent) => void): void
```

Now, add a check for the `handler` and set to empty function if not provided.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/onesignal/react-native-onesignal/1356)
<!-- Reviewable:end -->
