### PR TITLE
Release 5.0.3

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -31,7 +31,7 @@ dependencies {
 
     // api is used instead of implementation so the parent :app project can access any of the OneSignal Java
     //   classes if needed. Such as com.onesignal.NotificationExtenderService
-    api 'com.onesignal:OneSignal:5.0.3'
+    api 'com.onesignal:OneSignal:5.0.4'
 
     testImplementation 'junit:junit:4.12'
 }

--- a/android/src/main/java/com/onesignal/rnonesignalandroid/RNOneSignal.java
+++ b/android/src/main/java/com/onesignal/rnonesignalandroid/RNOneSignal.java
@@ -216,7 +216,7 @@ public class RNOneSignal extends ReactContextBaseJavaModule implements
     public void initialize(String appId) {
         Context context = mReactApplicationContext.getCurrentActivity();
         OneSignalWrapper.setSdkType("reactnative");
-        OneSignalWrapper.setSdkVersion("050002");
+        OneSignalWrapper.setSdkVersion("050003");
 
         if (oneSignalInitDone) {
             Log.e("OneSignal", "Already initialized the OneSignal React-Native SDK");

--- a/ios/RCTOneSignal/RCTOneSignal.m
+++ b/ios/RCTOneSignal/RCTOneSignal.m
@@ -47,7 +47,7 @@ OSNotificationClickResult* coldStartOSNotificationClickResult;
         return;
 
     OneSignalWrapper.sdkType = @"reactnative";
-    OneSignalWrapper.sdkVersion = @"050003";
+    OneSignalWrapper.sdkVersion = @"050004";
     // initialize the SDK with a nil app ID so cold start click listeners can be triggered
     [OneSignal initialize:nil withLaunchOptions:launchOptions];
     didInitialize = true;

--- a/ios/RCTOneSignal/RCTOneSignal.m
+++ b/ios/RCTOneSignal/RCTOneSignal.m
@@ -47,7 +47,7 @@ OSNotificationClickResult* coldStartOSNotificationClickResult;
         return;
 
     OneSignalWrapper.sdkType = @"reactnative";
-    OneSignalWrapper.sdkVersion = @"050002";
+    OneSignalWrapper.sdkVersion = @"050003";
     // initialize the SDK with a nil app ID so cold start click listeners can be triggered
     [OneSignal initialize:nil withLaunchOptions:launchOptions];
     didInitialize = true;

--- a/ios/RCTOneSignal/RCTOneSignal.m
+++ b/ios/RCTOneSignal/RCTOneSignal.m
@@ -47,7 +47,7 @@ OSNotificationClickResult* coldStartOSNotificationClickResult;
         return;
 
     OneSignalWrapper.sdkType = @"reactnative";
-    OneSignalWrapper.sdkVersion = @"050004";
+    OneSignalWrapper.sdkVersion = @"050003";
     // initialize the SDK with a nil app ID so cold start click listeners can be triggered
     [OneSignal initialize:nil withLaunchOptions:launchOptions];
     didInitialize = true;

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-native-onesignal",
-  "version": "5.0.2",
+  "version": "5.0.3",
   "description": "React Native OneSignal SDK",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/react-native-onesignal.podspec
+++ b/react-native-onesignal.podspec
@@ -22,5 +22,5 @@ Pod::Spec.new do |s|
   # pod 'React', :path => '../node_modules/react-native/'
 
   # The Native OneSignal-iOS-SDK XCFramework from cocoapods.
-  s.dependency 'OneSignalXCFramework', '5.0.2'
+  s.dependency 'OneSignalXCFramework', '5.0.4'
 end


### PR DESCRIPTION
## What's Changed
* Fix `requestPermission` to return `false` when permission is denied in https://github.com/OneSignal/react-native-onesignal/pull/1591
## Native SDK Updates
### Update Android SDK to [5.0.4](https://github.com/OneSignal/OneSignal-Android-SDK/releases/tag/5.0.4)
- Update PropertiesModel's deserialization of tags to not use Model.initializeFromJson in https://github.com/OneSignal/OneSignal-Android-SDK/pull/1884
- Retrieve current ADM PurchasingListener assuming it returns a nullable. in https://github.com/OneSignal/OneSignal-Android-SDK/pull/1888
- Fix: Add synchronized blocks to prevent ConcurrentModificationException  in https://github.com/OneSignal/OneSignal-Android-SDK/pull/1876
- Update work-runtime dependency version in https://github.com/OneSignal/OneSignal-Android-SDK/pull/1890
- General protection against exceptions that occur on a thread. in https://github.com/OneSignal/OneSignal-Android-SDK/pull/1887
### Update iOS SDK to [5.0.4](https://github.com/OneSignal/OneSignal-iOS-SDK/releases/tag/5.0.4)
- Fix badge clearing when calling clearAll in https://github.com/OneSignal/OneSignal-iOS-SDK/pull/1335
- Fix crash with direct influence but nil direct id https://github.com/OneSignal/OneSignal-iOS-SDK/pull/1327
- Fix forwarding notification opens from non onesignal notifs https://github.com/OneSignal/OneSignal-iOS-SDK/pull/1326

**Full Changelog**: https://github.com/OneSignal/react-native-onesignal/compare/5.0.2...5.0.3

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/OneSignal/react-native-onesignal/1599)
<!-- Reviewable:end -->
