### PR TITLE
Release 5.2.9

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -31,7 +31,7 @@ dependencies {
 
     // api is used instead of implementation so the parent :app project can access any of the OneSignal Java
     //   classes if needed. Such as com.onesignal.NotificationExtenderService
-    api 'com.onesignal:OneSignal:5.1.26'
+    api 'com.onesignal:OneSignal:5.1.29'
     
     testImplementation 'junit:junit:4.12'
 }

--- a/android/src/main/java/com/onesignal/rnonesignalandroid/RNOneSignal.java
+++ b/android/src/main/java/com/onesignal/rnonesignalandroid/RNOneSignal.java
@@ -229,7 +229,7 @@ public class RNOneSignal extends ReactContextBaseJavaModule implements
     public void initialize(String appId) {
         Context context = mReactApplicationContext.getCurrentActivity();
         OneSignalWrapper.setSdkType("reactnative");
-        OneSignalWrapper.setSdkVersion("050208");
+        OneSignalWrapper.setSdkVersion("050209");
 
         if (oneSignalInitDone) {
             Log.e("OneSignal", "Already initialized the OneSignal React-Native SDK");

--- a/ios/RCTOneSignal/RCTOneSignal.m
+++ b/ios/RCTOneSignal/RCTOneSignal.m
@@ -47,7 +47,7 @@ OSNotificationClickResult* coldStartOSNotificationClickResult;
         return;
 
     OneSignalWrapper.sdkType = @"reactnative";
-    OneSignalWrapper.sdkVersion = @"050208"; 
+    OneSignalWrapper.sdkVersion = @"050209"; 
     // initialize the SDK with a nil app ID so cold start click listeners can be triggered
     [OneSignal initialize:nil withLaunchOptions:launchOptions];
     didInitialize = true;

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-native-onesignal",
-  "version": "5.2.8",
+  "version": "5.2.9",
   "description": "React Native OneSignal SDK",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/react-native-onesignal.podspec
+++ b/react-native-onesignal.podspec
@@ -22,5 +22,5 @@ Pod::Spec.new do |s|
   # pod 'React', :path => '../node_modules/react-native/'
 
   # The Native OneSignal-iOS-SDK XCFramework from cocoapods.
-  s.dependency 'OneSignalXCFramework', '5.2.9'
+  s.dependency 'OneSignalXCFramework', '5.2.10'
 end


### PR DESCRIPTION
### 🐛 Bug Fixes
- when upgrading from v4 to v5 of this SDK, notifications will be received when the app has not been opened yet [Android fix](https://github.com/OneSignal/OneSignal-Android-SDK/pull/2244)

---------

### 🛠️ Native Dependency Updates
**Update Android SDK from 5.1.26 to 5.1.29 | select fixes listed**
- [add Amazon IAP v3.0.5 handle](https://github.com/OneSignal/OneSignal-Android-SDK/pull/2255)
- [fix issue with notification click not foregrounding the app on the first click in certain scenarios](https://github.com/OneSignal/OneSignal-Android-SDK/pull/2259)
- [fix rare 400 issues that happen on new installs](https://github.com/OneSignal/OneSignal-Android-SDK/pull/2059)
- See [release notes](https://github.com/OneSignal/OneSignal-Android-SDK/releases) for full details.

**Update iOS SDK from 5.2.9 to 5.2.10**
- [Fix requiring privacy consent blocks confirmed deliveries indefinitely](https://github.com/OneSignal/OneSignal-iOS-SDK/pull/1541)
- [Detect for timezone changes and update the user](https://github.com/OneSignal/OneSignal-iOS-SDK/pull/1542)
- See [release notes](https://github.com/OneSignal/OneSignal-iOS-SDK/releases) for full details.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/OneSignal/react-native-onesignal/1790)
<!-- Reviewable:end -->
