### PR TITLE
ci: remove extraneous inputs from release workflow

### DIFF
--- a/.github/workflows/create-release-pr.yml
+++ b/.github/workflows/create-release-pr.yml
@@ -66,7 +66,6 @@ jobs:
           cd examples/RNOneSignalTS
           bun install --frozen-lockfile
 
-
       - name: Get current native SDK versions
         id: current_versions
         run: |
@@ -142,8 +141,6 @@ jobs:
     uses: OneSignal/sdk-actions/.github/workflows/create-release.yml@main
     with:
       release_branch: ${{ needs.prep.outputs.release_branch }}
-      version_from: ${{ needs.update-version.outputs.rn_from }}
-      version_to: ${{ inputs.rn_version }}
       android_from: ${{ needs.update-version.outputs.android_from }}
       android_to: ${{ inputs.android_version }}
       ios_from: ${{ needs.update-version.outputs.ios_from }}

--- a/.github/workflows/create-release-pr.yml
+++ b/.github/workflows/create-release-pr.yml
@@ -16,6 +16,11 @@ on:
         description: 'New iOS SDK Version (e.g., 1.5.0). Leave blank to skip.'
         required: false
         type: string
+      target_branch:
+        description: 'Target branch to create the release PR on. Defaults to main.'
+        required: false
+        type: string
+        default: main
 
   # For making a release pr from cordova github actions
   workflow_dispatch:
@@ -32,6 +37,11 @@ on:
         description: 'New iOS SDK Version (e.g., 1.5.0). Leave blank to skip.'
         required: false
         type: string
+      target_branch:
+        description: 'Target branch to create the release PR on. Defaults to main.'
+        required: false
+        type: string
+        default: main
 
 jobs:
   prep:
@@ -141,6 +151,7 @@ jobs:
     uses: OneSignal/sdk-actions/.github/workflows/create-release.yml@main
     with:
       release_branch: ${{ needs.prep.outputs.release_branch }}
+      target_branch: ${{ inputs.target_branch }}
       android_from: ${{ needs.update-version.outputs.android_from }}
       android_to: ${{ inputs.android_version }}
       ios_from: ${{ needs.update-version.outputs.ios_from }}


### PR DESCRIPTION
# Description
## One Line Summary
- remove version_from & version_to inputs for release workflow, also adds target branch input

# Affected code checklist
   - [ ] Notifications
      - [ ] Display
      - [ ] Open
      - [ ] Push Processing
      - [ ] Confirm Deliveries
   - [ ] Outcomes
   - [ ] Sessions
   - [ ] In-App Messaging
   - [ ] REST API requests
   - [ ] Public API changes

# Checklist

## Overview

- [ ] I have filled out all **REQUIRED** sections above
- [ ] PR does one thing
  - If it is hard to explain how any codes changes are related to each other then it most likely needs to be more than one PR
- [ ] Any Public API changes are explained in the PR details and conform to existing APIs

## Testing

- [ ] I have included test coverage for these changes, or explained why they are not needed
- [ ] All automated tests pass, or I explained why that is not possible
- [ ] I have personally tested this on my device, or explained why that is not possible

## Final pass

- [ ] Code is as readable as possible.
  - Simplify with less code, followed by splitting up code into well named functions and variables, followed by adding comments to the code.
- [ ] I have reviewed this PR myself, ensuring it meets each checklist item
  - WIP (Work In Progress) is ok, but explain what is still in progress and what you would like feedback on. Start the PR title with "WIP" to indicate this.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/OneSignal/react-native-onesignal/1854)
<!-- Reviewable:end -->
