### PR TITLE
fix/error removing handlers when SDK is not initialized

### DIFF
--- a/android/src/main/java/com/onesignal/rnonesignalandroid/RNOneSignal.java
+++ b/android/src/main/java/com/onesignal/rnonesignalandroid/RNOneSignal.java
@@ -165,6 +165,11 @@ public class RNOneSignal extends ReactContextBaseJavaModule implements
     }
 
     private void removeHandlers() {
+        if(!oneSignalInitDone) {
+            Log.i("OneSignal", "OneSignal React-Native SDK not initialized yet. Could not remove handlers.");
+            return;
+        }
+
         OneSignal.getInAppMessages().removeClickListener(rnInAppClickListener);
         hasAddedInAppMessageClickListener = false;
         OneSignal.getInAppMessages().removeLifecycleListener(rnInAppLifecycleListener);


### PR DESCRIPTION
# Description
## Fix for the "initWithContext" error while trying to remove handlers when the SDK is not initialized

## Details

### Motivation
This issue happens in Android specifically when the app is closed and the OneSignal SDK has not been initialized yet
The error accused in the log is this one "**Must call 'initWithContext' before use**", and can be seen in the opened issue [[Bug]: initWithContext error in android-1554](https://github.com/OneSignal/react-native-onesignal/issues/1554)

### Scope
The mentioned code is inside the `removeHandlers()` method which is called inside `onHostDestroy()` and `onCatalystInstanceDestroy()` and causes a crash when the SDK has not been initialized before.
This PR adds one verification to check whether the initialization is made with the value `oneSignalInitDone`

# Affected code checklist
   - [X] Notifications
      - [ ] Display
      - [ ] Open
      - [ ] Push Processing
      - [ ] Confirm Deliveries
   - [ ] Outcomes
   - [ ] Sessions
   - [X] In-App Messaging
   - [ ] REST API requests
   - [ ] Public API changes

# Checklist
## Overview
   - [X] I have filled out all **REQUIRED** sections above
   - [X] PR does one thing
     - If it is hard to explain how any codes changes are related to each other then it most likely needs to be more than one PR
   - [X] Any Public API changes are explained in the PR details and conform to existing APIs

## Testing
   - [ ] I have included test coverage for these changes, or explained why they are not needed
   - [ ] All automated tests pass, or I explained why that is not possible
   - [x] I have personally tested this on my device, or explained why that is not possible

## Final pass
   - [X] Code is as readable as possible.
      - Simplify with less code, followed by splitting up code into well named functions and variables, followed by adding comments to the code.
   - [X] I have reviewed this PR myself, ensuring it meets each checklist item
      - WIP (Work In Progress) is ok, but explain what is still in progress and what you would like feedback on. Start the PR title with "WIP" to indicate this.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/OneSignal/react-native-onesignal/1639)
<!-- Reviewable:end -->
