### PR TITLE
Fix: Android use OneSignalLog, don't use `android.util.Log`, also fixes crash

### DIFF
--- a/android/src/main/java/com/onesignal/rnonesignalandroid/RNOneSignal.java
+++ b/android/src/main/java/com/onesignal/rnonesignalandroid/RNOneSignal.java
@@ -38,7 +38,7 @@ package com.onesignal.rnonesignalandroid;
 import android.content.Context;
 import android.content.pm.ApplicationInfo;
 import android.os.Bundle;
-import android.util.Log;
+import com.onesignal.debug.internal.logging.Logging;
 import com.facebook.react.bridge.Callback;
 import com.facebook.react.bridge.LifecycleEventListener;
 import com.facebook.react.bridge.Promise;
@@ -172,7 +172,7 @@ public class RNOneSignal extends ReactContextBaseJavaModule implements
 
     private void removeHandlers() {
         if(!oneSignalInitDone) {
-            Log.i("OneSignal", "OneSignal React-Native SDK not initialized yet. Could not remove handlers.");
+            Logging.debug("OneSignal React-Native SDK not initialized yet. Could not remove handlers.", null);
             return;
         }
 
@@ -232,7 +232,7 @@ public class RNOneSignal extends ReactContextBaseJavaModule implements
         OneSignalWrapper.setSdkVersion("050209");
 
         if (oneSignalInitDone) {
-            Log.e("OneSignal", "Already initialized the OneSignal React-Native SDK");
+            Logging.debug("Already initialized the OneSignal React-Native SDK", null);
             return;
         }
 
@@ -384,7 +384,7 @@ public class RNOneSignal extends ReactContextBaseJavaModule implements
                     }
                 }
             } catch(InterruptedException e){
-                Log.e("InterruptedException" + e.toString(), null);
+                Logging.error("InterruptedException: " + e.toString(), null);
             }
         } catch (JSONException e) {
             e.printStackTrace();
@@ -395,7 +395,7 @@ public class RNOneSignal extends ReactContextBaseJavaModule implements
     private void displayNotification(String notificationId){
         INotificationWillDisplayEvent event = notificationWillDisplayCache.get(notificationId);
         if (event == null) {
-            Log.e("Could not find onWillDisplayNotification event for notification with id: " + notificationId, null);
+            Logging.error("Could not find onWillDisplayNotification event for notification with id: " + notificationId, null);
             return;
         }
         event.getNotification().display();
@@ -405,7 +405,7 @@ public class RNOneSignal extends ReactContextBaseJavaModule implements
     private void preventDefault(String notificationId) {
         INotificationWillDisplayEvent event = notificationWillDisplayCache.get(notificationId);
         if (event == null) {
-            Log.e("Could not find onWillDisplayNotification event for notification with id: " + notificationId, null);
+            Logging.error("Could not find onWillDisplayNotification event for notification with id: " + notificationId, null);
             return;
         }
         event.preventDefault();
@@ -432,7 +432,7 @@ public class RNOneSignal extends ReactContextBaseJavaModule implements
     public void onNotificationPermissionChange(boolean permission) {
         try {
             sendEvent("OneSignal-permissionChanged", RNUtils.convertHashMapToWritableMap(RNUtils.convertPermissionToMap(permission)));
-            Log.i("OneSignal", "sending permission change event");
+            Logging.debug("Sending permission change event", null);
         } catch (JSONException e) {
             e.printStackTrace();
         }
@@ -546,7 +546,7 @@ public class RNOneSignal extends ReactContextBaseJavaModule implements
             sendEvent("OneSignal-subscriptionChanged",
                     RNUtils.convertHashMapToWritableMap(
                             RNUtils.convertPushSubscriptionChangedStateToMap(pushSubscriptionChangedState)));
-            Log.i("OneSignal", "sending subscription change event");
+            Logging.debug("Sending subscription change event", null);
         } catch (JSONException e) {
             e.printStackTrace();
         } 
@@ -715,7 +715,7 @@ public class RNOneSignal extends ReactContextBaseJavaModule implements
             sendEvent("OneSignal-userStateChanged",
                     RNUtils.convertHashMapToWritableMap(
                             RNUtils.convertUserChangedStateToMap(state)));
-            Log.i("OneSignal", "sending user state change event");
+            Logging.debug("Sending user state change event", null);
         } catch (JSONException e) {
             e.printStackTrace();
         } 


### PR DESCRIPTION
# Description

## One Line Summary
Obey log level set by developers and also fixes NPE crash when some malformed logs were actually invoked.

## Details

### Motivation
- Follow developer's log level they set by using our OneSignal Logging class instead of the Android utility Log class.
- Fix crash - see https://github.com/OneSignal/react-native-onesignal/issues/1577

### Scope
Logging only
The bug was some usages of `android.util.Log` had arguments conflated with our OneSignal `Logging`. OneSignalLog's 2nd parameter is a nullable throwable, but android.util.Log's 1st argument is a string TAG to represent your collection, and the 2nd parameter is the actual print statement.

# Testing

## Unit testing


## Manual testing

# Affected code checklist

- [ ] Notifications
  - [ ] Display
  - [ ] Open
  - [ ] Push Processing
  - [ ] Confirm Deliveries
- [ ] Outcomes
- [ ] Sessions
- [ ] In-App Messaging
- [ ] REST API requests
- [ ] Public API changes

# Checklist

## Overview

- [ ] I have filled out all **REQUIRED** sections above
- [ ] PR does one thing
- [ ] Any Public API changes are explained in the PR details and conform to existing APIs

## Testing

- [ ] I have included test coverage for these changes, or explained why they are not needed
- [ ] All automated tests pass, or I explained why that is not possible
- [ ] I have personally tested this on my device, or explained why that is not possible

## Final pass

- [ ] Code is as readable as possible.
- [ ] I have reviewed this PR myself, ensuring it meets each checklist item

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/OneSignal/react-native-onesignal/1806)
<!-- Reviewable:end -->
