### PR TITLE
Fix `requestPermission` to return `false` when permission is denied

### DIFF
--- a/android/src/main/java/com/onesignal/rnonesignalandroid/RNOneSignal.java
+++ b/android/src/main/java/com/onesignal/rnonesignalandroid/RNOneSignal.java
@@ -428,7 +428,11 @@ public class RNOneSignal extends ReactContextBaseJavaModule implements
     @ReactMethod
     public void requestNotificationPermission(final boolean fallbackToSettings, Promise promise) {
         OneSignal.getNotifications().requestPermission(fallbackToSettings, Continue.with(result -> {
-            promise.resolve(result.isSuccess());
+            if (result.isSuccess()) {
+                promise.resolve(result.getData());
+            } else {
+                promise.reject(result.getThrowable().getMessage());
+            }
         }));
     }
 

--- a/examples/RNOneSignalTS/src/OSButtons.tsx
+++ b/examples/RNOneSignalTS/src/OSButtons.tsx
@@ -139,6 +139,14 @@ class OSButtons extends React.Component<Props> {
       },
     );
 
+    const permissionNativeButton = renderButtonView(
+      'Permission Native',
+      async () => {
+        const granted = await OneSignal.Notifications.permissionNative();
+        loggingFunction(`Permission Native: ${granted}`);
+      },
+    );
+
     const canRequestPermissionButton = renderButtonView(
       'Can Request Permission',
       async () => {
@@ -151,9 +159,8 @@ class OSButtons extends React.Component<Props> {
       'Request Permission',
       async () => {
         loggingFunction('Requesting notification permission');
-        OneSignal.Notifications.requestPermission(false, (granted) => {
-          loggingFunction(`Notification permission granted ${granted}`);
-        });
+        const granted = await OneSignal.Notifications.requestPermission(false);
+        loggingFunction(`Notification permission granted ${granted}`);
       },
     );
 
@@ -167,6 +174,7 @@ class OSButtons extends React.Component<Props> {
 
     return [
       hasPermissionButton,
+      permissionNativeButton,
       canRequestPermissionButton,
       requestPermissionButton,
       clearOneSignalNotificationsButton,

--- a/src/index.ts
+++ b/src/index.ts
@@ -413,6 +413,10 @@ export namespace OneSignal {
       if (!isNativeModuleLoaded(RNOneSignal)) {
         return Promise.reject(new Error('OneSignal native module not loaded'));
       }
+      // if permission already exists, return early as the native call will not resolve
+      if (hasPermission()) {
+        return Promise.resolve(true);
+      }
 
       return RNOneSignal.requestNotificationPermission(fallbackToSettings);
     }

--- a/src/index.ts
+++ b/src/index.ts
@@ -249,14 +249,14 @@ export namespace OneSignal {
         return pushSub.optedIn;
       }
 
-      /** Enable the push notification subscription to OneSignal. */
+      /** Disable the push notification subscription to OneSignal. */
       export function optOut() {
         if (!isNativeModuleLoaded(RNOneSignal)) return;
 
         RNOneSignal.optOut();
       }
 
-      /** Disable the push notification subscription to OneSignal. */
+      /** Enable the push notification subscription to OneSignal. */
       export function optIn() {
         if (!isNativeModuleLoaded(RNOneSignal)) return;
 


### PR DESCRIPTION
# Description
## One Line Summary
Return the correct boolean for the `requestPermission` method when permission denied, and resolve correctly if permission is already granted.

## Details

### Motivation
This was reported by a GitHub issue and I was able to reproduce. This method was always returning `true` previously on denial.

In addition, we were not resolving if permission is already granted due to the Android implementation of suspend functions.

### Scope
* We used to return `result.isSuccess()` which always returns `true` because this is whether the coroutine call was successful.
* Instead return `result.getData()` which holds the value returned by the coroutine.
* If the coroutine is not successful, we get the Throwable's message and pass that along.
* Also add a button to get permission native in example app to facilitate testing.
* Now, we also resolve correctly when permission has already been granted.

# Testing
## Unit testing
None

## Manual testing
Android emulator API 33
* Tested the boolean returned when permission is accepted and denied and it returns `true` and `false` respectively.
* Tested combinations of toggling permissions in app settings and calls to `requestPermission`.

# Affected code checklist
   - [ ] Notifications
      - [ ] Display
      - [ ] Open
      - [ ] Push Processing
      - [ ] Confirm Deliveries
   - [ ] Outcomes
   - [ ] Sessions
   - [ ] In-App Messaging
   - [ ] REST API requests
   - [ ] Public API changes

# Checklist
## Overview
   - [x] I have filled out all **REQUIRED** sections above
   - [x] PR does one thing
   - [x] Any Public API changes are explained in the PR details and conform to existing APIs

## Testing
   - [x] I have included test coverage for these changes, or explained why they are not needed
   - [x] All automated tests pass, or I explained why that is not possible
   - [x] I have personally tested this on my device, or explained why that is not possible

## Final pass
   - [x] Code is as readable as possible.
   - [x] I have reviewed this PR myself, ensuring it meets each checklist item

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/OneSignal/react-native-onesignal/1591)
<!-- Reviewable:end -->
