### PR TITLE
Fix requestPermission to reject the promise when permission is denied

### DIFF
--- a/android/src/main/java/com/onesignal/rnonesignalandroid/RNOneSignal.java
+++ b/android/src/main/java/com/onesignal/rnonesignalandroid/RNOneSignal.java
@@ -431,9 +431,18 @@ public class RNOneSignal extends ReactContextBaseJavaModule implements
     public void requestNotificationPermission(final boolean fallbackToSettings, Promise promise) {
         OneSignal.getNotifications().requestPermission(fallbackToSettings, Continue.with(result -> {
             if (result.isSuccess()) {
-                promise.resolve(result.getData());
+                if (Boolean.TRUE.equals(result.getData())) {
+                    // `requestPermission` completed successfully and the user has accepted permission
+                    promise.resolve(true);
+                }
+                else {
+                    // `requestPermission` completed successfully but the user has rejected permission
+                    promise.reject("PERMISSION_REJECTED");
+                }
+                
             } else {
-                promise.reject(result.getThrowable().getMessage());
+                // `requestPermission` completed unsuccessfully
+                promise.reject(result.getThrowable() != null ? result.getThrowable().getMessage() : "PERMISSION_ERR");
             }
         }));
     }


### PR DESCRIPTION
# Description
## One Line Summary
Fix the requestPermission method when the permission is denied, and resolve **ONLY** if the permission is granted.

## Details

### Motivation
I faced this issue while implementing the notification permissions, when I deny the permission request the promise is never rejected.

# Testing

## Manual testing
Tested on Samsung A33

1. Tested the promise response and rejection when the permission is accepted and denied.
2. Tested changes to the permissions in the app settings and called requestPermission.
3. Tested changing the permissions within the app by toggling requestPermission and optOut.

# Affected code checklist
   - [x] Notifications
      - [ ] Display
      - [ ] Open
      - [ ] Push Processing
      - [ ] Confirm Deliveries
   - [ ] Outcomes
   - [ ] Sessions
   - [ ] In-App Messaging
   - [ ] REST API requests
   - [ ] Public API changes

# Checklist
## Overview
   - [x] I have filled out all **REQUIRED** sections above
   - [x] PR does one thing
   - [x] Any Public API changes are explained in the PR details and conform to existing APIs

## Testing
   - [x] I have included test coverage for these changes, or explained why they are not needed
   - [x] All automated tests pass, or I explained why that is not possible
   - [x] I have personally tested this on my device, or explained why that is not possible

## Final pass
   - [x] Code is as readable as possible.
   - [x] I have reviewed this PR myself, ensuring it meets each checklist item

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/OneSignal/react-native-onesignal/1631)
<!-- Reviewable:end -->
