### PR TITLE
[Feature] Add callbacks to `setLanguage`

### DIFF
--- a/ios/RCTOneSignal/RCTOneSignalEventEmitter.m
+++ b/ios/RCTOneSignal/RCTOneSignalEventEmitter.m
@@ -245,8 +245,12 @@ RCT_REMAP_METHOD(getDeviceState,
     }
 }
 
-RCT_EXPORT_METHOD(setLanguage:(NSString *)language) {
-    [OneSignal setLanguage:language];
+RCT_EXPORT_METHOD(setLanguage:(NSString *)language successCallback:(RCTResponseSenderBlock)successCallback failureCallback:(RCTResponseSenderBlock)failureCallback) {
+    [OneSignal setLanguage:language withSuccess:^(NSDictionary *success) {
+        successCallback(@[success]);
+    } withFailure:^(NSError *error) {
+        failureCallback([self processNSError:error]);
+    }];
 }
 
 RCT_EXPORT_METHOD(setNotificationOpenedHandler) {

--- a/src/index.ts
+++ b/src/index.ts
@@ -287,12 +287,21 @@ export default class OneSignal {
     /**
      * Allows you to set the app defined language with the OneSignal SDK.
      * @param  {string} language
+     * @param  {(success:object) => void} onSuccess
+     * @param  {(failure:object) => void} onFailure
      * @returns void
      */
-    static setLanguage(language: string): void {
+     static setLanguage(language: string, onSuccess?: (success: object) => void, onFailure?: (failure: object) => void): void {
         if (!isNativeModuleLoaded(RNOneSignal)) return;
 
-        RNOneSignal.setLanguage(language);
+        if (!onSuccess) {
+            onSuccess = function(){};
+        }
+
+        if (!onFailure) {
+            onFailure = function(){};
+        }
+        RNOneSignal.setLanguage(language, onSuccess, onFailure);
     }
 
     /* T A G S */


### PR DESCRIPTION
# Description
## One Line Summary
Adds optional `onSuccess` and `onFailure` callbacks for setting language (`setLanguage` method).

## Details

### Motivation
Provides developers with success and failure callbacks.

### Scope
* Add `setLanguage` `onSuccess` and `onFailure` callbacks
* On **Android**, if multiple channels are set (ie push, email, SMS), the callback will fire once for the first successful channel and subsequent success or failure callbacks will not be invoked.
* On **iOS**, if multiple channels are set (ie push, email, SMS), the callback will be invoked once with the states of all the channels.
* When testing **Android**, the responses from the native SDK are `null` for the successful message and the error response (I created error callback by turning off network connection). When these are `null`, I pass through a custom object. 
    ```java
    {'success' : 'true', 'message' : 'Successfully set language.'}

    {"error":"Failed to set language."}
    ```

# Testing

## Manual testing
Tested setting various languages on iOS and Android.
* ✅ Tested setting a language without providing any callbacks.
* ✅ Tested setting a language with `onSuccess` and `onFailure` callbacks provided, and no other channels set.
* ✅ Tested setting email and SMS first, then setting a language. See below for the responses passed to the developer's callbacks.

```java
// Android success
{'success' : 'true', 'message' : 'Successfully set language.'}

// iOS success
{"push":{"success":true},"email":{"success":true},"sms":{"success":true}}

// Android failure example: turn off wifi and data
{"error":"Failed to set language."}

// iOS failure example: turn off wifi and data
"Network Error"
```
 
# Affected code checklist
   - [ ] Notifications
      - [ ] Display
      - [ ] Open
      - [ ] Push Processing
      - [ ] Confirm Deliveries
   - [ ] Outcomes
   - [ ] Sessions
   - [ ] In-App Messaging
   - [ ] REST API requests
   - [x] Public API changes

# Checklist
## Overview
   - [x] I have filled out all **REQUIRED** sections above
   - [x] PR does one thing
   - [x] Any Public API changes are explained in the PR details and conform to existing APIs

## Testing
   - [x] I have included test coverage for these changes, or explained why they are not needed
   - [x] All automated tests pass, or I explained why that is not possible
   - [x] I have personally tested this on my device, or explained why that is not possible

## Final pass
   - [x] Code is as readable as possible.
   - [x] I have reviewed this PR myself, ensuring it meets each checklist item

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/onesignal/react-native-onesignal/1400)
<!-- Reviewable:end -->
