### PR TITLE
Release 5.2.2

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -31,7 +31,7 @@ dependencies {
 
     // api is used instead of implementation so the parent :app project can access any of the OneSignal Java
     //   classes if needed. Such as com.onesignal.NotificationExtenderService
-    api 'com.onesignal:OneSignal:5.1.15'
+    api 'com.onesignal:OneSignal:5.1.17'
     
     testImplementation 'junit:junit:4.12'
 }

--- a/android/src/main/java/com/onesignal/rnonesignalandroid/RNOneSignal.java
+++ b/android/src/main/java/com/onesignal/rnonesignalandroid/RNOneSignal.java
@@ -229,7 +229,7 @@ public class RNOneSignal extends ReactContextBaseJavaModule implements
     public void initialize(String appId) {
         Context context = mReactApplicationContext.getCurrentActivity();
         OneSignalWrapper.setSdkType("reactnative");
-        OneSignalWrapper.setSdkVersion("050201");
+        OneSignalWrapper.setSdkVersion("050202");
 
         if (oneSignalInitDone) {
             Log.e("OneSignal", "Already initialized the OneSignal React-Native SDK");

--- a/ios/RCTOneSignal/RCTOneSignal.m
+++ b/ios/RCTOneSignal/RCTOneSignal.m
@@ -47,7 +47,7 @@ OSNotificationClickResult* coldStartOSNotificationClickResult;
         return;
 
     OneSignalWrapper.sdkType = @"reactnative";
-    OneSignalWrapper.sdkVersion = @"050201"; 
+    OneSignalWrapper.sdkVersion = @"050202"; 
     // initialize the SDK with a nil app ID so cold start click listeners can be triggered
     [OneSignal initialize:nil withLaunchOptions:launchOptions];
     didInitialize = true;

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-native-onesignal",
-  "version": "5.2.1",
+  "version": "5.2.2",
   "description": "React Native OneSignal SDK",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/react-native-onesignal.podspec
+++ b/react-native-onesignal.podspec
@@ -22,5 +22,5 @@ Pod::Spec.new do |s|
   # pod 'React', :path => '../node_modules/react-native/'
 
   # The Native OneSignal-iOS-SDK XCFramework from cocoapods.
-  s.dependency 'OneSignalXCFramework', '5.2.1'
+  s.dependency 'OneSignalXCFramework', '5.2.2'
 end


### PR DESCRIPTION
## What's Changed
### 🐛 Bug Fixes
* [Bug] Ignore Live Activities code for Mac Catalyst in [1719](https://github.com/OneSignal/react-native-onesignal/pull/1719)

### 🔧 Update Android SDK from 5.1.15 to 5.1.17 
- [release notes](https://github.com/OneSignal/OneSignal-Android-SDK/releases)
- Fix "could not be instantiated" exception when; some modules are omitted AND android.enableR8.fullMode is enabled. https://github.com/OneSignal/OneSignal-Android-SDK/pull/2136
### 🔧 Update iOS SDK from 5.2.1 to 5.2.2 
- [release notes](https://github.com/OneSignal/OneSignal-iOS-SDK/releases/tag/5.2.2)
- Prevent In-App Message request crashes by making null values safe https://github.com/OneSignal/OneSignal-iOS-SDK/pull/1457
- Add Dispatch Queues to all executors to prevent concurrency crashes https://github.com/OneSignal/OneSignal-iOS-SDK/pull/1454
- Fix clearing notifications incorrectly such as when pulling down the notification center https://github.com/OneSignal/OneSignal-iOS-SDK/pull/1451

**Full Changelog**: https://github.com/OneSignal/react-native-onesignal/compare/5.2.1...5.2.2

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/OneSignal/react-native-onesignal/1720)
<!-- Reviewable:end -->
