### PR TITLE
ci: add lint pr title workflow

### DIFF
--- a/.github/workflows/lint-pr-title.yml
+++ b/.github/workflows/lint-pr-title.yml
@@ -1,0 +1,11 @@
+# Checks if the PR title follows semantic commit message conventions
+name: Lint PR
+
+on:
+  pull_request_target:
+    types: [opened, edited, reopened]
+
+jobs:
+  lint-pr-title:
+    uses: OneSignal/sdk-actions/.github/workflows/lint-pr-title.yml@main
+    secrets: inherit


### PR DESCRIPTION
# Description
## One Line Summary
- use shared lint pr title workflow

## Details
- added the shared pr title tool here:
https://github.com/OneSignal/sdk-actions/blob/main/.github/workflows/lint-pr-title.yml

### Motivation
- want to reuse as much as we cane

<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/OneSignal/react-native-onesignal/1847)
<!-- Reviewable:end -->
