### PR TITLE
[ios] fix array resolve in request permission

### DIFF
--- a/ios/RCTOneSignal/RCTOneSignalEventEmitter.m
+++ b/ios/RCTOneSignal/RCTOneSignalEventEmitter.m
@@ -282,7 +282,7 @@ RCT_REMAP_METHOD(requestNotificationPermission,
                  requestNotificationPermissionResolver:(RCTPromiseResolveBlock)resolve
                  rejecter:(RCTPromiseRejectBlock)reject) {
     [OneSignal.Notifications requestPermission:^(BOOL accepted) {
-        resolve(@[@(accepted)]);
+        resolve(@(accepted));
     } fallbackToSettings:fallbackToSettings];
 }
 


### PR DESCRIPTION
## Summary

Fixes an issue where the `requestNotificationPermission` method on iOS incorrectly resolved the promise with an array instead of a boolean value.

## Details

### Motivation

The TypeScript type definition for the `requestPermission` function specifies that it should return a `Promise<boolean>`, indicating a promise that resolves to a boolean value. However, on iOS, the method was actually resolving the promise with an array containing the boolean value. This mismatch between the type definition and the actual return value caused issues in applications that relied on the `requestPermission` function returning a simple boolean value. 

### Scope

This change only affects the `requestNotificationPermission` method in the iOS SDK. It does not change the behavior of any other methods or functionalities.

## Testing

### Manual testing

Manually tested the `requestNotificationPermission` method on a real iOS device and verified that the promise now correctly resolves with a boolean value.

# Affected code checklist

- [x] Notifications
 - [x] Push Processing

# Checklist

## Overview

- [x] I have filled out all **REQUIRED** sections above
- [x] PR does one thing
- [x] Any Public API changes are explained in the PR details and conform to existing APIs

## Testing

- [x] I have personally tested this on my device
- [x] All automated tests pass

## Final pass

- [x] Code is as readable as possible.
- [x] I have reviewed this PR myself, ensuring it meets each checklist item

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/OneSignal/react-native-onesignal/1721)
<!-- Reviewable:end -->
