### PR TITLE
Release 5.2.11

### DIFF
--- a/android/src/main/java/com/onesignal/rnonesignalandroid/RNOneSignal.java
+++ b/android/src/main/java/com/onesignal/rnonesignalandroid/RNOneSignal.java
@@ -229,7 +229,7 @@ public class RNOneSignal extends ReactContextBaseJavaModule implements
     public void initialize(String appId) {
         Context context = mReactApplicationContext.getCurrentActivity();
         OneSignalWrapper.setSdkType("reactnative");
-        OneSignalWrapper.setSdkVersion("050210");
+        OneSignalWrapper.setSdkVersion("050211");
 
         if (oneSignalInitDone) {
             Logging.debug("Already initialized the OneSignal React-Native SDK", null);

--- a/ios/RCTOneSignal/RCTOneSignal.m
+++ b/ios/RCTOneSignal/RCTOneSignal.m
@@ -47,7 +47,7 @@ OSNotificationClickResult* coldStartOSNotificationClickResult;
         return;
 
     OneSignalWrapper.sdkType = @"reactnative";
-    OneSignalWrapper.sdkVersion = @"050210"; 
+    OneSignalWrapper.sdkVersion = @"050211"; 
     // initialize the SDK with a nil app ID so cold start click listeners can be triggered
     [OneSignal initialize:nil withLaunchOptions:launchOptions];
     didInitialize = true;

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-native-onesignal",
-  "version": "5.2.10",
+  "version": "5.2.11",
   "description": "React Native OneSignal SDK",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/react-native-onesignal.podspec
+++ b/react-native-onesignal.podspec
@@ -22,5 +22,5 @@ Pod::Spec.new do |s|
   # pod 'React', :path => '../node_modules/react-native/'
 
   # The Native OneSignal-iOS-SDK XCFramework from cocoapods.
-  s.dependency 'OneSignalXCFramework', '5.2.11'
+  s.dependency 'OneSignalXCFramework', '5.2.10'
 end


### PR DESCRIPTION
Channels: Current

### 🐛 Bug Fixes
- Android: don't crash when logging, and follow the log level set by developers (#1806)

---------

### 🛠️ Native Dependency Updates
**Update Android SDK from 5.1.29 to 5.1.33 | select fixes listed**
- [Fix] very rare bug where app doesn't opening from notification tap when it cold starts the app, affects Samsung and Redmi (https://github.com/OneSignal/OneSignal-Android-SDK/pull/2289)
- IAM not showing fixes: (https://github.com/OneSignal/OneSignal-Android-SDK/pull/2287) and (https://github.com/OneSignal/OneSignal-Android-SDK/pull/2284)
- Fix: ANR fixes (https://github.com/OneSignal/OneSignal-Android-SDK/pull/2281)
- See [release notes](https://github.com/OneSignal/OneSignal-Android-SDK/releases) for full details.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/OneSignal/react-native-onesignal/1809)
<!-- Reviewable:end -->
