### PR TITLE
Adding react native bridging for live activities

### DIFF
--- a/ios/RCTOneSignal/RCTOneSignalEventEmitter.m
+++ b/ios/RCTOneSignal/RCTOneSignalEventEmitter.m
@@ -401,7 +401,6 @@ RCT_EXPORT_METHOD(setLaunchURLsInApp:(BOOL)isEnabled) {
  */
 
 RCT_EXPORT_METHOD(enterLiveActivity:(NSString *)activityId withToken:(NSString *)token withResponse:(RCTResponseSenderBlock)callback) {
-    // Auth hash token created on server and sent to client.
     [OneSignal enterLiveActivity:activityId withToken:token withSuccess:^{
         callback(@[]);
     } withFailure:^(NSError *error) {
@@ -410,7 +409,6 @@ RCT_EXPORT_METHOD(enterLiveActivity:(NSString *)activityId withToken:(NSString *
 }
 
 RCT_EXPORT_METHOD(exitLiveActivity:(NSString *)activityId withResponse:(RCTResponseSenderBlock)callback) {
-    // Auth hash token created on server and sent to client.
     [OneSignal exitLiveActivity:activityId withToken:token withSuccess:^{
         callback(@[]);
     } withFailure:^(NSError *error) {

--- a/ios/RCTOneSignal/RCTOneSignalEventEmitter.m
+++ b/ios/RCTOneSignal/RCTOneSignalEventEmitter.m
@@ -396,6 +396,28 @@ RCT_EXPORT_METHOD(setLaunchURLsInApp:(BOOL)isEnabled) {
   [OneSignal setLaunchURLsInApp:isEnabled];
 }
 
+/*
+ * Live Activity
+ */
+
+RCT_EXPORT_METHOD(enterLiveActivity:(NSString *)activityId withToken:(NSString *)token withResponse:(RCTResponseSenderBlock)callback) {
+    // Auth hash token created on server and sent to client.
+    [OneSignal enterLiveActivity:activityId withToken:token withSuccess:^{
+        callback(@[]);
+    } withFailure:^(NSError *error) {
+        callback([self processNSError:error]);
+    }];
+}
+
+RCT_EXPORT_METHOD(exitLiveActivity:(NSString *)activityId withResponse:(RCTResponseSenderBlock)callback) {
+    // Auth hash token created on server and sent to client.
+    [OneSignal exitLiveActivity:activityId withToken:token withSuccess:^{
+        callback(@[]);
+    } withFailure:^(NSError *error) {
+        callback([self processNSError:error]);
+    }];
+}
+
 RCT_EXPORT_METHOD(setLogLevel:(int)logLevel visualLogLevel:(int)visualLogLevel) {
     [OneSignal setLogLevel:logLevel visualLevel:visualLogLevel];
 }

--- a/react-native-onesignal.podspec
+++ b/react-native-onesignal.podspec
@@ -22,5 +22,5 @@ Pod::Spec.new do |s|
   # pod 'React', :path => '../node_modules/react-native/'
 
   # The Native OneSignal-iOS-SDK XCFramework from cocoapods.
-  s.dependency 'OneSignalXCFramework', '3.11.2'
+  s.dependency 'OneSignalXCFramework', '3.12.1'
 end

--- a/react-native-onesignal.podspec
+++ b/react-native-onesignal.podspec
@@ -22,5 +22,5 @@ Pod::Spec.new do |s|
   # pod 'React', :path => '../node_modules/react-native/'
 
   # The Native OneSignal-iOS-SDK XCFramework from cocoapods.
-  s.dependency 'OneSignalXCFramework', '3.12.1'
+  s.dependency 'OneSignalXCFramework', '3.12.2'
 end

--- a/src/index.ts
+++ b/src/index.ts
@@ -33,7 +33,7 @@ import {
 } from './models/InAppMessage';
 import { isValidCallback, isNativeModuleLoaded } from './helpers';
 
-const  RNOneSignal = NativeModules.OneSignal;
+const RNOneSignal = NativeModules.OneSignal;
 const eventManager = new EventManager(RNOneSignal);
 
 // 0 = None, 1 = Fatal, 2 = Errors, 3 = Warnings, 4 = Info, 5 = Debug, 6 = Verbose
@@ -319,9 +319,9 @@ export default class OneSignal {
       );
     }
   }
-   /* L I V E   A C T I V I T Y  */
+  /* L I V E   A C T I V I T Y  */
 
-    /**
+  /**
    * Associates a temporary push token with an Activity ID on the OneSignal server.
    * @param  {string} activityId
    * @param  {string} token
@@ -337,42 +337,36 @@ export default class OneSignal {
       return;
     }
 
-    // Android workaround for the current issue of callback fired more than once
-    if (!handler && Platform.OS === 'ios') {
+    if (!handler) {
       handler = function () {};
     }
 
     // Only Available on iOS
-    if (Platform.OS === 'ios'){
+    if (Platform.OS === 'ios') {
       RNOneSignal.enterLiveActivity(activityId, token, handler);
     }
   }
 
-   /**
+  /**
    * Deletes activityId associated temporary push token on the OneSignal server.
    * @param  {string} activityId
    * @param  {Function} handler
    * @returns void
    */
-    static exitLiveActivity(
-      activityId: string,
-      handler?: Function,
-    ): void {
-      if (!isNativeModuleLoaded(RNOneSignal)) {
-        return;
-      }
-  
-      // Android workaround for the current issue of callback fired more than once
-      if (!handler && Platform.OS === 'ios') {
-        handler = function () {};
-      }
-  
-      // Only Available on iOS
-      if (Platform.OS === 'ios'){
-        RNOneSignal.enterLiveActivity(activityId, handler);
-      }
+  static exitLiveActivity(activityId: string, handler?: Function): void {
+    if (!isNativeModuleLoaded(RNOneSignal)) {
+      return;
     }
 
+    if (!handler) {
+      handler = function () {};
+    }
+
+    // Only Available on iOS
+    if (Platform.OS === 'ios') {
+      RNOneSignal.enterLiveActivity(activityId, handler);
+    }
+  }
 
   /* L O C A T I O N */
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -33,7 +33,7 @@ import {
 } from './models/InAppMessage';
 import { isValidCallback, isNativeModuleLoaded } from './helpers';
 
-const RNOneSignal = NativeModules.OneSignal;
+const  RNOneSignal = NativeModules.OneSignal;
 const eventManager = new EventManager(RNOneSignal);
 
 // 0 = None, 1 = Fatal, 2 = Errors, 3 = Warnings, 4 = Info, 5 = Debug, 6 = Verbose
@@ -319,6 +319,60 @@ export default class OneSignal {
       );
     }
   }
+   /* L I V E   A C T I V I T Y  */
+
+    /**
+   * Associates a temporary push token with an Activity ID on the OneSignal server.
+   * @param  {string} activityId
+   * @param  {string} token
+   * @param  {Function} handler
+   * @returns void
+   */
+  static enterLiveActivity(
+    activityId: string,
+    token: string,
+    handler?: Function,
+  ): void {
+    if (!isNativeModuleLoaded(RNOneSignal)) {
+      return;
+    }
+
+    // Android workaround for the current issue of callback fired more than once
+    if (!handler && Platform.OS === 'ios') {
+      handler = function () {};
+    }
+
+    // Only Available on iOS
+    if (Platform.OS === 'ios'){
+      RNOneSignal.enterLiveActivity(activityId, token, handler);
+    }
+  }
+
+   /**
+   * Deletes activityId associated temporary push token on the OneSignal server.
+   * @param  {string} activityId
+   * @param  {Function} handler
+   * @returns void
+   */
+    static exitLiveActivity(
+      activityId: string,
+      handler?: Function,
+    ): void {
+      if (!isNativeModuleLoaded(RNOneSignal)) {
+        return;
+      }
+  
+      // Android workaround for the current issue of callback fired more than once
+      if (!handler && Platform.OS === 'ios') {
+        handler = function () {};
+      }
+  
+      // Only Available on iOS
+      if (Platform.OS === 'ios'){
+        RNOneSignal.enterLiveActivity(activityId, handler);
+      }
+    }
+
 
   /* L O C A T I O N */
 


### PR DESCRIPTION
# Description
## One Line Summary
Adds Live Activity support for the SDK

## Details

### Motivation
Adding 2 sdk methods that allow a customer to register their temporary live activity token with an activity ID on OneSignal's backend

### Scope
Adding bridging to access the two ned iOS sdk methods from React Native code.

# Testing
## Unit testing
The iOS repo contains tests, this is only bridging

## Manual testing
The backend piece is not available yet so only testing with mock data.

# Affected code checklist
   - [ ] Notifications
      - [ ] Display
      - [ ] Open
      - [ ] Push Processing
      - [ ] Confirm Deliveries
   - [ ] Outcomes
   - [ ] Sessions
   - [ ] In-App Messaging
   - [ ] REST API requests
   - [x] Public API changes

# Checklist
## Overview
   - [ x] I have filled out all **REQUIRED** sections above
   - [x] PR does one thing
     - If it is hard to explain how any codes changes are related to each other then it most likely needs to be more than one PR
   - [x] Any Public API changes are explained in the PR details and conform to existing APIs

## Testing
   - [x] I have included test coverage for these changes, or explained why they are not needed
   - [x] All automated tests pass, or I explained why that is not possible
   - [x] I have personally tested this on my device, or explained why that is not possible

## Final pass
   - [x] Code is as readable as possible.
      - Simplify with less code, followed by splitting up code into well named functions and variables, followed by adding comments to the code.
   - [x] I have reviewed this PR myself, ensuring it meets each checklist item
      - WIP (Work In Progress) is ok, but explain what is still in progress and what you would like feedback on. Start the PR title with "WIP" to indicate this.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/onesignal/react-native-onesignal/1453)
<!-- Reviewable:end -->
