### PR TITLE
[Bug] Ignore Live Activities code for Mac Catalyst

### DIFF
--- a/examples/RNOneSignalTS/ios/Podfile.lock
+++ b/examples/RNOneSignalTS/ios/Podfile.lock
@@ -10,9 +10,9 @@ PODS:
     - React-jsi (= 0.64.4)
     - ReactCommon/turbomodule/core (= 0.64.4)
   - glog (0.3.5)
-  - OneSignalXCFramework (5.2.0):
-    - OneSignalXCFramework/OneSignalComplete (= 5.2.0)
-  - OneSignalXCFramework/OneSignal (5.2.0):
+  - OneSignalXCFramework (5.2.1):
+    - OneSignalXCFramework/OneSignalComplete (= 5.2.1)
+  - OneSignalXCFramework/OneSignal (5.2.1):
     - OneSignalXCFramework/OneSignalCore
     - OneSignalXCFramework/OneSignalExtension
     - OneSignalXCFramework/OneSignalLiveActivities
@@ -20,38 +20,38 @@ PODS:
     - OneSignalXCFramework/OneSignalOSCore
     - OneSignalXCFramework/OneSignalOutcomes
     - OneSignalXCFramework/OneSignalUser
-  - OneSignalXCFramework/OneSignalComplete (5.2.0):
+  - OneSignalXCFramework/OneSignalComplete (5.2.1):
     - OneSignalXCFramework/OneSignal
     - OneSignalXCFramework/OneSignalInAppMessages
     - OneSignalXCFramework/OneSignalLocation
-  - OneSignalXCFramework/OneSignalCore (5.2.0)
-  - OneSignalXCFramework/OneSignalExtension (5.2.0):
+  - OneSignalXCFramework/OneSignalCore (5.2.1)
+  - OneSignalXCFramework/OneSignalExtension (5.2.1):
     - OneSignalXCFramework/OneSignalCore
     - OneSignalXCFramework/OneSignalOutcomes
-  - OneSignalXCFramework/OneSignalInAppMessages (5.2.0):
+  - OneSignalXCFramework/OneSignalInAppMessages (5.2.1):
     - OneSignalXCFramework/OneSignalCore
     - OneSignalXCFramework/OneSignalNotifications
     - OneSignalXCFramework/OneSignalOSCore
     - OneSignalXCFramework/OneSignalOutcomes
     - OneSignalXCFramework/OneSignalUser
-  - OneSignalXCFramework/OneSignalLiveActivities (5.2.0):
+  - OneSignalXCFramework/OneSignalLiveActivities (5.2.1):
     - OneSignalXCFramework/OneSignalCore
     - OneSignalXCFramework/OneSignalOSCore
     - OneSignalXCFramework/OneSignalUser
-  - OneSignalXCFramework/OneSignalLocation (5.2.0):
+  - OneSignalXCFramework/OneSignalLocation (5.2.1):
     - OneSignalXCFramework/OneSignalCore
     - OneSignalXCFramework/OneSignalNotifications
     - OneSignalXCFramework/OneSignalOSCore
     - OneSignalXCFramework/OneSignalUser
-  - OneSignalXCFramework/OneSignalNotifications (5.2.0):
+  - OneSignalXCFramework/OneSignalNotifications (5.2.1):
     - OneSignalXCFramework/OneSignalCore
     - OneSignalXCFramework/OneSignalExtension
     - OneSignalXCFramework/OneSignalOutcomes
-  - OneSignalXCFramework/OneSignalOSCore (5.2.0):
+  - OneSignalXCFramework/OneSignalOSCore (5.2.1):
     - OneSignalXCFramework/OneSignalCore
-  - OneSignalXCFramework/OneSignalOutcomes (5.2.0):
+  - OneSignalXCFramework/OneSignalOutcomes (5.2.1):
     - OneSignalXCFramework/OneSignalCore
-  - OneSignalXCFramework/OneSignalUser (5.2.0):
+  - OneSignalXCFramework/OneSignalUser (5.2.1):
     - OneSignalXCFramework/OneSignalCore
     - OneSignalXCFramework/OneSignalNotifications
     - OneSignalXCFramework/OneSignalOSCore
@@ -249,8 +249,8 @@ PODS:
     - React-jsi (= 0.64.4)
     - React-perflogger (= 0.64.4)
   - React-jsinspector (0.64.4)
-  - react-native-onesignal (5.1.2):
-    - OneSignalXCFramework (= 5.2.0)
+  - react-native-onesignal (5.2.1):
+    - OneSignalXCFramework (= 5.2.1)
     - React (< 1.0.0, >= 0.13.0)
   - React-perflogger (0.64.4)
   - React-RCTActionSheet (0.64.4):
@@ -421,9 +421,9 @@ SPEC CHECKSUMS:
   boost-for-react-native: 39c7adb57c4e60d6c5479dd8623128eb5b3f0f2c
   DoubleConversion: cf9b38bf0b2d048436d9a82ad2abe1404f11e7de
   FBLazyVector: fa8275d5086566e22a26ddc385ab5772e7f9b1bd
-  FBReactNativeSpec: 342841ad3cdf88a10071a3507d3708b236cee677
+  FBReactNativeSpec: ac29642c312b20b463b263a24f2472d03b7cd008
   glog: 73c2498ac6884b13ede40eda8228cb1eee9d9d62
-  OneSignalXCFramework: bdf74fdc06888f9466dc21e826fe1549ed143095
+  OneSignalXCFramework: fbafb3b4964a37f8b0ff273419d1c0e5ac0e07d6
   RCT-Folly: ec7a233ccc97cc556cf7237f0db1ff65b986f27c
   RCTRequired: f85fa00af016059cf88b90b8f8ff9a6af9e4b6c3
   RCTTypeSafety: 5279aaf0fb1ad715cbbbbee32d5c98c72598bc9c
@@ -435,7 +435,7 @@ SPEC CHECKSUMS:
   React-jsi: 64f80675a66899bf0f4a58b8e3908966fa516234
   React-jsiexecutor: 8c077bef1c64430b6034f27df1000d194551e2eb
   React-jsinspector: d4f6973dd474357dbaaf6f52f31ffc713bf3e766
-  react-native-onesignal: be215738778e57af4c6da177d548e7983052d3fd
+  react-native-onesignal: 77a5dfd158b6c190243af73e2a9fc724130fbff5
   React-perflogger: 5a890ca0911669421b7611661e9b58f91c805f5c
   React-RCTActionSheet: bd180e0879f8424a73650c5c28fbef4f3b5b27fb
   React-RCTAnimation: 1004d2b4be1f2cedfdc4cb2326adc95b989e6c6b

--- a/examples/RNOneSignalTS/ios/RNOneSignalTS.xcodeproj/project.pbxproj
+++ b/examples/RNOneSignalTS/ios/RNOneSignalTS.xcodeproj/project.pbxproj
@@ -104,6 +104,7 @@
 		8E4BE6162235D7E8F6F86819 /* Pods-RNOneSignalTS-RNOneSignalTSTests.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-RNOneSignalTS-RNOneSignalTSTests.debug.xcconfig"; path = "Target Support Files/Pods-RNOneSignalTS-RNOneSignalTSTests/Pods-RNOneSignalTS-RNOneSignalTSTests.debug.xcconfig"; sourceTree = "<group>"; };
 		B0F4647666F7BF086F879F61 /* libPods-RNOneSignalTS-RNOneSignalTSTests.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = "libPods-RNOneSignalTS-RNOneSignalTSTests.a"; sourceTree = BUILT_PRODUCTS_DIR; };
 		C40869784097C22EC34A0B5B /* Pods-RNOneSignalTS-tvOS.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-RNOneSignalTS-tvOS.debug.xcconfig"; path = "Target Support Files/Pods-RNOneSignalTS-tvOS/Pods-RNOneSignalTS-tvOS.debug.xcconfig"; sourceTree = "<group>"; };
+		CFC85F672C34BF3A00E78C88 /* RNOneSignalWidgetExtension.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; path = RNOneSignalWidgetExtension.entitlements; sourceTree = "<group>"; };
 		ED297162215061F000B7C4FE /* JavaScriptCore.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = JavaScriptCore.framework; path = System/Library/Frameworks/JavaScriptCore.framework; sourceTree = SDKROOT; };
 		ED2971642150620600B7C4FE /* JavaScriptCore.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = JavaScriptCore.framework; path = Platforms/AppleTVOS.platform/Developer/SDKs/AppleTVOS12.0.sdk/System/Library/Frameworks/JavaScriptCore.framework; sourceTree = DEVELOPER_DIR; };
 		F00EC2440AAB4AE04AB2B092 /* Pods-RNOneSignalTS-RNOneSignalTSTests.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-RNOneSignalTS-RNOneSignalTSTests.release.xcconfig"; path = "Target Support Files/Pods-RNOneSignalTS-RNOneSignalTSTests/Pods-RNOneSignalTS-RNOneSignalTSTests.release.xcconfig"; sourceTree = "<group>"; };
@@ -225,6 +226,7 @@
 		83CBB9F61A601CBA00E9B192 = {
 			isa = PBXGroup;
 			children = (
+				CFC85F672C34BF3A00E78C88 /* RNOneSignalWidgetExtension.entitlements */,
 				13B07FAE1A68108700A75B9A /* RNOneSignalTS */,
 				832341AE1AAA6A7D00B99B32 /* Libraries */,
 				00E356EF1AD99517003FC87E /* RNOneSignalTSTests */,
@@ -475,7 +477,7 @@
 /* Begin PBXShellScriptBuildPhase section */
 		00DD1BFF1BD5951E006B06BC /* Bundle React Native code and images */ = {
 			isa = PBXShellScriptBuildPhase;
-			buildActionMask = 2147483647;
+			buildActionMask = 8;
 			files = (
 			);
 			inputPaths = (
@@ -483,9 +485,9 @@
 			name = "Bundle React Native code and images";
 			outputPaths = (
 			);
-			runOnlyForDeploymentPostprocessing = 0;
+			runOnlyForDeploymentPostprocessing = 1;
 			shellPath = /bin/sh;
-			shellScript = "export NODE_BINARY=node\n../node_modules/react-native/scripts/react-native-xcode.sh";
+			shellScript = "export NODE_BINARY=node\n../node_modules/react-native/scripts/react-native-xcode.sh\n";
 		};
 		0FEF11F60825F2FC61B8C711 /* [CP] Check Pods Manifest.lock */ = {
 			isa = PBXShellScriptBuildPhase;
@@ -889,8 +891,11 @@
 				);
 				PRODUCT_BUNDLE_IDENTIFIER = com.onesignal.example;
 				PRODUCT_NAME = RNOneSignalTS;
+				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator";
+				SUPPORTS_MACCATALYST = YES;
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
 				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
 				VERSIONING_SYSTEM = "apple-generic";
 			};
 			name = Debug;
@@ -914,7 +919,10 @@
 				);
 				PRODUCT_BUNDLE_IDENTIFIER = com.onesignal.example;
 				PRODUCT_NAME = RNOneSignalTS;
+				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator";
+				SUPPORTS_MACCATALYST = YES;
 				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
 				VERSIONING_SYSTEM = "apple-generic";
 			};
 			name = Release;
@@ -1047,6 +1055,7 @@
 				CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
 				CLANG_WARN_QUOTED_INCLUDE_IN_FRAMEWORK_HEADER = YES;
 				CLANG_WARN_UNGUARDED_AVAILABILITY = YES_AGGRESSIVE;
+				CODE_SIGN_ENTITLEMENTS = RNOneSignalWidgetExtension.entitlements;
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 1;
 				DEBUG_INFORMATION_FORMAT = dwarf;
@@ -1072,6 +1081,7 @@
 				PRODUCT_BUNDLE_IDENTIFIER = com.onesignal.example.RNOneSignalWidget;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SKIP_INSTALL = YES;
+				SUPPORTS_MACCATALYST = YES;
 				SWIFT_ACTIVE_COMPILATION_CONDITIONS = "DEBUG $(inherited)";
 				SWIFT_EMIT_LOC_STRINGS = YES;
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
@@ -1094,6 +1104,7 @@
 				CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
 				CLANG_WARN_QUOTED_INCLUDE_IN_FRAMEWORK_HEADER = YES;
 				CLANG_WARN_UNGUARDED_AVAILABILITY = YES_AGGRESSIVE;
+				CODE_SIGN_ENTITLEMENTS = RNOneSignalWidgetExtension.entitlements;
 				CODE_SIGN_STYLE = Automatic;
 				COPY_PHASE_STRIP = NO;
 				CURRENT_PROJECT_VERSION = 1;
@@ -1119,6 +1130,7 @@
 				PRODUCT_BUNDLE_IDENTIFIER = com.onesignal.example.RNOneSignalWidget;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SKIP_INSTALL = YES;
+				SUPPORTS_MACCATALYST = YES;
 				SWIFT_COMPILATION_MODE = wholemodule;
 				SWIFT_EMIT_LOC_STRINGS = YES;
 				SWIFT_VERSION = 5.0;

--- a/examples/RNOneSignalTS/ios/RNOneSignalWidget/RNOneSignalWidgetBundle.swift
+++ b/examples/RNOneSignalTS/ios/RNOneSignalWidget/RNOneSignalWidgetBundle.swift
@@ -8,9 +8,11 @@
 import WidgetKit
 import SwiftUI
 
+#if !targetEnvironment(macCatalyst)
 @main
 struct RNOneSignalWidgetBundle: WidgetBundle {
     var body: some Widget {
         RNOneSignalWidgetLiveActivity()
     }
 }
+#endif

--- a/examples/RNOneSignalTS/ios/RNOneSignalWidget/RNOneSignalWidgetLiveActivity.swift
+++ b/examples/RNOneSignalTS/ios/RNOneSignalWidget/RNOneSignalWidgetLiveActivity.swift
@@ -5,6 +5,7 @@
 //  Created by Brian Smith on 4/26/24.
 //
 
+#if !targetEnvironment(macCatalyst)
 import ActivityKit
 import WidgetKit
 import SwiftUI
@@ -63,3 +64,4 @@ struct RNOneSignalWidgetLiveActivity: Widget {
         }
     }
 }
+#endif

--- a/examples/RNOneSignalTS/ios/RNOneSignalWidgetExtension.entitlements
+++ b/examples/RNOneSignalTS/ios/RNOneSignalWidgetExtension.entitlements
@@ -2,13 +2,9 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
-	<key>aps-environment</key>
-	<string>development</string>
 	<key>com.apple.security.app-sandbox</key>
 	<true/>
 	<key>com.apple.security.network.client</key>
-	<true/>
-	<key>com.apple.security.personal-information.location</key>
 	<true/>
 </dict>
 </plist>

--- a/ios/RCTOneSignal/RCTOneSignalEventEmitter.m
+++ b/ios/RCTOneSignal/RCTOneSignalEventEmitter.m
@@ -133,8 +133,8 @@ RCT_EXPORT_METHOD(exitLiveActivity:(NSString *)activityId
 
 RCT_EXPORT_METHOD(setPushToStartToken:(NSString *)activityType 
                   withToken:(NSString *)token) {
+    #if !TARGET_OS_MACCATALYST
     NSError* err=nil;
-
     if (@available(iOS 17.2, *)) {
         [OneSignalLiveActivitiesManagerImpl setPushToStartToken:activityType withToken:token error:&err];
         if (err) {
@@ -143,11 +143,12 @@ RCT_EXPORT_METHOD(setPushToStartToken:(NSString *)activityType
     } else {
         [OneSignalLog onesignalLog:ONE_S_LL_ERROR message:[NSString stringWithFormat:@"cannot setPushToStartToken on iOS < 17.2"]];
     }
+    #endif
 }
 
 RCT_EXPORT_METHOD(removePushToStartToken:(NSString *)activityType) {
+    #if !TARGET_OS_MACCATALYST
     NSError* err=nil;
-
     if (@available(iOS 17.2, *)) {
         [OneSignalLiveActivitiesManagerImpl removePushToStartToken:activityType error:&err];
         if (err) {
@@ -156,11 +157,12 @@ RCT_EXPORT_METHOD(removePushToStartToken:(NSString *)activityType) {
     } else {
         [OneSignalLog onesignalLog:ONE_S_LL_ERROR message:[NSString stringWithFormat:@"cannot removePushToStartToken on iOS < 17.2"]];
     }
+    #endif
 }
 
 RCT_EXPORT_METHOD(setupDefaultLiveActivity:(NSDictionary * _Nullable)options) {
+    #if !TARGET_OS_MACCATALYST
     LiveActivitySetupOptions *laOptions = nil;
-
     if (options != nil) {
         laOptions = [LiveActivitySetupOptions alloc];
         [laOptions setEnablePushToStart:[options[@"enablePushToStart"] boolValue]];
@@ -172,17 +174,19 @@ RCT_EXPORT_METHOD(setupDefaultLiveActivity:(NSDictionary * _Nullable)options) {
     } else {
         [OneSignalLog onesignalLog:ONE_S_LL_ERROR message:[NSString stringWithFormat:@"cannot setupDefault on iOS < 16.1"]];
     }
+    #endif
 }
 
 RCT_EXPORT_METHOD(startDefaultLiveActivity:(NSString *)activityId
                 withAttributes:(NSDictionary * _Nonnull)attributes
                 withContent:(NSDictionary * _Nonnull)content) {
-
+    #if !TARGET_OS_MACCATALYST
     if (@available(iOS 16.1, *)) {
         [OneSignalLiveActivitiesManagerImpl startDefault:activityId attributes:attributes content:content];
     } else {
         [OneSignalLog onesignalLog:ONE_S_LL_ERROR message:[NSString stringWithFormat:@"cannot startDefault on iOS < 16.1"]];
     }
+    #endif
 }
 
 RCT_EXPORT_METHOD(setPrivacyConsentGiven:(BOOL)granted) {


### PR DESCRIPTION
# Description
## One Line Summary
Fix Mac Catalyst builds by ignoring offending Live Activities code.

## Details
* We fixed Mac Catalyst Live Activities build issues in native SDK https://github.com/OneSignal/OneSignal-iOS-SDK/pull/1446
* However, this wrapper SDK has code that reference `OneSignalLiveActivitiesManagerImpl` directly which is in a module not available to Mac Catalyst due to ActivityKit dependency
* Therefore, it caused build failures for Mac Catalyst.
* Live Activities does not work for Mac anyway, so just ignore these methods.

### Motivation
Fix builds, address followup report here https://github.com/OneSignal/OneSignal-iOS-SDK/issues/1445.

### Scope
- No op Live Activities for Mac Catalyst

# Testing
## Unit testing
None

## Manual testing
Tested on my Mac Catalyst - builds, Live Activities is no-op
Tested on iPhone - builds, Live Activities setup is done

# Affected code checklist
   - [ ] Notifications
      - [ ] Display
      - [ ] Open
      - [ ] Push Processing
      - [ ] Confirm Deliveries
   - [ ] Outcomes
   - [ ] Sessions
   - [ ] In-App Messaging
   - [ ] REST API requests
   - [ ] Public API changes

# Checklist
## Overview
   - [x] I have filled out all **REQUIRED** sections above
   - [x] PR does one thing
   - [x] Any Public API changes are explained in the PR details and conform to existing APIs

## Testing
   - [x] I have included test coverage for these changes, or explained why they are not needed
   - [x] All automated tests pass, or I explained why that is not possible
   - [x] I have personally tested this on my device, or explained why that is not possible

## Final pass
   - [x] Code is as readable as possible.
   - [x] I have reviewed this PR myself, ensuring it meets each checklist item

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/OneSignal/react-native-onesignal/1719)
<!-- Reviewable:end -->
