### PR TITLE
Prevent init onHostResume if already initialized for that activity context

### DIFF
--- a/android/src/main/java/com/geektime/rnonesignalandroid/RNOneSignal.java
+++ b/android/src/main/java/com/geektime/rnonesignalandroid/RNOneSignal.java
@@ -154,21 +154,14 @@ public class RNOneSignal extends ReactContextBaseJavaModule
    }
 
    // Initialize OneSignal only once when an Activity is available.
-   // React creates an instance of this class to late for OneSignal to get the current Activity
+   // React creates an instance of this class too late for OneSignal to get the current Activity
    // based on registerActivityLifecycleCallbacks it uses to listen for the first Activity.
    // However it seems it is also to soon to call getCurrentActivity() from the reactContext as well.
    // This will normally succeed when onHostResume fires instead.
    private void initOneSignal() {
+      oneSignalInitDone = true;
       OneSignal.sdkType = "react";
       Context context = mReactApplicationContext.getCurrentActivity();
-
-      if (oneSignalInitDone) {
-         Log.e("OneSignal", "Already initialized the OneSignal React-Native SDK");
-         return;
-      }
-
-      oneSignalInitDone = true;
-
 
       if (context == null) {
          // in some cases, especially when react-native-navigation is installed,
@@ -844,7 +837,14 @@ public class RNOneSignal extends ReactContextBaseJavaModule
 
    @Override
    public void onHostResume() {
-      initOneSignal();
+      // Initialize OneSignal only once when an Activity is available.
+      // React creates an instance of this class too late for OneSignal to get the current Activity
+      // based on registerActivityLifecycleCallbacks it uses to listen for the first Activity.
+      // However it seems it is also to soon to call getCurrentActivity() from the reactContext as well.
+      // This will normally succeed when onHostResume fires instead.
+      if (!oneSignalInitDone) {
+        initOneSignal();
+      }
    }
 
    @Override


### PR DESCRIPTION
# Description
## One Line Summary
Prevent init onHostResume if already initialized for that activity context

## Details
Previously we were entering into the init function and logging the error "Already initialized..." which was reported as a bug.

### Motivation
Fixes: #1521

# Testing
## Manual testing
TO DO: haven't tested

# Affected code checklist
   - [ ] Notifications
      - [ ] Display
      - [ ] Open
      - [ ] Push Processing
      - [ ] Confirm Deliveries
   - [ ] Outcomes
   - [ ] Sessions
   - [ ] In-App Messaging
   - [ ] REST API requests
   - [ ] Public API changes

# Checklist
## Overview
   - [ ] I have filled out all **REQUIRED** sections above
   - [ ] PR does one thing
     - If it is hard to explain how any codes changes are related to each other then it most likely needs to be more than one PR
   - [ ] Any Public API changes are explained in the PR details and conform to existing APIs

## Testing
   - [ ] I have included test coverage for these changes, or explained why they are not needed
   - [ ] All automated tests pass, or I explained why that is not possible
   - [ ] I have personally tested this on my device, or explained why that is not possible

## Final pass
   - [ ] Code is as readable as possible.
      - Simplify with less code, followed by splitting up code into well named functions and variables, followed by adding comments to the code.
   - [ ] I have reviewed this PR myself, ensuring it meets each checklist item
      - WIP (Work In Progress) is ok, but explain what is still in progress and what you would like feedback on. Start the PR title with "WIP" to indicate this.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/OneSignal/react-native-onesignal/1553)
<!-- Reviewable:end -->
