### PR TITLE
Release 5.1.1

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -31,7 +31,7 @@ dependencies {
 
     // api is used instead of implementation so the parent :app project can access any of the OneSignal Java
     //   classes if needed. Such as com.onesignal.NotificationExtenderService
-    api 'com.onesignal:OneSignal:5.1.6'
+    api 'com.onesignal:OneSignal:5.1.8'
     
     testImplementation 'junit:junit:4.12'
 }

--- a/android/src/main/java/com/onesignal/rnonesignalandroid/RNOneSignal.java
+++ b/android/src/main/java/com/onesignal/rnonesignalandroid/RNOneSignal.java
@@ -229,7 +229,7 @@ public class RNOneSignal extends ReactContextBaseJavaModule implements
     public void initialize(String appId) {
         Context context = mReactApplicationContext.getCurrentActivity();
         OneSignalWrapper.setSdkType("reactnative");
-        OneSignalWrapper.setSdkVersion("050100");
+        OneSignalWrapper.setSdkVersion("050101");
 
         if (oneSignalInitDone) {
             Log.e("OneSignal", "Already initialized the OneSignal React-Native SDK");

--- a/ios/RCTOneSignal/RCTOneSignal.m
+++ b/ios/RCTOneSignal/RCTOneSignal.m
@@ -47,7 +47,7 @@ OSNotificationClickResult* coldStartOSNotificationClickResult;
         return;
 
     OneSignalWrapper.sdkType = @"reactnative";
-    OneSignalWrapper.sdkVersion = @"050100";
+    OneSignalWrapper.sdkVersion = @"050101";
     // initialize the SDK with a nil app ID so cold start click listeners can be triggered
     [OneSignal initialize:nil withLaunchOptions:launchOptions];
     didInitialize = true;

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-native-onesignal",
-  "version": "5.1.0",
+  "version": "5.1.1",
   "description": "React Native OneSignal SDK",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/react-native-onesignal.podspec
+++ b/react-native-onesignal.podspec
@@ -22,5 +22,5 @@ Pod::Spec.new do |s|
   # pod 'React', :path => '../node_modules/react-native/'
 
   # The Native OneSignal-iOS-SDK XCFramework from cocoapods.
-  s.dependency 'OneSignalXCFramework', '5.1.3'
+  s.dependency 'OneSignalXCFramework', '5.1.4'
 end


### PR DESCRIPTION
## 🔧 Native SDK Dependency Updates Only

**Update Android SDK from `5.1.6` to `5.1.8`**
- Fix crash with EventProducer's fire events in https://github.com/OneSignal/OneSignal-Android-SDK/pull/2034
- Battery improvements
    - Possibly resolves issues of "Egregious levels of battery drain"
    - Prevent OperationRepo from continuously pulling when empty (https://github.com/OneSignal/OneSignal-Android-SDK/pull/2033)
    - Add backoff to OperationRepo when retrying network calls (https://github.com/OneSignal/OneSignal-Android-SDK/pull/2017)
    - Limit refresh User and GET IAMs to foreground (https://github.com/OneSignal/OneSignal-Android-SDK/pull/2036)
- Fixes network call batching not waiting the full 5 seconds in most cases to reduce the total number of REST API calls to OneSignal. 
- Issue with external_id being skipped and updates stop if something updates the User (such as addTag) shortly before login is called https://github.com/OneSignal/OneSignal-Android-SDK/pull/2046
- For full changes, [see the native release notes](https://github.com/OneSignal/OneSignal-Android-SDK/releases)

**Update iOS SDK from `5.1.3` to `5.1.4`**
- [5.1.4 Release Notes](https://github.com/OneSignal/OneSignal-iOS-SDK/releases/tag/5.1.4)
- The XCFrameworks in this release is signed to help keep your apps secure
- Fix rare scenario where login requests are stuck and prevent the SDK from making updates (https://github.com/OneSignal/OneSignal-iOS-SDK/pull/1398)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/OneSignal/react-native-onesignal/1685)
<!-- Reviewable:end -->
