### PR TITLE
[Feat] Add Android 13 push permission prompting

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -29,7 +29,7 @@ dependencies {
 
     // api is used instead of implementation so the parent :app project can access any of the OneSignal Java
     //   classes if needed. Such as com.onesignal.NotificationExtenderService
-    api 'com.onesignal:OneSignal:4.7.3'
+    api 'com.onesignal:OneSignal:4.8.1'
 
     testImplementation 'junit:junit:4.12'
 }

--- a/android/src/main/java/com/geektime/rnonesignalandroid/RNOneSignal.java
+++ b/android/src/main/java/com/geektime/rnonesignalandroid/RNOneSignal.java
@@ -468,6 +468,20 @@ public class RNOneSignal extends ReactContextBaseJavaModule
    }
 
    @ReactMethod
+   public void promptForPushNotificationsWithUserResponse(final boolean fallbackToSettings, final Callback callback) {
+      final Callback[] callbackArr = new Callback[]{ callback };
+      OneSignal.promptForPushNotifications(fallbackToSettings, new OneSignal.PromptForPushNotificationPermissionResponseHandler() {
+         @Override
+         public void response(boolean accepted) {
+            if (callbackArr[0] != null) {
+               callbackArr[0].invoke(accepted);
+               callbackArr[0] = null;
+            }
+         }
+      });
+   }
+
+   @ReactMethod
    public void promptLocation() {
       OneSignal.promptLocation();
    }

--- a/examples/RNOneSignalTS/android/app/src/main/AndroidManifest.xml
+++ b/examples/RNOneSignalTS/android/app/src/main/AndroidManifest.xml
@@ -16,6 +16,7 @@
         android:label="@string/app_name"
         android:configChanges="keyboard|keyboardHidden|orientation|screenSize|uiMode"
         android:launchMode="singleTask"
+        android:exported="true"
         android:windowSoftInputMode="adjustResize">
         <intent-filter>
             <action android:name="android.intent.action.MAIN" />

--- a/examples/RNOneSignalTS/android/build.gradle
+++ b/examples/RNOneSignalTS/android/build.gradle
@@ -4,8 +4,8 @@ buildscript {
     ext {
         buildToolsVersion = "29.0.2"
         minSdkVersion = 21
-        compileSdkVersion = 29
-        targetSdkVersion = 29
+        compileSdkVersion = 33
+        targetSdkVersion = 33
     }
     repositories {
         google()

--- a/examples/RNOneSignalTS/src/OSButtons.tsx
+++ b/examples/RNOneSignalTS/src/OSButtons.tsx
@@ -72,7 +72,7 @@ class OSButtons extends React.Component<Props, State> {
             color,
             () => {
                 loggingFunction("Prompting for push with user response...");
-                OneSignal.promptForPushNotificationsWithUserResponse(response => {
+                OneSignal.promptForPushNotificationsWithUserResponse(true, response => {
                     loggingFunction(`User response: ${response}`);
                 });
             }
@@ -115,13 +115,8 @@ class OSButtons extends React.Component<Props, State> {
 
         elements.push(subscribedButton,
             unsubscribeWhenNotificationsAreDisabledButton,
-            registerForProvisionalAuthorization,
+            registerForProvisionalAuthorization, promptForPush,
             locationShared, setLocationShared, promptLocationButton);
-
-        if (Platform.OS === 'ios') {
-            elements.push(promptForPush);
-        }
-
         return elements;
     }
 

--- a/examples/RNOneSignalTS/src/OSDemo.tsx
+++ b/examples/RNOneSignalTS/src/OSDemo.tsx
@@ -38,9 +38,6 @@ class OSDemo extends React.Component<Props, State> {
         OneSignal.setAppId("ce8572ae-ff57-4e77-a265-5c91f00ecc4c");
         OneSignal.setLogLevel(6, 0);
         OneSignal.setRequiresUserPrivacyConsent(this.state.requiresPrivacyConsent);
-        OneSignal.promptForPushNotificationsWithUserResponse(response => {
-            this.OSLog("Prompt response:", response);
-        });
 
         /* O N E S I G N A L  H A N D L E R S */
         OneSignal.setNotificationWillShowInForegroundHandler(notifReceivedEvent => {

--- a/ios/RCTOneSignal/RCTOneSignalEventEmitter.m
+++ b/ios/RCTOneSignal/RCTOneSignalEventEmitter.m
@@ -194,12 +194,6 @@ RCT_EXPORT_METHOD(setAppId:(NSString* _Nonnull)newAppId) {
     [OneSignal setAppId:newAppId];
 }
 
-RCT_EXPORT_METHOD(promptForPushNotificationPermissions:(RCTResponseSenderBlock)callback) {
-    [OneSignal promptForPushNotificationsWithUserResponse:^(BOOL accepted) {
-        callback(@[@(accepted)]);
-    }];
-}
-
 RCT_EXPORT_METHOD(requestPermissions:(NSDictionary *)permissions) {
     if (RCTRunningInAppExtension()) {
         return;
@@ -326,11 +320,11 @@ RCT_EXPORT_METHOD(logoutSMSNumber:(RCTResponseSenderBlock)callback) {
     }];
 }
 
-RCT_EXPORT_METHOD(promptForPushNotificationsWithUserResponse:(RCTResponseSenderBlock)callback) {
+RCT_EXPORT_METHOD(promptForPushNotificationsWithUserResponse:(BOOL)fallbackToSettings withResponse:(RCTResponseSenderBlock)callback) {
     [OneSignal promptForPushNotificationsWithUserResponse:^(BOOL accepted) {
         [OneSignal onesignalLog:ONE_S_LL_VERBOSE message:@"Prompt For Push Notifications Success"];
         callback(@[@(accepted)]);
-    }];
+    } fallbackToSettings:fallbackToSettings];
 }
 
 RCT_EXPORT_METHOD(registerForProvisionalAuthorization:(RCTResponseSenderBlock)callback) {

--- a/src/index.ts
+++ b/src/index.ts
@@ -170,19 +170,36 @@ export default class OneSignal {
     /* R E G I S T R A T I O N  E T C */
 
     /**
-     * Prompts the iOS user for push notifications.
+     * Prompts the user for push notifications permission in iOS and Android 13+.
+     * Use the fallbackToSettings parameter to prompt to open the settings app if a user has already declined push permissions.
+     *
+     * Call with promptForPushNotificationsWithUserResponse(fallbackToSettings?, handler?)
+     *
+     * Recommended: Do not use and instead follow: https://documentation.onesignal.com/docs/ios-push-opt-in-prompt.
+     * @param  {boolean} fallbackToSettings
      * @param  {(response:boolean) => void} handler
      * @returns void
      */
-    static promptForPushNotificationsWithUserResponse(handler: (response: boolean) => void): void {
+    static promptForPushNotificationsWithUserResponse(fallbackToSettingsOrHandler?: boolean | ((response: boolean) => void), handler?: (response: boolean) => void): void {
         if (!isNativeModuleLoaded(RNOneSignal)) return;
 
-        if (Platform.OS === 'ios') {
-            isValidCallback(handler);
-            RNOneSignal.promptForPushNotificationsWithUserResponse(handler);
-        } else {
-            console.log("promptForPushNotificationsWithUserResponse: this function is not supported on Android");
+        var fallbackToSettings = false;
+
+        if (typeof fallbackToSettingsOrHandler === "function") {
+            // Method was called like promptForPushNotificationsWithUserResponse(handler: function)
+            handler = fallbackToSettingsOrHandler;
         }
+        else if (typeof fallbackToSettingsOrHandler === "boolean") {
+            // Method was called like promptForPushNotificationsWithUserResponse(fallbackToSettings: boolean, handler?: function)
+            fallbackToSettings = fallbackToSettingsOrHandler;
+        }
+        // Else method was called like promptForPushNotificationsWithUserResponse(), no need to modify
+
+        if (!handler && Platform.OS === 'ios') {
+            handler = function(){};
+        }
+
+        RNOneSignal.promptForPushNotificationsWithUserResponse(fallbackToSettings, handler);
     }
 
     /**

--- a/src/index.ts
+++ b/src/index.ts
@@ -183,7 +183,7 @@ export default class OneSignal {
     static promptForPushNotificationsWithUserResponse(fallbackToSettingsOrHandler?: boolean | ((response: boolean) => void), handler?: (response: boolean) => void): void {
         if (!isNativeModuleLoaded(RNOneSignal)) return;
 
-        var fallbackToSettings = false;
+        let fallbackToSettings = false;
 
         if (typeof fallbackToSettingsOrHandler === "function") {
             // Method was called like promptForPushNotificationsWithUserResponse(handler: function)


### PR DESCRIPTION
# Description
## One Line Summary
This PR implements push permission prompting in Android for Android 13 devices.

## Details

### Motivation
This is a new Android 13 features/requirement.

### Scope
Push permission prompting on Android 13 devices. In order to not immediately be prompted in Android 13, apps will need to set their Android target SDK version to 33+.

Pre-existing `OneSignal.PromptForPushNotificationsWithUserResponse` method has the following changes:
- Works on Android
- Added an optional `fallbackToSettings` option.

```typescript
promptForPushNotificationsWithUserResponse(fallbackToSettings?: boolean, handler?: (response: boolean) => void)
```

# Testing

## Manual testing
I tested on physical iPhone 13 and Android emulator on API 33 using combinations of allowing, denying, changing the permission in settings, and re-prompting. These are the ways of calling the method tested.

```typescript
OneSignal.promptForPushNotificationsWithUserResponse();

OneSignal.promptForPushNotificationsWithUserResponse(true);

OneSignal.promptForPushNotificationsWithUserResponse(false);

OneSignal.promptForPushNotificationsWithUserResponse(res => console.log(res));

OneSignal.promptForPushNotificationsWithUserResponse(undefined, (res) => console.log(res));

OneSignal.promptForPushNotificationsWithUserResponse(true, (res) => console.log(res));
```

# Affected code checklist
   - [x] Notifications
      - [ ] Display
      - [ ] Open
      - [ ] Push Processing
      - [ ] Confirm Deliveries
      - [x] Prompting
   - [ ] Outcomes
   - [ ] Sessions
   - [ ] In-App Messaging
   - [ ] REST API requests
   - [x] Public API changes

# Checklist
## Overview
   - [x] I have filled out all **REQUIRED** sections above
   - [x] PR does one thing
   - [x] Any Public API changes are explained in the PR details and conform to existing APIs

## Testing
   - [ ] I have included test coverage for these changes, or explained why they are not needed
   - [ ] All automated tests pass, or I explained why that is not possible
   - [x] I have personally tested this on my device, or explained why that is not possible

## Final pass
   - [x] Code is as readable as possible.
   - [x] I have reviewed this PR myself, ensuring it meets each checklist item

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/onesignal/react-native-onesignal/1415)
<!-- Reviewable:end -->
