### PR TITLE
Release 5.1.2

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -31,7 +31,7 @@ dependencies {
 
     // api is used instead of implementation so the parent :app project can access any of the OneSignal Java
     //   classes if needed. Such as com.onesignal.NotificationExtenderService
-    api 'com.onesignal:OneSignal:5.1.8'
+    api 'com.onesignal:OneSignal:5.1.9'
     
     testImplementation 'junit:junit:4.12'
 }

--- a/android/src/main/java/com/onesignal/rnonesignalandroid/RNOneSignal.java
+++ b/android/src/main/java/com/onesignal/rnonesignalandroid/RNOneSignal.java
@@ -229,7 +229,7 @@ public class RNOneSignal extends ReactContextBaseJavaModule implements
     public void initialize(String appId) {
         Context context = mReactApplicationContext.getCurrentActivity();
         OneSignalWrapper.setSdkType("reactnative");
-        OneSignalWrapper.setSdkVersion("050101");
+        OneSignalWrapper.setSdkVersion("050102");
 
         if (oneSignalInitDone) {
             Log.e("OneSignal", "Already initialized the OneSignal React-Native SDK");

--- a/ios/RCTOneSignal/RCTOneSignal.m
+++ b/ios/RCTOneSignal/RCTOneSignal.m
@@ -47,7 +47,7 @@ OSNotificationClickResult* coldStartOSNotificationClickResult;
         return;
 
     OneSignalWrapper.sdkType = @"reactnative";
-    OneSignalWrapper.sdkVersion = @"050101";
+    OneSignalWrapper.sdkVersion = @"050102";
     // initialize the SDK with a nil app ID so cold start click listeners can be triggered
     [OneSignal initialize:nil withLaunchOptions:launchOptions];
     didInitialize = true;

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-native-onesignal",
-  "version": "5.1.1",
+  "version": "5.1.2",
   "description": "React Native OneSignal SDK",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/react-native-onesignal.podspec
+++ b/react-native-onesignal.podspec
@@ -22,5 +22,5 @@ Pod::Spec.new do |s|
   # pod 'React', :path => '../node_modules/react-native/'
 
   # The Native OneSignal-iOS-SDK XCFramework from cocoapods.
-  s.dependency 'OneSignalXCFramework', '5.1.4'
+  s.dependency 'OneSignalXCFramework', '5.1.5'
 end


### PR DESCRIPTION
## 🔧 Native SDK Dependency Updates Only

**Update Android SDK from `5.1.8` to `5.1.9`**
- [5.1.9 release notes](https://github.com/OneSignal/OneSignal-Android-SDK/releases/tag/5.1.9)
- Added Network call optimizations
- Fix for WorkManager not initialized crash
- Added `AndroidManifest` options to override In-App Messages **gray overlay** and **dropshadow** 
```
<meta-data android:name="com.onesignal.inAppMessageHideGrayOverlay" android:value="true"/>
<meta-data android:name="com.onesignal.inAppMessageHideDropShadow" android:value="true"/>
```

**Update iOS SDK from `5.1.4` to `5.1.5`**
- [5.1.5 Release Notes](https://github.com/OneSignal/OneSignal-iOS-SDK/releases/tag/5.1.5)
- ✨ In-App Message Enhancements:
  - The **status bar** will be hidden on full-bleed In-App Messages
  - Add back the **dropshadow** on In-App Messages and include a `plist` option to disable it
  - Add `plist` option to override and hide the **gray overlay** to In-App Messages
```
OneSignal_in_app_message_hide_gray_overlay
OneSignal_in_app_message_hide_drop_shadow
```

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/OneSignal/react-native-onesignal/1692)
<!-- Reviewable:end -->
