### PR TITLE
Release 5.2.13

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -31,7 +31,7 @@ dependencies {
 
     // api is used instead of implementation so the parent :app project can access any of the OneSignal Java
     //   classes if needed. Such as com.onesignal.NotificationExtenderService
-    api 'com.onesignal:OneSignal:5.1.34'
+    api 'com.onesignal:OneSignal:5.1.35'
     
     testImplementation 'junit:junit:4.12'
 }

--- a/android/src/main/java/com/onesignal/rnonesignalandroid/RNOneSignal.java
+++ b/android/src/main/java/com/onesignal/rnonesignalandroid/RNOneSignal.java
@@ -229,7 +229,7 @@ public class RNOneSignal extends ReactContextBaseJavaModule implements
     public void initialize(String appId) {
         Context context = mReactApplicationContext.getCurrentActivity();
         OneSignalWrapper.setSdkType("reactnative");
-        OneSignalWrapper.setSdkVersion("050212");
+        OneSignalWrapper.setSdkVersion("050213");
 
         if (oneSignalInitDone) {
             Logging.debug("Already initialized the OneSignal React-Native SDK", null);

--- a/ios/RCTOneSignal/RCTOneSignal.m
+++ b/ios/RCTOneSignal/RCTOneSignal.m
@@ -47,7 +47,7 @@ OSNotificationClickResult* coldStartOSNotificationClickResult;
         return;
 
     OneSignalWrapper.sdkType = @"reactnative";
-    OneSignalWrapper.sdkVersion = @"050212"; 
+    OneSignalWrapper.sdkVersion = @"050213"; 
     // initialize the SDK with a nil app ID so cold start click listeners can be triggered
     [OneSignal initialize:nil withLaunchOptions:launchOptions];
     didInitialize = true;

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-native-onesignal",
-  "version": "5.2.12",
+  "version": "5.2.13",
   "description": "React Native OneSignal SDK",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/react-native-onesignal.podspec
+++ b/react-native-onesignal.podspec
@@ -22,5 +22,5 @@ Pod::Spec.new do |s|
   # pod 'React', :path => '../node_modules/react-native/'
 
   # The Native OneSignal-iOS-SDK XCFramework from cocoapods.
-  s.dependency 'OneSignalXCFramework', '5.2.13'
+  s.dependency 'OneSignalXCFramework', '5.2.14'
 end


### PR DESCRIPTION
Channels: Current

### 🛠️ Native Dependency Updates Only
**Update Android SDK from 5.1.34 to 5.1.35**
- https://github.com/OneSignal/OneSignal-Android-SDK/pull/2333
- https://github.com/OneSignal/OneSignal-Android-SDK/pull/2330
- https://github.com/OneSignal/OneSignal-Android-SDK/pull/2328
- https://github.com/OneSignal/OneSignal-Android-SDK/pull/2329
- https://github.com/OneSignal/OneSignal-Android-SDK/pull/2327
- https://github.com/OneSignal/OneSignal-Android-SDK/pull/2332
- See [release notes](https://github.com/OneSignal/OneSignal-Android-SDK/releases) for full details.

**Update iOS SDK from 5.2.13 to 5.2.14**
- https://github.com/OneSignal/OneSignal-iOS-SDK/pull/1573
- See [release notes](https://github.com/OneSignal/OneSignal-iOS-SDK/releases) for full details.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/OneSignal/react-native-onesignal/1823)
<!-- Reviewable:end -->
