### PR TITLE
chore: add namespace to `build.gradle` for react-native 0.73+

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -5,6 +5,7 @@ def safeExtGet(prop, fallback) {
 }
 
 android {
+    namespace "com.geektime.rnonesignalandroid"
     compileSdkVersion safeExtGet('compileSdkVersion', 28)
     buildToolsVersion safeExtGet('buildToolsVersion', '28.0.3')
 

--- a/android/src/main/AndroidManifest.xml
+++ b/android/src/main/AndroidManifest.xml
@@ -1,3 +1,2 @@
-<manifest xmlns:android="http://schemas.android.com/apk/res/android"
-    package="com.geektime.rnonesignalandroid">
+<manifest xmlns:android="http://schemas.android.com/apk/res/android">
 </manifest>


### PR DESCRIPTION
# Description
## One Line Summary
This is a change that'll be required starting from React Native 0.73.x. More context can be found here: https://github.com/react-native-community/discussions-and-proposals/issues/671
# Testing
## Manual testing
Run the example app on android, everything should work fine ✅

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/OneSignal/react-native-onesignal/1526)
<!-- Reviewable:end -->
