### PR TITLE
Fix typescript types for getTags and additionalData

### DIFF
--- a/src/OSNotification.ts
+++ b/src/OSNotification.ts
@@ -7,7 +7,7 @@ export default class OSNotification {
         launchURL           ?: string;
         rawPayload          : object | string; // platform bridges return different types
         actionButtons       ?: object[];
-        additionalData      : object;
+        additionalData      ?: object;
         notificationId      : string;
         // android only
         groupKey                ?: string;

--- a/src/index.ts
+++ b/src/index.ts
@@ -331,10 +331,10 @@ export default class OneSignal {
 
     /**
      * Retrieve a list of tags that have been set on the user from the OneSignal server.
-     * @param  {(tags: {[key: string]: string}) => void} handler
+     * @param  {(tags: {[key: string]: string} | null) => void} handler
      * @returns void
      */
-    static getTags(handler: (tags: { [key: string]: string }) => void): void {
+    static getTags(handler: (tags: { [key: string]: string } | null) => void): void {
         if (!isNativeModuleLoaded(RNOneSignal)) return;
         RNOneSignal.getTags(handler);
     }


### PR DESCRIPTION
This PR fixes TS types on two different locations:

1- I noticed `getTags` could return null if user is deleted on OneSignal dashboard, so updated the types to take that into account

2- Our app crashed in production once due to `additionalData` being null/undefined, while types were saying it should be an object.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/onesignal/react-native-onesignal/1358)
<!-- Reviewable:end -->
