### PR TITLE
Release 4.5.1

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -29,7 +29,7 @@ dependencies {
 
     // api is used instead of implementation so the parent :app project can access any of the OneSignal Java
     //   classes if needed. Such as com.onesignal.NotificationExtenderService
-    api 'com.onesignal:OneSignal:4.8.2'
+    api 'com.onesignal:OneSignal:4.8.5'
 
     testImplementation 'junit:junit:4.12'
 }

--- a/examples/RNOneSignalTS/package.json
+++ b/examples/RNOneSignalTS/package.json
@@ -12,7 +12,7 @@
   "dependencies": {
     "react": "16.13.1",
     "react-native": "0.64.1",
-    "react-native-onesignal": "^4.5.0"
+    "react-native-onesignal": "^4.5.1"
   },
   "devDependencies": {
     "@babel/core": "^7.8.4",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-native-onesignal",
-  "version": "4.5.0",
+  "version": "4.5.1",
   "description": "React Native OneSignal SDK",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/react-native-onesignal.podspec
+++ b/react-native-onesignal.podspec
@@ -22,5 +22,5 @@ Pod::Spec.new do |s|
   # pod 'React', :path => '../node_modules/react-native/'
 
   # The Native OneSignal-iOS-SDK XCFramework from cocoapods.
-  s.dependency 'OneSignalXCFramework', '3.12.3'
+  s.dependency 'OneSignalXCFramework', '3.12.4'
 end


### PR DESCRIPTION
## Native iOS SDK Update
Bump native iOS SDK version from `3.12.3` to `3.12.4`
- Fix In App Messages occasionally being displayed twice 
- Fix a OneSignal log ignoring the "None" log level

## Native Android SDK Update
Bump native Android SDK version from `4.8.2` to `4.8.5`
- Fix issue which caused groupless notifications to not get cleared if there were at least 4 of them
- Remove OneSignal gradle plugin from build.gradle files 
- Fix an issue with liquid IAMs when a non-existent tag doesn't show the correct default value.
- Speculative Fix for WorkManager not Initialized Crash

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/OneSignal/react-native-onesignal/1499)
<!-- Reviewable:end -->
