### PR TITLE
Release 5.2.6

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -31,7 +31,7 @@ dependencies {
 
     // api is used instead of implementation so the parent :app project can access any of the OneSignal Java
     //   classes if needed. Such as com.onesignal.NotificationExtenderService
-    api 'com.onesignal:OneSignal:5.1.23'
+    api 'com.onesignal:OneSignal:5.1.24'
     
     testImplementation 'junit:junit:4.12'
 }

--- a/android/src/main/java/com/onesignal/rnonesignalandroid/RNOneSignal.java
+++ b/android/src/main/java/com/onesignal/rnonesignalandroid/RNOneSignal.java
@@ -229,7 +229,7 @@ public class RNOneSignal extends ReactContextBaseJavaModule implements
     public void initialize(String appId) {
         Context context = mReactApplicationContext.getCurrentActivity();
         OneSignalWrapper.setSdkType("reactnative");
-        OneSignalWrapper.setSdkVersion("050205");
+        OneSignalWrapper.setSdkVersion("050206");
 
         if (oneSignalInitDone) {
             Log.e("OneSignal", "Already initialized the OneSignal React-Native SDK");

--- a/ios/RCTOneSignal/RCTOneSignal.m
+++ b/ios/RCTOneSignal/RCTOneSignal.m
@@ -47,7 +47,7 @@ OSNotificationClickResult* coldStartOSNotificationClickResult;
         return;
 
     OneSignalWrapper.sdkType = @"reactnative";
-    OneSignalWrapper.sdkVersion = @"050205"; 
+    OneSignalWrapper.sdkVersion = @"050206"; 
     // initialize the SDK with a nil app ID so cold start click listeners can be triggered
     [OneSignal initialize:nil withLaunchOptions:launchOptions];
     didInitialize = true;

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-native-onesignal",
-  "version": "5.2.5",
+  "version": "5.2.6",
   "description": "React Native OneSignal SDK",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/react-native-onesignal.podspec
+++ b/react-native-onesignal.podspec
@@ -22,5 +22,5 @@ Pod::Spec.new do |s|
   # pod 'React', :path => '../node_modules/react-native/'
 
   # The Native OneSignal-iOS-SDK XCFramework from cocoapods.
-  s.dependency 'OneSignalXCFramework', '5.2.5'
+  s.dependency 'OneSignalXCFramework', '5.2.7'
 end


### PR DESCRIPTION
🔧 Native SDK Dependency Updates Only
--------
### Update Android SDK from 5.1.23 to 5.1.24 | [release notes](https://github.com/OneSignal/OneSignal-Android-SDK/releases/tag/5.1.24)

🐛 Bug Fixes
* Fix setting consentGiven throwing if called before initWithContext [#2200](https://github.com/OneSignal/OneSignal-Android-SDK/pull/2200)
* Window manager BadTokenException / WindowLeaked [#2208](https://github.com/OneSignal/OneSignal-Android-SDK/pull/2208)

✨ Improvements
* Make use of ryw_delay to minimize retries on IAM fetch [#2207](https://github.com/OneSignal/OneSignal-Android-SDK/pull/2207)

### Update iOS SDK from 5.2.5 to 5.2.7 | [release notes](https://github.com/OneSignal/OneSignal-iOS-SDK/releases/tag/5.2.7)
✨ Improvements
- Don't use cached in-app messages if the SDK encounters an error fetching them or when the server returns none [#1499](https://github.com/OneSignal/OneSignal-iOS-SDK/pull/1499)
- Improve segment membership calculation that allows for fetching more accurate and updated in-app messages for a user [#1486](https://github.com/OneSignal/OneSignal-iOS-SDK/pull/1486)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/OneSignal/react-native-onesignal/1757)
<!-- Reviewable:end -->
