### PR TITLE
chore(example): cleanup event listeners

### DIFF
--- a/examples/RNOneSignalTS/OSDemo.tsx
+++ b/examples/RNOneSignalTS/OSDemo.tsx
@@ -26,6 +26,72 @@ export interface State {
 }
 
 class OSDemo extends React.Component<Props, State> {
+  // Event listener references for cleanup
+  private onForegroundWillDisplay = (event: any) => {
+    this.OSLog('OneSignal: notification will show in foreground:', event);
+    let notif = event.getNotification();
+
+    const cancelButton = {
+      text: 'Cancel',
+      onPress: () => {
+        event.preventDefault();
+      },
+      style: 'cancel',
+    };
+
+    const completeButton = {
+      text: 'Display',
+      onPress: () => {
+        event.getNotification().display();
+      },
+    };
+
+    Alert.alert(
+      'Display notification?',
+      notif.title,
+      [cancelButton, completeButton],
+      {
+        cancelable: true,
+      },
+    );
+  };
+
+  private onNotificationClick = (event: any) => {
+    this.OSLog('OneSignal: notification clicked:', event);
+  };
+
+  private onIAMClick = (event: any) => {
+    this.OSLog('OneSignal IAM clicked:', event);
+  };
+
+  private onIAMWillDisplay = (event: any) => {
+    this.OSLog('OneSignal: will display IAM: ', event);
+  };
+
+  private onIAMDidDisplay = (event: any) => {
+    this.OSLog('OneSignal: did display IAM: ', event);
+  };
+
+  private onIAMWillDismiss = (event: any) => {
+    this.OSLog('OneSignal: will dismiss IAM: ', event);
+  };
+
+  private onIAMDidDismiss = (event: any) => {
+    this.OSLog('OneSignal: did dismiss IAM: ', event);
+  };
+
+  private onSubscriptionChange = (subscription: any) => {
+    this.OSLog('OneSignal: subscription changed:', subscription);
+  };
+
+  private onPermissionChange = (granted: any) => {
+    this.OSLog('OneSignal: permission changed:', granted);
+  };
+
+  private onUserChange = (event: any) => {
+    this.OSLog('OneSignal: user changed: ', event);
+  };
+
   constructor(props: Props) {
     super(props);
 
@@ -46,76 +112,30 @@ class OSDemo extends React.Component<Props, State> {
     //   enablePushToUpdate: true,
     // });
 
-    OneSignal.Notifications.addEventListener(
-      'foregroundWillDisplay',
-      (event) => {
-        this.OSLog('OneSignal: notification will show in foreground:', event);
-        let notif = event.getNotification();
+    OneSignal.Notifications.addEventListener('foregroundWillDisplay', this.onForegroundWillDisplay);
+    OneSignal.Notifications.addEventListener('click', this.onNotificationClick);
+    OneSignal.InAppMessages.addEventListener('click', this.onIAMClick);
+    OneSignal.InAppMessages.addEventListener('willDisplay', this.onIAMWillDisplay);
+    OneSignal.InAppMessages.addEventListener('didDisplay', this.onIAMDidDisplay);
+    OneSignal.InAppMessages.addEventListener('willDismiss', this.onIAMWillDismiss);
+    OneSignal.InAppMessages.addEventListener('didDismiss', this.onIAMDidDismiss);
+    OneSignal.User.pushSubscription.addEventListener('change', this.onSubscriptionChange);
+    OneSignal.Notifications.addEventListener('permissionChange', this.onPermissionChange);
+    OneSignal.User.addEventListener('change', this.onUserChange);
+  }
 
-        const cancelButton = {
-          text: 'Cancel',
-          onPress: () => {
-            event.preventDefault();
-          },
-          style: 'cancel',
-        };
-
-        const completeButton = {
-          text: 'Display',
-          onPress: () => {
-            event.getNotification().display();
-          },
-        };
-
-        Alert.alert(
-          'Display notification?',
-          notif.title,
-          [cancelButton, completeButton],
-          {
-            cancelable: true,
-          },
-        );
-      },
-    );
-
-    OneSignal.Notifications.addEventListener('click', (event) => {
-      this.OSLog('OneSignal: notification clicked:', event);
-    });
-
-    OneSignal.InAppMessages.addEventListener('click', (event) => {
-      this.OSLog('OneSignal IAM clicked:', event);
-    });
-
-    OneSignal.InAppMessages.addEventListener('willDisplay', (event) => {
-      this.OSLog('OneSignal: will display IAM: ', event);
-    });
-
-    OneSignal.InAppMessages.addEventListener('didDisplay', (event) => {
-      this.OSLog('OneSignal: did display IAM: ', event);
-    });
-
-    OneSignal.InAppMessages.addEventListener('willDismiss', (event) => {
-      this.OSLog('OneSignal: will dismiss IAM: ', event);
-    });
-
-    OneSignal.InAppMessages.addEventListener('didDismiss', (event) => {
-      this.OSLog('OneSignal: did dismiss IAM: ', event);
-    });
-
-    OneSignal.User.pushSubscription.addEventListener(
-      'change',
-      (subscription) => {
-        this.OSLog('OneSignal: subscription changed:', subscription);
-      },
-    );
-
-    OneSignal.Notifications.addEventListener('permissionChange', (granted) => {
-      this.OSLog('OneSignal: permission changed:', granted);
-    });
-
-    OneSignal.User.addEventListener('change', (event) => {
-      this.OSLog('OneSignal: user changed: ', event);
-    });
+  componentWillUnmount() {
+    // Clean up all event listeners
+    OneSignal.Notifications.removeEventListener('foregroundWillDisplay', this.onForegroundWillDisplay);
+    OneSignal.Notifications.removeEventListener('click', this.onNotificationClick);
+    OneSignal.InAppMessages.removeEventListener('click', this.onIAMClick);
+    OneSignal.InAppMessages.removeEventListener('willDisplay', this.onIAMWillDisplay);
+    OneSignal.InAppMessages.removeEventListener('didDisplay', this.onIAMDidDisplay);
+    OneSignal.InAppMessages.removeEventListener('willDismiss', this.onIAMWillDismiss);
+    OneSignal.InAppMessages.removeEventListener('didDismiss', this.onIAMDidDismiss);
+    OneSignal.User.pushSubscription.removeEventListener('change', this.onSubscriptionChange);
+    OneSignal.Notifications.removeEventListener('permissionChange', this.onPermissionChange);
+    OneSignal.User.removeEventListener('change', this.onUserChange);
   }
 
   OSLog = (message: string, optionalArg: any = null) => {

--- a/examples/RNOneSignalTS/OSDemo.tsx
+++ b/examples/RNOneSignalTS/OSDemo.tsx
@@ -112,29 +112,74 @@ class OSDemo extends React.Component<Props, State> {
     //   enablePushToUpdate: true,
     // });
 
-    OneSignal.Notifications.addEventListener('foregroundWillDisplay', this.onForegroundWillDisplay);
+    OneSignal.Notifications.addEventListener(
+      'foregroundWillDisplay',
+      this.onForegroundWillDisplay,
+    );
     OneSignal.Notifications.addEventListener('click', this.onNotificationClick);
     OneSignal.InAppMessages.addEventListener('click', this.onIAMClick);
-    OneSignal.InAppMessages.addEventListener('willDisplay', this.onIAMWillDisplay);
-    OneSignal.InAppMessages.addEventListener('didDisplay', this.onIAMDidDisplay);
-    OneSignal.InAppMessages.addEventListener('willDismiss', this.onIAMWillDismiss);
-    OneSignal.InAppMessages.addEventListener('didDismiss', this.onIAMDidDismiss);
-    OneSignal.User.pushSubscription.addEventListener('change', this.onSubscriptionChange);
-    OneSignal.Notifications.addEventListener('permissionChange', this.onPermissionChange);
+    OneSignal.InAppMessages.addEventListener(
+      'willDisplay',
+      this.onIAMWillDisplay,
+    );
+    OneSignal.InAppMessages.addEventListener(
+      'didDisplay',
+      this.onIAMDidDisplay,
+    );
+    OneSignal.InAppMessages.addEventListener(
+      'willDismiss',
+      this.onIAMWillDismiss,
+    );
+    OneSignal.InAppMessages.addEventListener(
+      'didDismiss',
+      this.onIAMDidDismiss,
+    );
+    OneSignal.User.pushSubscription.addEventListener(
+      'change',
+      this.onSubscriptionChange,
+    );
+    OneSignal.Notifications.addEventListener(
+      'permissionChange',
+      this.onPermissionChange,
+    );
     OneSignal.User.addEventListener('change', this.onUserChange);
   }
 
   componentWillUnmount() {
     // Clean up all event listeners
-    OneSignal.Notifications.removeEventListener('foregroundWillDisplay', this.onForegroundWillDisplay);
-    OneSignal.Notifications.removeEventListener('click', this.onNotificationClick);
+    OneSignal.Notifications.removeEventListener(
+      'foregroundWillDisplay',
+      this.onForegroundWillDisplay,
+    );
+    OneSignal.Notifications.removeEventListener(
+      'click',
+      this.onNotificationClick,
+    );
     OneSignal.InAppMessages.removeEventListener('click', this.onIAMClick);
-    OneSignal.InAppMessages.removeEventListener('willDisplay', this.onIAMWillDisplay);
-    OneSignal.InAppMessages.removeEventListener('didDisplay', this.onIAMDidDisplay);
-    OneSignal.InAppMessages.removeEventListener('willDismiss', this.onIAMWillDismiss);
-    OneSignal.InAppMessages.removeEventListener('didDismiss', this.onIAMDidDismiss);
-    OneSignal.User.pushSubscription.removeEventListener('change', this.onSubscriptionChange);
-    OneSignal.Notifications.removeEventListener('permissionChange', this.onPermissionChange);
+    OneSignal.InAppMessages.removeEventListener(
+      'willDisplay',
+      this.onIAMWillDisplay,
+    );
+    OneSignal.InAppMessages.removeEventListener(
+      'didDisplay',
+      this.onIAMDidDisplay,
+    );
+    OneSignal.InAppMessages.removeEventListener(
+      'willDismiss',
+      this.onIAMWillDismiss,
+    );
+    OneSignal.InAppMessages.removeEventListener(
+      'didDismiss',
+      this.onIAMDidDismiss,
+    );
+    OneSignal.User.pushSubscription.removeEventListener(
+      'change',
+      this.onSubscriptionChange,
+    );
+    OneSignal.Notifications.removeEventListener(
+      'permissionChange',
+      this.onPermissionChange,
+    );
     OneSignal.User.removeEventListener('change', this.onUserChange);
   }
 


### PR DESCRIPTION


# Description

## One Line Summary

The OSDemo component was registering 10 event listeners but never removing them during clean up. This change updates the example to provide an instance of best practices for anyone using it as a reference.

## Details

### Motivation

I noticed this while testing some other event listener behavior in the library.

### Scope

Scope is limited to the example app we provide in the repo.

# Affected code checklist

- [ ] Notifications
  - [ ] Display
  - [ ] Open
  - [ ] Push Processing
  - [ ] Confirm Deliveries
- [ ] Outcomes
- [ ] Sessions
- [ ] In-App Messaging
- [ ] REST API requests
- [ ] Public API changes

# Checklist

## Overview

- [x] I have filled out all **REQUIRED** sections above
- [x] PR does one thing
  - If it is hard to explain how any codes changes are related to each other then it most likely needs to be more than one PR
- [x] Any Public API changes are explained in the PR details and conform to existing APIs

## Testing

- [x] I have included test coverage for these changes, or explained why they are not needed
- [x] All automated tests pass, or I explained why that is not possible
- [x] I have personally tested this on my device, or explained why that is not possible

## Final pass

- [x] Code is as readable as possible.
  - Simplify with less code, followed by splitting up code into well named functions and variables, followed by adding comments to the code.
- [x] I have reviewed this PR myself, ensuring it meets each checklist item
  - WIP (Work In Progress) is ok, but explain what is still in progress and what you would like feedback on. Start the PR title with "WIP" to indicate this.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/OneSignal/react-native-onesignal/1848)
<!-- Reviewable:end -->
