### PR TITLE
Release 5.2.12

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -31,7 +31,7 @@ dependencies {
 
     // api is used instead of implementation so the parent :app project can access any of the OneSignal Java
     //   classes if needed. Such as com.onesignal.NotificationExtenderService
-    api 'com.onesignal:OneSignal:5.1.33'
+    api 'com.onesignal:OneSignal:5.1.34'
     
     testImplementation 'junit:junit:4.12'
 }

--- a/android/src/main/java/com/onesignal/rnonesignalandroid/RNOneSignal.java
+++ b/android/src/main/java/com/onesignal/rnonesignalandroid/RNOneSignal.java
@@ -229,7 +229,7 @@ public class RNOneSignal extends ReactContextBaseJavaModule implements
     public void initialize(String appId) {
         Context context = mReactApplicationContext.getCurrentActivity();
         OneSignalWrapper.setSdkType("reactnative");
-        OneSignalWrapper.setSdkVersion("050211");
+        OneSignalWrapper.setSdkVersion("050212");
 
         if (oneSignalInitDone) {
             Logging.debug("Already initialized the OneSignal React-Native SDK", null);

--- a/ios/RCTOneSignal/RCTOneSignal.m
+++ b/ios/RCTOneSignal/RCTOneSignal.m
@@ -47,7 +47,7 @@ OSNotificationClickResult* coldStartOSNotificationClickResult;
         return;
 
     OneSignalWrapper.sdkType = @"reactnative";
-    OneSignalWrapper.sdkVersion = @"050211"; 
+    OneSignalWrapper.sdkVersion = @"050212"; 
     // initialize the SDK with a nil app ID so cold start click listeners can be triggered
     [OneSignal initialize:nil withLaunchOptions:launchOptions];
     didInitialize = true;

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-native-onesignal",
-  "version": "5.2.11",
+  "version": "5.2.12",
   "description": "React Native OneSignal SDK",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/react-native-onesignal.podspec
+++ b/react-native-onesignal.podspec
@@ -22,5 +22,5 @@ Pod::Spec.new do |s|
   # pod 'React', :path => '../node_modules/react-native/'
 
   # The Native OneSignal-iOS-SDK XCFramework from cocoapods.
-  s.dependency 'OneSignalXCFramework', '5.2.10'
+  s.dependency 'OneSignalXCFramework', '5.2.12'
 end

--- a/react-native-onesignal.podspec
+++ b/react-native-onesignal.podspec
@@ -22,5 +22,5 @@ Pod::Spec.new do |s|
   # pod 'React', :path => '../node_modules/react-native/'
 
   # The Native OneSignal-iOS-SDK XCFramework from cocoapods.
-  s.dependency 'OneSignalXCFramework', '5.2.12'
+  s.dependency 'OneSignalXCFramework', '5.2.13'
 end


### PR DESCRIPTION
Channels: Current

### 🛠️ Native Dependency Updates Only
**Update Android SDK from 5.1.33 to 5.1.34**
- https://github.com/OneSignal/OneSignal-Android-SDK/pull/2305
- https://github.com/OneSignal/OneSignal-Android-SDK/pull/2304
- https://github.com/OneSignal/OneSignal-Android-SDK/pull/2296
- See [release notes](https://github.com/OneSignal/OneSignal-Android-SDK/releases) for full details.

**Update iOS SDK from 5.2.10 to 5.2.12**
- https://github.com/OneSignal/OneSignal-iOS-SDK/pull/1554
- https://github.com/OneSignal/OneSignal-iOS-SDK/pull/1559
- https://github.com/OneSignal/OneSignal-iOS-SDK/pull/1568
- https://github.com/OneSignal/OneSignal-iOS-SDK/pull/1565
- See [release notes](https://github.com/OneSignal/OneSignal-iOS-SDK/releases) for full details.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/OneSignal/react-native-onesignal/1814)
<!-- Reviewable:end -->
