### PR TITLE
[5.0.0] Fix permission listener, export a few more types

### DIFF
--- a/android/src/main/java/com/onesignal/rnonesignalandroid/RNOneSignal.java
+++ b/android/src/main/java/com/onesignal/rnonesignalandroid/RNOneSignal.java
@@ -52,6 +52,7 @@ import com.facebook.react.modules.core.DeviceEventManagerModule;
 import com.onesignal.Continue;
 import com.onesignal.OneSignal;
 import com.onesignal.debug.LogLevel;
+import com.onesignal.common.OneSignalWrapper;
 import com.onesignal.inAppMessages.IInAppMessage;
 import com.onesignal.inAppMessages.IInAppMessageClickListener;
 import com.onesignal.inAppMessages.IInAppMessageClickEvent;
@@ -214,6 +215,8 @@ public class RNOneSignal extends ReactContextBaseJavaModule implements
     @ReactMethod
     public void initialize(String appId) {
         Context context = mReactApplicationContext.getCurrentActivity();
+        OneSignalWrapper.setSdkType("reactnative");
+        OneSignalWrapper.setSdkVersion("050000");
 
         if (oneSignalInitDone) {
             Log.e("OneSignal", "Already initialized the OneSignal React-Native SDK");

--- a/examples/RNOneSignalTS/src/OSButtons.tsx
+++ b/examples/RNOneSignalTS/src/OSButtons.tsx
@@ -1,4 +1,4 @@
-import {OneSignal, OutcomeEvent} from 'react-native-onesignal';
+import {OneSignal} from 'react-native-onesignal';
 import * as React from 'react';
 import {StyleSheet, View, Platform} from 'react-native';
 import {renderButtonView} from './Helpers';

--- a/ios/RCTOneSignal/RCTOneSignal.m
+++ b/ios/RCTOneSignal/RCTOneSignal.m
@@ -46,6 +46,8 @@ OSNotificationClickResult* coldStartOSNotificationClickResult;
     if (didInitialize)
         return;
 
+    OneSignalWrapper.sdkType = @"reactnative";
+    OneSignalWrapper.sdkVersion = @"050000";
     [OneSignal setLaunchOptions:launchOptions];
     didInitialize = true;
 }

--- a/src/events/EventManager.ts
+++ b/src/events/EventManager.ts
@@ -98,7 +98,7 @@ export default class EventManager {
             );
           });
         } else if (eventName === PERMISSION_CHANGED) {
-          const typedPayload = payload as {permission: boolean}
+          const typedPayload = payload as { permission: boolean };
           handlerArray.forEach((handler) => {
             handler(typedPayload.permission);
           });

--- a/src/events/EventManager.ts
+++ b/src/events/EventManager.ts
@@ -97,6 +97,11 @@ export default class EventManager {
               new NotificationWillDisplayEvent(payload as OSNotification),
             );
           });
+        } else if (eventName === PERMISSION_CHANGED) {
+          const typedPayload = payload as {permission: boolean}
+          handlerArray.forEach((handler) => {
+            handler(typedPayload.permission);
+          });
         } else {
           handlerArray.forEach((handler) => {
             handler(payload);

--- a/src/index.ts
+++ b/src/index.ts
@@ -24,7 +24,6 @@ import {
   PushSubscriptionChangedState,
 } from './models/Subscription';
 import NotificationWillDisplayEvent from './events/NotificationWillDisplayEvent';
-import { OutcomeEvent } from './models/Outcomes';
 import {
   InAppMessage,
   InAppMessageEventTypeMap,
@@ -791,7 +790,6 @@ export {
   InAppMessageDidDisplayEvent,
   InAppMessageWillDismissEvent,
   InAppMessageDidDismissEvent,
-  OutcomeEvent,
 };
 
 export { default as OSNotification } from './OSNotification';

--- a/src/index.ts
+++ b/src/index.ts
@@ -790,8 +790,11 @@ export {
   InAppMessageDidDisplayEvent,
   InAppMessageWillDismissEvent,
   InAppMessageDidDismissEvent,
+  PushSubscriptionState,
+  PushSubscriptionChangedState,
+  OSNotificationPermission,
 };
 
 export { default as OSNotification } from './OSNotification';
 export { NotificationClickResult } from './models/NotificationEvents';
-export { OSNotificationPermission } from './models/Subscription';
+export { InAppMessageClickResult } from './models/InAppMessage';

--- a/src/models/Outcomes.ts
+++ b/src/models/Outcomes.ts
@@ -1,7 +1,0 @@
-export interface OutcomeEvent {
-  session: string;
-  id: string;
-  timestamp: number;
-  weight: number;
-  notification_ids: string[];
-}


### PR DESCRIPTION
# Description
## One Line Summary
A few fixes post 5.0.0-release, includes 1 bug fix.

## Details

### Motivation
A few fixes post 5.0.0-release, includes 1 bug fix.

**1. Remove OutcomeEvent as no longer used**

**2. Export a few more types through index file**
- `PushSubscriptionState`
- `PushSubscriptionChangedState`
- `InAppMessageClickResult`

**3. Add** the SDK wrapper type
 
**4. Fix permission boolean**
The bridge passes a dictionary, not a single boolean. We need to extract the boolean to pass to permission listeners.

# Testing

## Manual testing
Test on Android emulator 33 and iPhone 13

# Affected code checklist
   - [ ] Notifications
      - [ ] Display
      - [ ] Open
      - [ ] Push Processing
      - [ ] Confirm Deliveries
   - [ ] Outcomes
   - [ ] Sessions
   - [ ] In-App Messaging
   - [ ] REST API requests
   - [ ] Public API changes

# Checklist
## Overview
   - [ ] I have filled out all **REQUIRED** sections above
   - [ ] PR does one thing
   - [ ] Any Public API changes are explained in the PR details and conform to existing APIs

## Testing
   - [ ] I have included test coverage for these changes, or explained why they are not needed
   - [ ] All automated tests pass, or I explained why that is not possible
   - [ ] I have personally tested this on my device, or explained why that is not possible

## Final pass
   - [ ] Code is as readable as possible.
   - [ ] I have reviewed this PR myself, ensuring it meets each checklist item

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/OneSignal/react-native-onesignal/1558)
<!-- Reviewable:end -->
