### PR TITLE
Release 5.1.3

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -31,7 +31,7 @@ dependencies {
 
     // api is used instead of implementation so the parent :app project can access any of the OneSignal Java
     //   classes if needed. Such as com.onesignal.NotificationExtenderService
-    api 'com.onesignal:OneSignal:5.1.9'
+    api 'com.onesignal:OneSignal:5.1.10'
     
     testImplementation 'junit:junit:4.12'
 }

--- a/android/src/main/java/com/onesignal/rnonesignalandroid/RNOneSignal.java
+++ b/android/src/main/java/com/onesignal/rnonesignalandroid/RNOneSignal.java
@@ -229,7 +229,7 @@ public class RNOneSignal extends ReactContextBaseJavaModule implements
     public void initialize(String appId) {
         Context context = mReactApplicationContext.getCurrentActivity();
         OneSignalWrapper.setSdkType("reactnative");
-        OneSignalWrapper.setSdkVersion("050102");
+        OneSignalWrapper.setSdkVersion("050103");
 
         if (oneSignalInitDone) {
             Log.e("OneSignal", "Already initialized the OneSignal React-Native SDK");

--- a/ios/RCTOneSignal/RCTOneSignal.m
+++ b/ios/RCTOneSignal/RCTOneSignal.m
@@ -47,7 +47,7 @@ OSNotificationClickResult* coldStartOSNotificationClickResult;
         return;
 
     OneSignalWrapper.sdkType = @"reactnative";
-    OneSignalWrapper.sdkVersion = @"050102";
+    OneSignalWrapper.sdkVersion = @"050103";
     // initialize the SDK with a nil app ID so cold start click listeners can be triggered
     [OneSignal initialize:nil withLaunchOptions:launchOptions];
     didInitialize = true;

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-native-onesignal",
-  "version": "5.1.2",
+  "version": "5.1.3",
   "description": "React Native OneSignal SDK",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/react-native-onesignal.podspec
+++ b/react-native-onesignal.podspec
@@ -22,5 +22,5 @@ Pod::Spec.new do |s|
   # pod 'React', :path => '../node_modules/react-native/'
 
   # The Native OneSignal-iOS-SDK XCFramework from cocoapods.
-  s.dependency 'OneSignalXCFramework', '5.1.5'
+  s.dependency 'OneSignalXCFramework', '5.1.6'
 end


### PR DESCRIPTION
## What's Changed
- 🐛  Enforce tag value string conversion [#1696](https://github.com/OneSignal/react-native-onesignal/pull/1696)

## 🔧 Native SDK Dependency Updates

**Update Android SDK from `5.1.9` to `5.1.10`**
- [5.1.10 release notes](https://github.com/OneSignal/OneSignal-Android-SDK/releases/tag/5.1.10)
- 🛠️ Added additional Network call optimizations
- 🐛 Handle incorrect 404 responses; add a delay after creates and retries on 404 of new ids [#2095](https://github.com/OneSignal/OneSignal-Android-SDK/pull/2059)

**Update iOS SDK from `5.1.5` to `5.1.6`**
- [5.1.6 Release Notes](https://github.com/OneSignal/OneSignal-iOS-SDK/releases/tag/5.1.6)
- 🐛 Bug Fixes
  - Fix crashes when encoding user models [#1412]([OneSignal/OneSignal-iOS-SDK#1412](https://github.com/OneSignal/OneSignal-iOS-SDK/pull/1412))
  - Some pending properties can be sent to new user, when users change quickly after the last updates are made ([#1418](https://github.com/OneSignal/OneSignal-iOS-SDK/pull/1418))
  - Fix crash in OneSignalAttachmentHandler trimURLSpacing method ([#1411](https://github.com/OneSignal/OneSignal-iOS-SDK/pull/1411))
  - Fix crash when handling a dialog result when stack traces point to delayResult ([#1417](https://github.com/OneSignal/OneSignal-iOS-SDK/pull/1417))
  - [Bug] Remove IAM window when an in app message is inactive ([#1413](https://github.com/OneSignal/OneSignal-iOS-SDK/pull/1413))

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/OneSignal/react-native-onesignal/1702)
<!-- Reviewable:end -->
