### PR TITLE
Release 4.5.0

### DIFF
--- a/examples/RNOneSignalTS/package.json
+++ b/examples/RNOneSignalTS/package.json
@@ -12,7 +12,7 @@
   "dependencies": {
     "react": "16.13.1",
     "react-native": "0.64.1",
-    "react-native-onesignal": "^4.4.1"
+    "react-native-onesignal": "^4.5.0"
   },
   "devDependencies": {
     "@babel/core": "^7.8.4",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-native-onesignal",
-  "version": "4.4.1",
+  "version": "4.5.0",
   "description": "React Native OneSignal SDK",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",


### PR DESCRIPTION
## Native SDK Updates
- Bump native iOS SDK version to `3.12.3`
  - Adds `enterLiveActivity` and `exitLiveActivity`

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/onesignal/react-native-onesignal/1457)
<!-- Reviewable:end -->
