### PR TITLE
Add public `getTags` method

### DIFF
--- a/MIGRATION_GUIDE.md
+++ b/MIGRATION_GUIDE.md
@@ -211,7 +211,7 @@ The User namespace is accessible via `OneSignal.User` and provides access to use
 | `OneSignal.User.addTags({"KEY_01": "VALUE_01", "KEY_02": "VALUE_02"})`                      | _Add multiple tags for the current user. Tags are key:value pairs used as building blocks for targeting specific users and/or personalizing messages. If the tag key already exists, it will be replaced with the value provided here._ |
 | `OneSignal.User.removeTag("KEY")`                                                           | _Remove the data tag with the provided key from the current user._                                                                                                                                                                      |
 | `OneSignal.User.removeTags(["KEY_01", "KEY_02"])`                                           | _Remove multiple tags with the provided keys from the current user._                                                                                                                                                                    |
-
+| `OneSignal.User.getTags()`                                                                  | _Returns the local tags for the current user._|
 ## Push Subscription Namespace
 
 The Push Subscription namespace is accessible via `OneSignal.User.pushSubscription` and provides access to push subscription-scoped functionality.

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -31,7 +31,7 @@ dependencies {
 
     // api is used instead of implementation so the parent :app project can access any of the OneSignal Java
     //   classes if needed. Such as com.onesignal.NotificationExtenderService
-    api 'com.onesignal:OneSignal:5.0.4'
+    api 'com.onesignal:OneSignal:5.0.5'
 
     testImplementation 'junit:junit:4.12'
 }

--- a/android/src/main/java/com/onesignal/rnonesignalandroid/RNOneSignal.java
+++ b/android/src/main/java/com/onesignal/rnonesignalandroid/RNOneSignal.java
@@ -577,16 +577,12 @@ public class RNOneSignal extends ReactContextBaseJavaModule implements
 
     @ReactMethod
     public void getTags(Promise promise) {
-        try {
-            Map<String, String> tags = OneSignal.getUser().getTags();
-            WritableMap writableTags = Arguments.createMap();
-            for (Map.Entry<String, String> entry : tags.entrySet()) {
-                writableTags.putString(entry.getKey(), entry.getValue());
-            }
-            promise.resolve(writableTags);
-        } catch (Throwable t) {
-            promise.reject(t.getMessage());
+        Map<String, String> tags = OneSignal.getUser().getTags();
+        WritableMap writableTags = Arguments.createMap();
+        for (Map.Entry<String, String> entry : tags.entrySet()) {
+            writableTags.putString(entry.getKey(), entry.getValue());
         }
+        promise.resolve(writableTags); 
     }
 
     @ReactMethod

--- a/android/src/main/java/com/onesignal/rnonesignalandroid/RNOneSignal.java
+++ b/android/src/main/java/com/onesignal/rnonesignalandroid/RNOneSignal.java
@@ -49,6 +49,8 @@ import com.facebook.react.bridge.ReactMethod;
 import com.facebook.react.bridge.ReadableArray;
 import com.facebook.react.bridge.ReadableMap;
 import com.facebook.react.modules.core.DeviceEventManagerModule;
+import com.facebook.react.bridge.WritableMap;
+import com.facebook.react.bridge.Arguments;
 import com.onesignal.Continue;
 import com.onesignal.OneSignal;
 import com.onesignal.debug.LogLevel;
@@ -73,9 +75,9 @@ import com.onesignal.user.subscriptions.IPushSubscriptionObserver;
 import com.onesignal.user.subscriptions.PushSubscriptionState;
 import com.onesignal.user.subscriptions.PushSubscriptionChangedState;
 import org.json.JSONException;
-import org.json.JSONObject;
 
 import java.util.HashMap;
+import java.util.Map;
 
 public class RNOneSignal extends ReactContextBaseJavaModule implements
         IPushSubscriptionObserver,
@@ -571,6 +573,20 @@ public class RNOneSignal extends ReactContextBaseJavaModule implements
     @ReactMethod
     public void removeTags(ReadableArray tagKeys) {
         OneSignal.getUser().removeTags(RNUtils.convertReadableArrayIntoStringCollection(tagKeys));
+    }
+
+    @ReactMethod
+    public void getTags(Promise promise) {
+        try {
+            Map<String, String> tags = OneSignal.getUser().getTags();
+            WritableMap writableTags = Arguments.createMap();
+            for (Map.Entry<String, String> entry : tags.entrySet()) {
+                writableTags.putString(entry.getKey(), entry.getValue());
+            }
+            promise.resolve(writableTags);
+        } catch (Throwable t) {
+            promise.reject(t.getMessage());
+        }
     }
 
     @ReactMethod

--- a/examples/RNOneSignalTS/src/OSButtons.tsx
+++ b/examples/RNOneSignalTS/src/OSButtons.tsx
@@ -276,6 +276,11 @@ class OSButtons extends React.Component<Props> {
       OneSignal.User.removeTags(['my_tag1', 'my_tag2']);
     });
 
+    const getTagsButton = renderButtonView('Get tags', async () => {
+        const tags = await OneSignal.User.getTags();
+        loggingFunction('Tags:', tags);
+    });
+
     const setLanguageButton = renderButtonView('Set Language', () => {
       loggingFunction(
         'Attempting to set language: ',
@@ -346,6 +351,7 @@ class OSButtons extends React.Component<Props> {
       deleteTagWithKeyButton,
       addTagsButton,
       removeTagsButton,
+      getTagsButton,
       setLanguageButton,
       addSmsButton,
       removeSmsButton,

--- a/ios/RCTOneSignal/RCTOneSignalEventEmitter.m
+++ b/ios/RCTOneSignal/RCTOneSignalEventEmitter.m
@@ -357,6 +357,11 @@ RCT_EXPORT_METHOD(removeTags:(NSArray *)keys) {
     [OneSignal.User removeTags:keys];
 }
 
+RCT_EXPORT_METHOD(getTags:(RCTPromiseResolveBlock)resolve rejecter:(RCTPromiseRejectBlock)reject) {
+    NSDictionary<NSString *, NSString *> *tags = [OneSignal.User getTags];
+    resolve(tags);
+}
+
 RCT_EXPORT_METHOD(addAlias:(NSString *)label :(NSString *)id) {
     [OneSignal.User addAliasWithLabel:label id:id];
 }

--- a/react-native-onesignal.podspec
+++ b/react-native-onesignal.podspec
@@ -22,5 +22,5 @@ Pod::Spec.new do |s|
   # pod 'React', :path => '../node_modules/react-native/'
 
   # The Native OneSignal-iOS-SDK XCFramework from cocoapods.
-  s.dependency 'OneSignalXCFramework', '5.0.4'
+  s.dependency 'OneSignalXCFramework', '5.0.5'
 end

--- a/src/index.ts
+++ b/src/index.ts
@@ -391,6 +391,15 @@ export namespace OneSignal {
 
       RNOneSignal.removeTags(keys);
     }
+
+    /** Returns the local tags for the current user. */
+    export function getTags(): Promise<{ [key: string]: string }> {
+      if (!isNativeModuleLoaded(RNOneSignal)) {
+        return Promise.reject(new Error('OneSignal native module not loaded'));
+      }
+
+      return RNOneSignal.getTags();
+    }
   }
 
   export namespace Notifications {


### PR DESCRIPTION
# Description
## One Line Summary
Add public `OneSignal.User.getTags()` method to return local tags for the current user.

## Details
Add `getTags` public method that will return local tags for the current user on both Android and iOS.

### Motivation
We removed the `getTags` method in v5 of the SDKs to discourage use of OneSignal tags as a data store. We have heard feedback from app developers that they have a need for this method still, so we are adding back an implementation to return the local tags.

### Scope
Keep note it returns the local tags and not via a server fetch so any tags added mid-session through the REST API will not be reflected.

# Testing
## Unit testing
None

## Manual testing
Successfully call new method getTags on iPhone 15 emulator running iOS 17.0.1 and Pixel 7 running Android 14.

# Affected code checklist
   - [ ] Notifications
      - [ ] Display
      - [ ] Open
      - [ ] Push Processing
      - [ ] Confirm Deliveries
   - [ ] Outcomes
   - [ ] Sessions
   - [ ] In-App Messaging
   - [ ] REST API requests
   - [x] Public API changes

# Checklist
## Overview
   - [x] I have filled out all **REQUIRED** sections above
   - [x] PR does one thing
   - [x] Any Public API changes are explained in the PR details and conform to existing APIs

## Testing
   - [x] I have included test coverage for these changes, or explained why they are not needed
   - [x] All automated tests pass, or I explained why that is not possible
   - [x] I have personally tested this on my device, or explained why that is not possible

## Final pass
   - [x] Code is as readable as possible.
   - [x] I have reviewed this PR myself, ensuring it meets each checklist item

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/OneSignal/react-native-onesignal/1609)
<!-- Reviewable:end -->
