### PR TITLE
[user model] Fix notification click listener not firing on cold start

### DIFF
--- a/ios/RCTOneSignal/RCTOneSignal.m
+++ b/ios/RCTOneSignal/RCTOneSignal.m
@@ -41,12 +41,13 @@ OSNotificationClickResult* coldStartOSNotificationClickResult;
     return _sharedInstance;
 }
 
-- (void)setLaunchOptions:(NSDictionary *)launchOptions {
+- (void)initOneSignal:(NSDictionary *)launchOptions {
 
     if (didInitialize)
         return;
 
-    [OneSignal setLaunchOptions:launchOptions];
+    // initialize the SDK with a nil app ID so cold start click listeners can be triggered
+    [OneSignal initialize:nil withLaunchOptions:launchOptions];
     didInitialize = true;
 }
 

--- a/ios/RCTOneSignal/UIApplication+RCTOnesignal.m
+++ b/ios/RCTOneSignal/UIApplication+RCTOnesignal.m
@@ -4,7 +4,7 @@
 @interface RCTOneSignal
 + (RCTOneSignal *) sharedInstance;
 - (void)initialize:(nonnull NSString*)newAppId withLaunchOptions:(nullable NSDictionary*)launchOptions;
-- (void)setLaunchOptions:(NSDictionary*)launchOptions;
+- (void)initOneSignal:(NSDictionary*)launchOptions;
 @end
 
 @implementation UIApplication(OneSignalReactNative)
@@ -55,7 +55,7 @@ static void injectSelector(Class newClass, SEL newSel, Class addToClass, SEL mak
 }
 
 - (BOOL)oneSignalApplication:(UIApplication*)application didFinishLaunchingWithOptions:(NSDictionary*)launchOptions {
-    [[RCTOneSignal sharedInstance] setLaunchOptions:launchOptions];
+    [[RCTOneSignal sharedInstance] initOneSignal:launchOptions];
     if ([self respondsToSelector:@selector(oneSignalApplication:didFinishLaunchingWithOptions:)])
         return [self oneSignalApplication:application didFinishLaunchingWithOptions:launchOptions];
     return YES;

--- a/react-native-onesignal.podspec
+++ b/react-native-onesignal.podspec
@@ -22,5 +22,5 @@ Pod::Spec.new do |s|
   # pod 'React', :path => '../node_modules/react-native/'
 
   # The Native OneSignal-iOS-SDK XCFramework from cocoapods.
-  s.dependency 'OneSignalXCFramework', '5.0.1'
+  s.dependency 'OneSignalXCFramework', '5.0.2'
 end


### PR DESCRIPTION
# Description
## One Line Summary
Fix iOS notifications clicked event not firing when clicking a notification to open the app from a cold start.

## Details

### Motivation
Fixes iOS bug where notification click listener is set but not firing when clicking the notification from a cold start.

### Scope
In the iOS bridge, the `setLaunchOptions` has been updated to call `initialize:nil withLaunchOptions:launchOptions` so that the SDK can be initialized in order to get the cold start notification click event. This will result in the iOS SDK reading the appId from cache when nil is passed.

# Testing
## Manual testing
Tested the following scenarios on an iPhone 13 Pro with iOS 16.6:

1. Add click listener on app start. Kill app and and click notification to open from cold start. Alert is shown via visual logging. 
2. Click on notification from cold start, app opens, then add the click listener from a button. Click event for previously-clicked notification successfully fires. 

# Affected code checklist
   - [ ] Notifications
      - [ ] Display
      - [X] Open
      - [ ] Push Processing
      - [ ] Confirm Deliveries
   - [ ] Outcomes
   - [ ] Sessions
   - [ ] In-App Messaging
   - [ ] REST API requests
   - [ ] Public API changes

# Checklist
## Overview
   - [X] I have filled out all **REQUIRED** sections above
   - [X] PR does one thing
   - [X] Any Public API changes are explained in the PR details and conform to existing APIs

## Testing
   - [X] I have included test coverage for these changes, or explained why they are not needed
   - [X] All automated tests pass, or I explained why that is not possible
   - [X] I have personally tested this on my device, or explained why that is not possible

## Final pass
   - [X] Code is as readable as possible.
   - [X] I have reviewed this PR myself, ensuring it meets each checklist item

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/OneSignal/react-native-onesignal/1567)
<!-- Reviewable:end -->
