### PR TITLE
Fix: prevent addNotificationForegroundLifecycleListener getting called multiple times

### DIFF
--- a/ios/RCTOneSignal/RCTOneSignalEventEmitter.m
+++ b/ios/RCTOneSignal/RCTOneSignalEventEmitter.m
@@ -264,7 +264,10 @@ RCT_EXPORT_METHOD(addNotificationClickListener) {
 }
 
 RCT_EXPORT_METHOD(addNotificationForegroundLifecycleListener) {
-    [OneSignal.Notifications addForegroundLifecycleListener:self];
+    if (!_hasAddedNotificationLifecycleListener) {
+        [OneSignal.Notifications addForegroundLifecycleListener:self];
+        _hasAddedNotificationLifecycleListener = true;
+    }
 }
 
 RCT_EXPORT_METHOD(onWillDisplayNotification:(OSNotificationWillDisplayEvent *)event){

--- a/ios/RCTOneSignal/RCTOneSignalEventEmitter.m
+++ b/ios/RCTOneSignal/RCTOneSignalEventEmitter.m
@@ -10,7 +10,7 @@
     BOOL _hasSetSubscriptionObserver;
     BOOL _hasSetPermissionObserver;
     BOOL _hasAddedNotificationClickListener;
-    BOOL _hasAddedNotificationLifecycleListener;
+    BOOL _hasAddedNotificationForegroundLifecycleListener;
     BOOL _hasAddedInAppMessageClickListener;
     BOOL _hasAddedInAppMessageLifecycleListener;
     NSMutableDictionary* _preventDefaultCache;
@@ -264,9 +264,9 @@ RCT_EXPORT_METHOD(addNotificationClickListener) {
 }
 
 RCT_EXPORT_METHOD(addNotificationForegroundLifecycleListener) {
-    if (!_hasAddedNotificationLifecycleListener) {
+    if (!_hasAddedNotificationForegroundLifecycleListener) {
         [OneSignal.Notifications addForegroundLifecycleListener:self];
-        _hasAddedNotificationLifecycleListener = true;
+        _hasAddedNotificationForegroundLifecycleListener = true;
     }
 }
 


### PR DESCRIPTION
# Description
## One Line Summary
 Prevents multiple executions of handlers by adding a conditional check.

## Details

### Motivation
The code change aims to prevent redundant executions of handlers when using the `addNotificationForegroundLifecycleListener` method. This addresses an issue where handlers were executed multiple times due to multiple listener additions.

### Scope
The change impacts the `addNotificationForegroundLifecycleListener` method by using an existing check `_hasAddedNotificationLifecycleListener` and renamed it to `_hasAddedNotificationForegroundLifecycleListener ` to ensure the listener is added only once. This doesn't affect the core functionality but enhances its behavior to prevent duplicates.

# Testing
## Unit testing
No new unit tests added as the change involves a conditional check within an existing method.

## Manual testing
Tested scenarios:
- Verified the fix locally by attaching handlers and confirming they are executed only once.
- Tested on iOS and Android environments with different notification scenarios to ensure single handler execution.

# Affected code checklist
   - [x] Notifications
      - [x] Display
      - [x] Open
      - [x] Push Processing

# Checklist
## Overview
   - [x] I have filled out all **REQUIRED** sections above
   - [x] PR does one thing
   - [x] Any Public API changes are explained in the PR details and conform to existing APIs

## Testing
   - [ ] I have included test coverage for these changes, or explained why they are not needed
   - [x] All automated tests pass
   - [x] I have personally tested this on my device

## Final pass
   - [ ] Code is as readable as possible.
   - [x] I have reviewed this PR myself, ensuring it meets each checklist item

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/OneSignal/react-native-onesignal/1601)
<!-- Reviewable:end -->
