### PR TITLE
Release 5.2.0

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -31,7 +31,7 @@ dependencies {
 
     // api is used instead of implementation so the parent :app project can access any of the OneSignal Java
     //   classes if needed. Such as com.onesignal.NotificationExtenderService
-    api 'com.onesignal:OneSignal:5.1.10'
+    api 'com.onesignal:OneSignal:5.1.13'
     
     testImplementation 'junit:junit:4.12'
 }

--- a/android/src/main/java/com/onesignal/rnonesignalandroid/RNOneSignal.java
+++ b/android/src/main/java/com/onesignal/rnonesignalandroid/RNOneSignal.java
@@ -229,7 +229,7 @@ public class RNOneSignal extends ReactContextBaseJavaModule implements
     public void initialize(String appId) {
         Context context = mReactApplicationContext.getCurrentActivity();
         OneSignalWrapper.setSdkType("reactnative");
-        OneSignalWrapper.setSdkVersion("050103");
+        OneSignalWrapper.setSdkVersion("050200");
 
         if (oneSignalInitDone) {
             Log.e("OneSignal", "Already initialized the OneSignal React-Native SDK");

--- a/ios/RCTOneSignal/RCTOneSignal.m
+++ b/ios/RCTOneSignal/RCTOneSignal.m
@@ -47,7 +47,7 @@ OSNotificationClickResult* coldStartOSNotificationClickResult;
         return;
 
     OneSignalWrapper.sdkType = @"reactnative";
-    OneSignalWrapper.sdkVersion = @"050103";
+    OneSignalWrapper.sdkVersion = @"050200";
     // initialize the SDK with a nil app ID so cold start click listeners can be triggered
     [OneSignal initialize:nil withLaunchOptions:launchOptions];
     didInitialize = true;

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-native-onesignal",
-  "version": "5.1.3",
+  "version": "5.2.0",
   "description": "React Native OneSignal SDK",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",


### PR DESCRIPTION
What's New
--------
### 🎉 Push to Start Live Activities
Starting with iOS 17.2, Live Activities can now be started via push notification ([Apple's documentation](https://developer.apple.com/documentation/activitykit/starting-and-updating-live-activities-with-activitykit-push-notifications#Start-new-Live-Activities-with-ActivityKit-push-notifications)). This change enhances the OneSignal SDK to provide application's access to the full suite of Live Activity functionality.

To use Push To Start Live Activities, see documentation on [How to start a Live Activity with a remote push notification](https://documentation.onesignal.com/docs/push-to-start-live-activities).

**Default Live Activity**
The concept of a "Default" Live Activity has been established in the SDK, which eliminates the need for a customer app to define and manage their own `ActivityAttributes`. The primary use case of the "Default" Live Activity is to facilitate easier cross-platform adoption.

- A new function `OneSignal.LiveActivities.setupDefault()` which tells the OneSignal SDK to manage the LiveActivity lifecycle for the `DefaultLiveActivityAttributes` type. When calling this method, a customer can use both `push-to-start` and `push-to-update` notifications to start/update/end their Default Live Activity.
- A new function `OneSignal.LiveActivities.startDefault(activityId, activityAttributes, initialContentState)` which allows a customer app to start a live activity based on the `DefaultLiveActivityAttributes` type "in app".

**Four New APIs for Live Activities**
```typescript
OneSignal.LiveActivities.setupDefault()
OneSignal.LiveActivities.startDefault(activityId, activityAttributes, initialContentState)
OneSignal.LiveActivities.setPushToStartToken(activityType: string, token: string)
OneSignal.LiveActivities.removePushToStartToken(activityType: string)
```

Please see the PR description for more details.
- Push to start live activities added to the SDK (#1701)

🔧 Native SDK Dependency Updates
--------
### Update Android SDK from `5.1.10` to `5.1.13`
- For full changes, [see the native release notes](https://github.com/OneSignal/OneSignal-Android-SDK/releases)
**🐛 Bug Fixes**
- [Fix] grouping skipping opRepoPostCreateDelay, causing operations being applied out of order when multiple login operations are pending. (fixes issue since 5.1.10) ([2087](https://github.com/OneSignal/OneSignal-Android-SDK/pull/2087))
- [Fix]: Cancelling permission request dialog does not fire continuation ([2085](https://github.com/OneSignal/OneSignal-Android-SDK/pull/2085))
- [Fix] RecoverFromDroppedLoginBug not running in very rare cases ([2084](https://github.com/OneSignal/OneSignal-Android-SDK/pull/2084))
- Fix the ANR issue caused by prolonged loading of OperationRepo and potentially by extended holding of the model lock during disk I/O read operations. ([2068](ttps://github.com/OneSignal/OneSignal-Android-SDK/pull/2068))
**🔧 Maintenance**
- Add HTTP header `OneSignal-Install-Id` that allows the OneSignal's backend know where traffic is coming from ([2072](https://github.com/OneSignal/OneSignal-Android-SDK/pull/2072))

### Update iOS SDK from `5.1.6` to `5.2.0`
- [5.2.0 Release Notes](https://github.com/OneSignal/OneSignal-iOS-SDK/releases/tag/5.2.0)
- ✨ Privacy Manifest Improvements
- 🐛 [Bug] Fix rare scenario of dropping data when multiple logins are called ([1427](https://github.com/OneSignal/OneSignal-iOS-SDK/pull/1427))

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/OneSignal/react-native-onesignal/1709)
<!-- Reviewable:end -->
