### PR TITLE
Release 4.5.2

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -29,7 +29,7 @@ dependencies {
 
     // api is used instead of implementation so the parent :app project can access any of the OneSignal Java
     //   classes if needed. Such as com.onesignal.NotificationExtenderService
-    api 'com.onesignal:OneSignal:4.8.5'
+    api 'com.onesignal:OneSignal:4.8.6'
 
     testImplementation 'junit:junit:4.12'
 }

--- a/examples/RNOneSignalTS/package.json
+++ b/examples/RNOneSignalTS/package.json
@@ -12,7 +12,7 @@
   "dependencies": {
     "react": "16.13.1",
     "react-native": "0.64.1",
-    "react-native-onesignal": "^4.5.1"
+    "react-native-onesignal": "^4.5.2"
   },
   "devDependencies": {
     "@babel/core": "^7.8.4",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-native-onesignal",
-  "version": "4.5.1",
+  "version": "4.5.2",
   "description": "React Native OneSignal SDK",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/react-native-onesignal.podspec
+++ b/react-native-onesignal.podspec
@@ -22,5 +22,5 @@ Pod::Spec.new do |s|
   # pod 'React', :path => '../node_modules/react-native/'
 
   # The Native OneSignal-iOS-SDK XCFramework from cocoapods.
-  s.dependency 'OneSignalXCFramework', '3.12.4'
+  s.dependency 'OneSignalXCFramework', '3.12.6'
 end


### PR DESCRIPTION
## Native iOS SDK Update
Bump native iOS SDK version from `3.12.4` to `3.12.6`
- Fix swizzling subclass of already swizzled class (https://github.com/OneSignal/OneSignal-iOS-SDK/pull/1284)
- Always remove the window when an InApp Message is dismissed (https://github.com/OneSignal/OneSignal-iOS-SDK/pull/1276)
- Make web views inspectable (https://github.com/OneSignal/OneSignal-iOS-SDK/pull/1286) https://github.com/OneSignal/OneSignal-iOS-SDK/pull/1292
- Enable push notifications for iOS simulators (https://github.com/OneSignal/OneSignal-iOS-SDK/pull/1244)
- Fix Crash for In App Message clicks with no id (https://github.com/OneSignal/OneSignal-iOS-SDK/pull/1248)
- Fix tracking influenced opens in firebase (https://github.com/OneSignal/OneSignal-iOS-SDK/pull/1241)

## Native Android SDK Update
Bump native Android SDK version from `4.8.5` to `4.8.6`
- Add public class CallbackThreadManager (https://github.com/OneSignal/OneSignal-Android-SDK/pull/1776)
- Prevent ANRs when backgrounding app (https://github.com/OneSignal/OneSignal-Android-SDK/pull/1775)
- Bump firebase-messaging dependency version 23 (https://github.com/OneSignal/OneSignal-Android-SDK/pull/1762)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/OneSignal/react-native-onesignal/1544)
<!-- Reviewable:end -->
