### PR TITLE
docs(typo): Fix live activities typo

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -157,7 +157,7 @@ export namespace OneSignal {
 
   export namespace LiveActivities {
     /**
-     * Indicate this device has exited a live activity, identified within OneSignal by the `activityId`.
+     * Indicate this device has entered a live activity, identified within OneSignal by the `activityId`.
      *
      * Only applies to iOS
      *


### PR DESCRIPTION
# Description

## One Line Summary
 Fix typo where the description for Live Activities `exit` says enter.

## Details

### Motivation
Typo

# Testing
None

# Affected code checklist

- [ ] Notifications
  - [ ] Display
  - [ ] Open
  - [ ] Push Processing
  - [ ] Confirm Deliveries
- [ ] Outcomes
- [ ] Sessions
- [ ] In-App Messaging
- [ ] REST API requests
- [ ] Public API changes

# Checklist

## Overview

- [ ] I have filled out all **REQUIRED** sections above
- [ ] PR does one thing
- [ ] Any Public API changes are explained in the PR details and conform to existing APIs

## Testing

- [ ] I have included test coverage for these changes, or explained why they are not needed
- [ ] All automated tests pass, or I explained why that is not possible
- [ ] I have personally tested this on my device, or explained why that is not possible

## Final pass

- [ ] Code is as readable as possible.
- [ ] I have reviewed this PR myself, ensuring it meets each checklist item

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/OneSignal/react-native-onesignal/1819)
<!-- Reviewable:end -->
