### PR TITLE
Release 5.2.1

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -31,7 +31,7 @@ dependencies {
 
     // api is used instead of implementation so the parent :app project can access any of the OneSignal Java
     //   classes if needed. Such as com.onesignal.NotificationExtenderService
-    api 'com.onesignal:OneSignal:5.1.13'
+    api 'com.onesignal:OneSignal:5.1.15'
     
     testImplementation 'junit:junit:4.12'
 }

--- a/android/src/main/java/com/onesignal/rnonesignalandroid/RNOneSignal.java
+++ b/android/src/main/java/com/onesignal/rnonesignalandroid/RNOneSignal.java
@@ -229,7 +229,7 @@ public class RNOneSignal extends ReactContextBaseJavaModule implements
     public void initialize(String appId) {
         Context context = mReactApplicationContext.getCurrentActivity();
         OneSignalWrapper.setSdkType("reactnative");
-        OneSignalWrapper.setSdkVersion("050200");
+        OneSignalWrapper.setSdkVersion("050201");
 
         if (oneSignalInitDone) {
             Log.e("OneSignal", "Already initialized the OneSignal React-Native SDK");

--- a/ios/RCTOneSignal/RCTOneSignal.m
+++ b/ios/RCTOneSignal/RCTOneSignal.m
@@ -47,7 +47,7 @@ OSNotificationClickResult* coldStartOSNotificationClickResult;
         return;
 
     OneSignalWrapper.sdkType = @"reactnative";
-    OneSignalWrapper.sdkVersion = @"050200";
+    OneSignalWrapper.sdkVersion = @"050201"; 
     // initialize the SDK with a nil app ID so cold start click listeners can be triggered
     [OneSignal initialize:nil withLaunchOptions:launchOptions];
     didInitialize = true;

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-native-onesignal",
-  "version": "5.2.0",
+  "version": "5.2.1",
   "description": "React Native OneSignal SDK",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/react-native-onesignal.podspec
+++ b/react-native-onesignal.podspec
@@ -22,5 +22,5 @@ Pod::Spec.new do |s|
   # pod 'React', :path => '../node_modules/react-native/'
 
   # The Native OneSignal-iOS-SDK XCFramework from cocoapods.
-  s.dependency 'OneSignalXCFramework', '5.2.0'
+  s.dependency 'OneSignalXCFramework', '5.2.1'
 end


### PR DESCRIPTION
What's New
--------
- Fix notification launchUrl changed to launchURL to make it compatible… (#1704)

🔧 Native SDK Dependency Updates
--------
### Update Android SDK from `5.1.13` to `5.1.15`
For full changes, [see the native release notes](https://github.com/OneSignal/OneSignal-Android-SDK/releases)

### 🐛 Bug Fixes
- Xiaomi notification click was not foregrounding app https://github.com/OneSignal/OneSignal-Android-SDK/pull/2129
- FCM push token was not being refreshed (https://github.com/OneSignal/OneSignal-Android-SDK/pull/2125, https://github.com/OneSignal/OneSignal-Android-SDK/pull/2118)
- Poll for notification permission changes to detect permission change when prompting outside of OneSignal https://github.com/OneSignal/OneSignal-Android-SDK/pull/2112
- WorkManager fixes when the app uses a custom WorkManager https://github.com/OneSignal/OneSignal-Android-SDK/pull/2122

### ✨ Improvements
- Cold start creates new session and refreshes the user from the server https://github.com/OneSignal/OneSignal-Android-SDK/pull/2113

### Update iOS SDK from `5.2.0` to `5.2.1`
[5.2.0 Release Notes](https://github.com/OneSignal/OneSignal-iOS-SDK/releases/tag/5.2.1)

### 🐛 Bug Fixes
- Fix warning about decoding a boolean (#1436)
- Fix a purchases bug for the amount spent (#1444)
- Fix a build issue for mac catalyst (#1446)
- Fix crash when IAM window fails to load by using the main thread (#1447)

### 🔧 Maintenance 
- **Network call optimizations:** Combine user property updates for network call improvements (#1444)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/OneSignal/react-native-onesignal/1718)
<!-- Reviewable:end -->
