### PR TITLE
Release 5.2.7

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -31,7 +31,7 @@ dependencies {
 
     // api is used instead of implementation so the parent :app project can access any of the OneSignal Java
     //   classes if needed. Such as com.onesignal.NotificationExtenderService
-    api 'com.onesignal:OneSignal:5.1.24'
+    api 'com.onesignal:OneSignal:5.1.25'
     
     testImplementation 'junit:junit:4.12'
 }

--- a/android/src/main/java/com/onesignal/rnonesignalandroid/RNOneSignal.java
+++ b/android/src/main/java/com/onesignal/rnonesignalandroid/RNOneSignal.java
@@ -229,7 +229,7 @@ public class RNOneSignal extends ReactContextBaseJavaModule implements
     public void initialize(String appId) {
         Context context = mReactApplicationContext.getCurrentActivity();
         OneSignalWrapper.setSdkType("reactnative");
-        OneSignalWrapper.setSdkVersion("050206");
+        OneSignalWrapper.setSdkVersion("050207");
 
         if (oneSignalInitDone) {
             Log.e("OneSignal", "Already initialized the OneSignal React-Native SDK");

--- a/ios/RCTOneSignal/RCTOneSignal.m
+++ b/ios/RCTOneSignal/RCTOneSignal.m
@@ -47,7 +47,7 @@ OSNotificationClickResult* coldStartOSNotificationClickResult;
         return;
 
     OneSignalWrapper.sdkType = @"reactnative";
-    OneSignalWrapper.sdkVersion = @"050206"; 
+    OneSignalWrapper.sdkVersion = @"050207"; 
     // initialize the SDK with a nil app ID so cold start click listeners can be triggered
     [OneSignal initialize:nil withLaunchOptions:launchOptions];
     didInitialize = true;

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-native-onesignal",
-  "version": "5.2.6",
+  "version": "5.2.7",
   "description": "React Native OneSignal SDK",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/react-native-onesignal.podspec
+++ b/react-native-onesignal.podspec
@@ -22,5 +22,5 @@ Pod::Spec.new do |s|
   # pod 'React', :path => '../node_modules/react-native/'
 
   # The Native OneSignal-iOS-SDK XCFramework from cocoapods.
-  s.dependency 'OneSignalXCFramework', '5.2.7'
+  s.dependency 'OneSignalXCFramework', '5.2.8'
 end


### PR DESCRIPTION
🔧 Native SDK Dependency Updates Only
--------
### Update Android SDK from 5.1.24 to 5.1.25 | [release notes](https://github.com/OneSignal/OneSignal-Android-SDK/releases/tag/5.1.25)

🐛 Bug Fixes

- [Fix] NPE by getScheduleBackgroundRunIn [OneSignal/OneSignal-Android-SDK#2212](https://github.com/OneSignal/OneSignal-Android-SDK/pull/2212)

### Update iOS SDK from 5.2.7 to 5.2.8 | [release notes](https://github.com/OneSignal/OneSignal-iOS-SDK/releases/tag/5.2.8)
🐛 Bug Fixes

- Fix [__NSPlaceholderDictionary initWithObjects:forKeys:count:] crashes caused by nil HTTPResponse headers [OneSignal/OneSignal-iOS-SDK#1518](https://github.com/OneSignal/OneSignal-iOS-SDK/pull/1518)

✨ Improvements

- Include debug symbols (dSYM) in the SDK [OneSignal/OneSignal-iOS-SDK#1519](https://github.com/OneSignal/OneSignal-iOS-SDK/pull/1519)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/OneSignal/react-native-onesignal/1765)
<!-- Reviewable:end -->
