### PR TITLE
Release 5.1.0

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -31,7 +31,7 @@ dependencies {
 
     // api is used instead of implementation so the parent :app project can access any of the OneSignal Java
     //   classes if needed. Such as com.onesignal.NotificationExtenderService
-    api 'com.onesignal:OneSignal:5.1.4'
+    api 'com.onesignal:OneSignal:5.1.6'
 
     testImplementation 'junit:junit:4.12'
 }

--- a/android/src/main/java/com/onesignal/rnonesignalandroid/RNOneSignal.java
+++ b/android/src/main/java/com/onesignal/rnonesignalandroid/RNOneSignal.java
@@ -229,7 +229,7 @@ public class RNOneSignal extends ReactContextBaseJavaModule implements
     public void initialize(String appId) {
         Context context = mReactApplicationContext.getCurrentActivity();
         OneSignalWrapper.setSdkType("reactnative");
-        OneSignalWrapper.setSdkVersion("050006");
+        OneSignalWrapper.setSdkVersion("050100");
 
         if (oneSignalInitDone) {
             Log.e("OneSignal", "Already initialized the OneSignal React-Native SDK");

--- a/ios/RCTOneSignal/RCTOneSignal.m
+++ b/ios/RCTOneSignal/RCTOneSignal.m
@@ -47,7 +47,7 @@ OSNotificationClickResult* coldStartOSNotificationClickResult;
         return;
 
     OneSignalWrapper.sdkType = @"reactnative";
-    OneSignalWrapper.sdkVersion = @"050006";
+    OneSignalWrapper.sdkVersion = @"050100";
     // initialize the SDK with a nil app ID so cold start click listeners can be triggered
     [OneSignal initialize:nil withLaunchOptions:launchOptions];
     didInitialize = true;

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-native-onesignal",
-  "version": "5.0.6",
+  "version": "5.1.0",
   "description": "React Native OneSignal SDK",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/react-native-onesignal.podspec
+++ b/react-native-onesignal.podspec
@@ -22,5 +22,5 @@ Pod::Spec.new do |s|
   # pod 'React', :path => '../node_modules/react-native/'
 
   # The Native OneSignal-iOS-SDK XCFramework from cocoapods.
-  s.dependency 'OneSignalXCFramework', '5.1.0'
+  s.dependency 'OneSignalXCFramework', '5.1.3'
 end


### PR DESCRIPTION
## What's Changed
**🎉  New Methods 🎉** 
* Add getter for `onesignalId` and `externalId` and a UserState Observer to be notified of changes in [#1627](https://github.com/OneSignal/react-native-onesignal/pull/1627)
    * See the [User Namespace API Reference](https://github.com/OneSignal/react-native-onesignal/blob/major_release_5.0.0/MIGRATION_GUIDE.md#user-namespace) in the Migration Guide for usage
* Add asynchronous getter methods for Notifications `permission` and Push Subscription `token`, `id`,`optedIn` in [#1649](https://github.com/OneSignal/react-native-onesignal/pull/1649)
    * 🛑 Deprecated methods 🛑
        * `Notifications.hasPermission`, `User.pushSubscription.id`, `User.pushSubscription.token`, and `User.pushSubscription.optedIn` are now deprecated but non-breaking.
    * See the [Push Subscription Namespace API Reference](https://github.com/OneSignal/OneSignal-Cordova-SDK/blob/main/MIGRATION_GUIDE.md#push-subscription-namespace) and [Notifications Namespace API Reference](https://github.com/OneSignal/react-native-onesignal/blob/major_release_5.0.0/MIGRATION_GUIDE.md#notifications-namespace) in the Migration Guide for usage of new methods `getPermissionAsync`, `getIdAsync`, `getTokenAsync`, and `getOptedInAsync`. 

**⚠️ Minor Breaking Change ⚠️**

- API update for PushSubscriptionState: the Push Subscription observer will now be passed nullable properties. Please account for the possibility of the push subscription token and id being null. 

### Native Changes
* Bump Android Native Version to [5.1.6](https://github.com/OneSignal/OneSignal-Android-SDK/releases/tag/5.1.6)
* Bump iOS Native Version to [5.1.3](https://github.com/OneSignal/OneSignal-iOS-SDK/releases/tag/5.1.3)

**Full Changelog**: https://github.com/OneSignal/react-native-onesignal/compare/5.0.6...5.1.0

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/OneSignal/react-native-onesignal/1662)
<!-- Reviewable:end -->
