### PR TITLE
Skip creation of EventManager if module not loaded

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -30,7 +30,11 @@ import { InAppMessage, InAppMessageAction, InAppMessageLifecycleHandlerObject } 
 import { isValidCallback, isNativeModuleLoaded } from './helpers';
 
 const RNOneSignal = NativeModules.OneSignal;
-const eventManager = new EventManager(RNOneSignal);
+let eventManager: EventManager;
+
+if (isNativeModuleLoaded(RNOneSignal)) {
+  eventManager = new EventManager(RNOneSignal);
+}
 
 // 0 = None, 1 = Fatal, 2 = Errors, 3 = Warnings, 4 = Info, 5 = Debug, 6 = Verbose
 export type LogLevel = 0 | 1 | 2 | 3 | 4 | 5 | 6;


### PR DESCRIPTION
# Description
## One Line Summary
Prevent the creation of a NativeEventEmitter with `null` as argument

## Details
Creating `EventManager` when the module is not loaded will generate the following error
```
Invariant Violation: `new NativeEventEmitter()` requires a non-null argument.
```

### Motivation
This change will affect most likely `expo` users.
Since version 4.x of OneSignal, `EventManager` is always created which leads to the error above
when running the app in Expo go and IOS Simulator.

## Manual testing
  - Create a simple expo project
  - Import OneSignal and call OneSignal.init()
  - Launch ExpoGo in an IOS simulator

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/onesignal/react-native-onesignal/1427)
<!-- Reviewable:end -->
