### PR TITLE
Release 5.2.3

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -31,7 +31,7 @@ dependencies {
 
     // api is used instead of implementation so the parent :app project can access any of the OneSignal Java
     //   classes if needed. Such as com.onesignal.NotificationExtenderService
-    api 'com.onesignal:OneSignal:5.1.17'
+    api 'com.onesignal:OneSignal:5.1.20'
     
     testImplementation 'junit:junit:4.12'
 }

--- a/android/src/main/java/com/onesignal/rnonesignalandroid/RNOneSignal.java
+++ b/android/src/main/java/com/onesignal/rnonesignalandroid/RNOneSignal.java
@@ -229,7 +229,7 @@ public class RNOneSignal extends ReactContextBaseJavaModule implements
     public void initialize(String appId) {
         Context context = mReactApplicationContext.getCurrentActivity();
         OneSignalWrapper.setSdkType("reactnative");
-        OneSignalWrapper.setSdkVersion("050202");
+        OneSignalWrapper.setSdkVersion("050203");
 
         if (oneSignalInitDone) {
             Log.e("OneSignal", "Already initialized the OneSignal React-Native SDK");

--- a/ios/RCTOneSignal/RCTOneSignal.m
+++ b/ios/RCTOneSignal/RCTOneSignal.m
@@ -47,7 +47,7 @@ OSNotificationClickResult* coldStartOSNotificationClickResult;
         return;
 
     OneSignalWrapper.sdkType = @"reactnative";
-    OneSignalWrapper.sdkVersion = @"050202"; 
+    OneSignalWrapper.sdkVersion = @"050203"; 
     // initialize the SDK with a nil app ID so cold start click listeners can be triggered
     [OneSignal initialize:nil withLaunchOptions:launchOptions];
     didInitialize = true;

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-native-onesignal",
-  "version": "5.2.2",
+  "version": "5.2.3",
   "description": "React Native OneSignal SDK",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/react-native-onesignal.podspec
+++ b/react-native-onesignal.podspec
@@ -22,5 +22,5 @@ Pod::Spec.new do |s|
   # pod 'React', :path => '../node_modules/react-native/'
 
   # The Native OneSignal-iOS-SDK XCFramework from cocoapods.
-  s.dependency 'OneSignalXCFramework', '5.2.2'
+  s.dependency 'OneSignalXCFramework', '5.2.3'
 end


### PR DESCRIPTION
## What's Changed

### 🐛  Bug Fixes
- [Bug] iOS - requestPermission fallbackToSettings fix [(#1729)](https://github.com/OneSignal/react-native-onesignal/pull/1729)
- [ios] fix array resolve in request permission [(#1721)](https://github.com/OneSignal/react-native-onesignal/pull/1721)

### 🔧  Native Updates
#### Update Android SDK from 5.1.17 to 5.1.20 [release notes](https://github.com/OneSignal/OneSignal-Android-SDK/releases/tag/5.1.20)

🐛 Bug Fixes
* IAM with dynamic trigger showing forever [(#2137)](https://github.com/OneSignal/OneSignal-Android-SDK/pull/2137)
* Allow preventDefault to be fired up to two times [(#2138)](https://github.com/OneSignal/OneSignal-Android-SDK/pull/2138)
* Recover null onesignal ID crashes for Operations [(#2157)](https://github.com/OneSignal/OneSignal-Android-SDK/pull/2157)
*Prevent retrying IAM display if 410 is received from backend [(#2158)](https://github.com/OneSignal/OneSignal-Android-SDK/pull/2158)


✨ Improvements
- Optimized the initialization process by moving some service initialization to a background thread [(#2125)](https://github.com/OneSignal/OneSignal-Android-SDK/pull/2151)
- Add option to default to HMS over FCM [(#2163)](https://github.com/OneSignal/OneSignal-Android-SDK/pull/2163)
- Remove fallback code for FCM pre-21.0.0 [(#2148)](https://github.com/OneSignal/OneSignal-Android-SDK/pull/2148)
- Clean up Android Support Library references, drop dependency on androidx.legacy, & Android 4.4 and older code [(#2147)](https://github.com/OneSignal/OneSignal-Android-SDK/pull/2147)

#### Update iOS SDK from 5.2.2 to 5.2.3 [release notes](https://github.com/OneSignal/OneSignal-iOS-SDK/releases/tag/5.2.3)

🐛 Bug Fixes
- The user executor needs to uncache first which fixes some cached requests being dropped for past users [(#1465)](https://github.com/OneSignal/OneSignal-iOS-SDK/pull/1465)

✨ Improvements
- Omit misleading fatal-level log for cross-platform SDKs [(#1468)](https://github.com/OneSignal/OneSignal-iOS-SDK/pull/1468)

🛠️ Maintenance
- [For our server] Use only OneSignal ID for requests [(#1464)](https://github.com/OneSignal/OneSignal-iOS-SDK/pull/1464)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/OneSignal/react-native-onesignal/1731)
<!-- Reviewable:end -->
