### PR TITLE
test: add event manager tests

### DIFF
--- a/__mocks__/react-native.ts
+++ b/__mocks__/react-native.ts
@@ -1,5 +1,28 @@
 import { vi } from 'vitest';
 
+export const createEmitterSubscriptionMock = (
+  eventName: string,
+  callback: (payload: unknown) => void,
+) => ({
+  remove: vi.fn(),
+  emitter: {
+    addListener: vi.fn(),
+    removeAllListeners: vi.fn(),
+    listenerCount: vi.fn(() => 1),
+    emit: vi.fn(),
+  },
+  listener: () => callback,
+  context: undefined,
+  eventType: eventName,
+  key: 0,
+  subscriber: {
+    addSubscription: vi.fn(),
+    removeSubscription: vi.fn(),
+    removeAllSubscriptions: vi.fn(),
+    getSubscriptionsForType: vi.fn(),
+  },
+});
+
 const mockRNOneSignal = {
   initialize: vi.fn(),
   login: vi.fn(),
@@ -79,10 +102,8 @@ export { mockPlatform, mockRNOneSignal };
 export class NativeEventEmitter {
   constructor(_nativeModule: typeof mockRNOneSignal) {}
 
-  addListener(_eventName: string, _callback: (payload: unknown) => void) {
-    return {
-      remove: vi.fn(),
-    };
+  addListener(eventName: string, callback: (payload: unknown) => void) {
+    return createEmitterSubscriptionMock(eventName, callback);
   }
 
   removeListener(_eventName: string, _callback: (payload: unknown) => void) {

--- a/__mocks__/react-native.ts
+++ b/__mocks__/react-native.ts
@@ -61,6 +61,7 @@ const mockRNOneSignal = {
   addOutcome: vi.fn(),
   addUniqueOutcome: vi.fn(),
   addOutcomeWithValue: vi.fn(),
+  displayNotification: vi.fn(),
 };
 
 const mockPlatform = {

--- a/src/OSNotification.test.ts
+++ b/src/OSNotification.test.ts
@@ -1,0 +1,242 @@
+import { NativeModules, Platform } from 'react-native';
+import OSNotification, { type BaseNotificationData } from './OSNotification';
+
+const mockRNOneSignal = NativeModules.OneSignal;
+const mockPlatform = Platform;
+
+describe('OSNotification', () => {
+  const baseNotificationData: BaseNotificationData = {
+    body: 'Test notification body',
+    sound: 'default',
+    title: 'Test Title',
+    launchURL: 'https://example.com',
+    rawPayload: { key: 'value' },
+    actionButtons: [{ id: 'btn1', text: 'Button 1' }],
+    additionalData: { custom: 'data' },
+    notificationId: 'test-notification-id',
+  };
+
+  beforeEach(() => {
+    mockPlatform.OS = 'ios';
+    mockRNOneSignal.displayNotification.mockClear();
+  });
+
+  describe('constructor', () => {
+    test('should initialize common properties', () => {
+      const notification = new OSNotification(baseNotificationData);
+
+      expect(notification.body).toBe('Test notification body');
+      expect(notification.sound).toBe('default');
+      expect(notification.title).toBe('Test Title');
+      expect(notification.launchURL).toBe('https://example.com');
+      expect(notification.rawPayload).toEqual({ key: 'value' });
+      expect(notification.actionButtons).toEqual([
+        { id: 'btn1', text: 'Button 1' },
+      ]);
+      expect(notification.additionalData).toEqual({ custom: 'data' });
+      expect(notification.notificationId).toBe('test-notification-id');
+    });
+
+    test('should initialize with optional common properties as undefined', () => {
+      const notificationData = {
+        body: 'Test body',
+        rawPayload: '',
+        notificationId: 'id-123',
+      };
+      const notification = new OSNotification(notificationData);
+
+      expect(notification.body).toBe('Test body');
+      expect(notification.sound).toBeUndefined();
+      expect(notification.title).toBeUndefined();
+      expect(notification.launchURL).toBeUndefined();
+      expect(notification.actionButtons).toBeUndefined();
+      expect(notification.additionalData).toBeUndefined();
+    });
+
+    describe('Android-specific properties', () => {
+      beforeEach(() => {
+        mockPlatform.OS = 'android';
+      });
+
+      test('should initialize Android-specific properties on Android platform', () => {
+        const androidData = {
+          ...baseNotificationData,
+          groupKey: 'group-1',
+          groupMessage: 'group message',
+          ledColor: 'FFFF0000',
+          priority: 2,
+          smallIcon: 'icon_small',
+          largeIcon: 'icon_large',
+          bigPicture: 'image_url',
+          collapseId: 'collapse-1',
+          fromProjectNumber: '123456789',
+          smallIconAccentColor: 'FFFF0000',
+          lockScreenVisibility: '1',
+          androidNotificationId: 456,
+        };
+        const notification = new OSNotification(androidData);
+
+        expect(notification.groupKey).toBe('group-1');
+        expect(notification.groupMessage).toBe('group message');
+        expect(notification.ledColor).toBe('FFFF0000');
+        expect(notification.priority).toBe(2);
+        expect(notification.smallIcon).toBe('icon_small');
+        expect(notification.largeIcon).toBe('icon_large');
+        expect(notification.bigPicture).toBe('image_url');
+        expect(notification.collapseId).toBe('collapse-1');
+        expect(notification.fromProjectNumber).toBe('123456789');
+        expect(notification.smallIconAccentColor).toBe('FFFF0000');
+        expect(notification.lockScreenVisibility).toBe('1');
+        expect(notification.androidNotificationId).toBe(456);
+      });
+
+      test('should not set iOS-specific properties on Android', () => {
+        const notification = new OSNotification(baseNotificationData);
+
+        expect(notification.badge).toBeUndefined();
+        expect(notification.badgeIncrement).toBeUndefined();
+        expect(notification.category).toBeUndefined();
+        expect(notification.threadId).toBeUndefined();
+        expect(notification.subtitle).toBeUndefined();
+        expect(notification.templateId).toBeUndefined();
+        expect(notification.templateName).toBeUndefined();
+        expect(notification.attachments).toBeUndefined();
+        expect(notification.mutableContent).toBeUndefined();
+        expect(notification.contentAvailable).toBeUndefined();
+        expect(notification.relevanceScore).toBeUndefined();
+        expect(notification.interruptionLevel).toBeUndefined();
+      });
+    });
+
+    describe('iOS-specific properties', () => {
+      beforeEach(() => {
+        mockPlatform.OS = 'ios';
+      });
+
+      test('should initialize iOS-specific properties on iOS platform', () => {
+        const iosData = {
+          ...baseNotificationData,
+          badge: '1',
+          badgeIncrement: '5',
+          category: 'NOTIFICATION_CATEGORY',
+          threadId: 'thread-123',
+          subtitle: 'Test Subtitle',
+          templateId: 'template-1',
+          templateName: 'template-name',
+          attachments: { key: 'attachment-value' },
+          mutableContent: true,
+          contentAvailable: '1',
+          relevanceScore: 0.9,
+          interruptionLevel: 'timeSensitive',
+        };
+        const notification = new OSNotification(iosData);
+
+        expect(notification.badge).toBe('1');
+        expect(notification.badgeIncrement).toBe('5');
+        expect(notification.category).toBe('NOTIFICATION_CATEGORY');
+        expect(notification.threadId).toBe('thread-123');
+        expect(notification.subtitle).toBe('Test Subtitle');
+        expect(notification.templateId).toBe('template-1');
+        expect(notification.templateName).toBe('template-name');
+        expect(notification.attachments).toEqual({ key: 'attachment-value' });
+        expect(notification.mutableContent).toBe(true);
+        expect(notification.contentAvailable).toBe('1');
+        expect(notification.relevanceScore).toBe(0.9);
+        expect(notification.interruptionLevel).toBe('timeSensitive');
+      });
+
+      test('should not set Android-specific properties on iOS', () => {
+        const notification = new OSNotification(baseNotificationData);
+
+        expect(notification.groupKey).toBeUndefined();
+        expect(notification.groupMessage).toBeUndefined();
+        expect(notification.ledColor).toBeUndefined();
+        expect(notification.priority).toBeUndefined();
+        expect(notification.smallIcon).toBeUndefined();
+        expect(notification.largeIcon).toBeUndefined();
+        expect(notification.bigPicture).toBeUndefined();
+        expect(notification.collapseId).toBeUndefined();
+        expect(notification.fromProjectNumber).toBeUndefined();
+        expect(notification.smallIconAccentColor).toBeUndefined();
+        expect(notification.lockScreenVisibility).toBeUndefined();
+        expect(notification.androidNotificationId).toBeUndefined();
+      });
+    });
+  });
+
+  describe('display', () => {
+    test('should call native displayNotification with notificationId', () => {
+      const notification = new OSNotification(baseNotificationData);
+      notification.display();
+
+      expect(mockRNOneSignal.displayNotification).toHaveBeenCalledWith(
+        'test-notification-id',
+      );
+    });
+
+    test('should display notification with different notificationId', () => {
+      const notificationID = 'custom-id-789';
+      const notification = new OSNotification({
+        ...baseNotificationData,
+        notificationId: notificationID,
+      });
+      notification.display();
+
+      expect(mockRNOneSignal.displayNotification).toHaveBeenCalledWith(
+        notificationID,
+      );
+    });
+
+    test('should return undefined', () => {
+      const notification = new OSNotification(baseNotificationData);
+      const result = notification.display();
+
+      expect(result).toBeUndefined();
+    });
+  });
+
+  describe('rawPayload types', () => {
+    test('should accept object as rawPayload', () => {
+      const notificationData = {
+        ...baseNotificationData,
+        rawPayload: { key: 'value', nested: { key: 'value' } },
+      };
+      const notification = new OSNotification(notificationData);
+
+      expect(notification.rawPayload).toEqual({
+        key: 'value',
+        nested: { key: 'value' },
+      });
+    });
+
+    test('should accept string as rawPayload', () => {
+      const notificationData = {
+        ...baseNotificationData,
+        rawPayload: '{"key":"value"}',
+      };
+      const notification = new OSNotification(notificationData);
+
+      expect(notification.rawPayload).toBe('{"key":"value"}');
+    });
+
+    test('should accept empty object as rawPayload', () => {
+      const notificationData = {
+        ...baseNotificationData,
+        rawPayload: {},
+      };
+      const notification = new OSNotification(notificationData);
+
+      expect(notification.rawPayload).toEqual({});
+    });
+
+    test('should accept empty string as rawPayload', () => {
+      const notificationData = {
+        ...baseNotificationData,
+        rawPayload: '',
+      };
+      const notification = new OSNotification(notificationData);
+
+      expect(notification.rawPayload).toBe('');
+    });
+  });
+});

--- a/src/OSNotification.ts
+++ b/src/OSNotification.ts
@@ -42,6 +42,8 @@ interface iOSNotificationData extends BaseNotificationData {
   interruptionLevel?: string;
 }
 
+export type OSNotificationData = AndroidNotificationData | iOSNotificationData;
+
 export default class OSNotification {
   body: string;
   sound?: string;
@@ -78,7 +80,7 @@ export default class OSNotification {
   relevanceScore?: number;
   interruptionLevel?: string;
 
-  constructor(receivedEvent: AndroidNotificationData | iOSNotificationData) {
+  constructor(receivedEvent: OSNotificationData) {
     this.body = receivedEvent.body;
     this.sound = receivedEvent.sound;
     this.title = receivedEvent.title;

--- a/src/events/EventManager.test.ts
+++ b/src/events/EventManager.test.ts
@@ -1,0 +1,474 @@
+import { NativeEventEmitter } from 'react-native';
+import { createEmitterSubscriptionMock } from '../../__mocks__/react-native';
+import {
+  IN_APP_MESSAGE_CLICKED,
+  IN_APP_MESSAGE_DID_DISMISS,
+  IN_APP_MESSAGE_DID_DISPLAY,
+  IN_APP_MESSAGE_WILL_DISMISS,
+  IN_APP_MESSAGE_WILL_DISPLAY,
+  NOTIFICATION_CLICKED,
+  NOTIFICATION_WILL_DISPLAY,
+  PERMISSION_CHANGED,
+  SUBSCRIPTION_CHANGED,
+  USER_STATE_CHANGED,
+} from '../constants/events';
+import type { PushSubscriptionChangedState } from '../types/subscription';
+import type { UserChangedState } from '../types/user';
+import EventManager, { type EventListenerMap } from './EventManager';
+import NotificationWillDisplayEvent from './NotificationWillDisplayEvent';
+
+describe('EventManager', () => {
+  let eventManager: EventManager;
+  let mockNativeModule: any;
+  let eventCallbacks: Map<string, (payload: any) => void>;
+
+  const getCallback = <K extends keyof EventListenerMap>(
+    eventName: K,
+  ): ((payload: Parameters<EventListenerMap[K]>[0]) => void) | undefined => {
+    return eventCallbacks.get(eventName) as any;
+  };
+
+  beforeEach(() => {
+    eventCallbacks = new Map();
+
+    mockNativeModule = {
+      addListener: vi.fn(),
+      removeListener: vi.fn(),
+    };
+
+    // Spy on NativeEventEmitter.prototype.addListener to capture callbacks
+    vi.spyOn(NativeEventEmitter.prototype, 'addListener').mockImplementation(
+      (eventName: string, callback: (payload: any) => void) => {
+        eventCallbacks.set(eventName, callback);
+        return createEmitterSubscriptionMock(eventName, callback) as never;
+      },
+    );
+
+    eventManager = new EventManager(mockNativeModule);
+  });
+
+  describe('constructor', () => {
+    test('should initialize with all required properties and listeners', () => {
+      expect(eventManager).toBeDefined();
+      expect(eventManager['RNOneSignal']).toBe(mockNativeModule);
+      expect(eventManager['oneSignalEventEmitter']).toBeDefined();
+      expect(eventManager['eventListenerArrayMap']).toBeInstanceOf(Map);
+
+      const listeners = eventManager['listeners'];
+      const expectedEvents = [
+        PERMISSION_CHANGED,
+        SUBSCRIPTION_CHANGED,
+        USER_STATE_CHANGED,
+        NOTIFICATION_WILL_DISPLAY,
+        NOTIFICATION_CLICKED,
+        IN_APP_MESSAGE_CLICKED,
+        IN_APP_MESSAGE_WILL_DISPLAY,
+        IN_APP_MESSAGE_WILL_DISMISS,
+        IN_APP_MESSAGE_DID_DISMISS,
+        IN_APP_MESSAGE_DID_DISPLAY,
+      ];
+
+      expectedEvents.forEach((eventName) => {
+        expect(listeners[eventName]).toBeDefined();
+      });
+
+      // Verify that eventCallbacks were populated during setup
+      expect(eventCallbacks.size).toBe(10);
+    });
+  });
+
+  describe('setupListeners', () => {
+    test('should register all event listeners with NativeEventEmitter', () => {
+      const eventList = [
+        PERMISSION_CHANGED,
+        SUBSCRIPTION_CHANGED,
+        USER_STATE_CHANGED,
+        NOTIFICATION_WILL_DISPLAY,
+        NOTIFICATION_CLICKED,
+        IN_APP_MESSAGE_CLICKED,
+        IN_APP_MESSAGE_WILL_DISPLAY,
+        IN_APP_MESSAGE_WILL_DISMISS,
+        IN_APP_MESSAGE_DID_DISMISS,
+        IN_APP_MESSAGE_DID_DISPLAY,
+      ];
+
+      eventList.forEach((eventName) => {
+        expect(eventCallbacks.has(eventName)).toBe(true);
+      });
+    });
+
+    test('should not setup listeners if RNOneSignal is null', () => {
+      new EventManager(null as any);
+      expect(mockNativeModule.addListener).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('addEventListener', () => {
+    test('should add a handler to a new event', () => {
+      const handler = vi.fn();
+      eventManager.addEventListener(PERMISSION_CHANGED, handler);
+
+      const handlerArray =
+        eventManager['eventListenerArrayMap'].get(PERMISSION_CHANGED);
+      expect(handlerArray).toContain(handler);
+    });
+
+    test('should add multiple handlers to the same event', () => {
+      const handler1 = vi.fn();
+      const handler2 = vi.fn();
+
+      eventManager.addEventListener(PERMISSION_CHANGED, handler1);
+      eventManager.addEventListener(PERMISSION_CHANGED, handler2);
+
+      const handlerArray =
+        eventManager['eventListenerArrayMap'].get(PERMISSION_CHANGED);
+      expect(handlerArray).toContain(handler1);
+      expect(handlerArray).toContain(handler2);
+      expect(handlerArray?.length).toBe(2);
+    });
+
+    test('should add handlers to different events independently', () => {
+      const handler1 = vi.fn();
+      const handler2 = vi.fn();
+
+      eventManager.addEventListener(PERMISSION_CHANGED, handler1);
+      eventManager.addEventListener(SUBSCRIPTION_CHANGED, handler2);
+
+      const handlerArray1 =
+        eventManager['eventListenerArrayMap'].get(PERMISSION_CHANGED);
+      const handlerArray2 =
+        eventManager['eventListenerArrayMap'].get(SUBSCRIPTION_CHANGED);
+
+      expect(handlerArray1).toContain(handler1);
+      expect(handlerArray2).toContain(handler2);
+    });
+  });
+
+  describe('removeEventListener', () => {
+    test('should remove a handler from an event', () => {
+      const handler = vi.fn();
+      eventManager.addEventListener(PERMISSION_CHANGED, handler);
+      eventManager.removeEventListener(PERMISSION_CHANGED, handler);
+
+      const handlerArray =
+        eventManager['eventListenerArrayMap'].get(PERMISSION_CHANGED);
+      expect(handlerArray).toBeUndefined();
+    });
+
+    test('should remove specific handler when multiple exist', () => {
+      const handler1 = vi.fn();
+      const handler2 = vi.fn();
+      const handler3 = vi.fn();
+
+      eventManager.addEventListener(SUBSCRIPTION_CHANGED, handler1);
+      eventManager.addEventListener(SUBSCRIPTION_CHANGED, handler2);
+      eventManager.addEventListener(SUBSCRIPTION_CHANGED, handler3);
+      eventManager.removeEventListener(SUBSCRIPTION_CHANGED, handler2);
+
+      const handlerArray =
+        eventManager['eventListenerArrayMap'].get(SUBSCRIPTION_CHANGED);
+      expect(handlerArray).toContain(handler1);
+      expect(handlerArray).not.toContain(handler2);
+      expect(handlerArray).toContain(handler3);
+      expect(handlerArray?.length).toBe(2);
+    });
+
+    test('should do nothing if event does not exist', () => {
+      const handler = vi.fn();
+      expect(() => {
+        eventManager.removeEventListener('non-existent-event' as any, handler);
+      }).not.toThrow();
+    });
+
+    test('should do nothing if handler is not in the list', () => {
+      const handler1 = vi.fn();
+      const handler2 = vi.fn();
+
+      eventManager.addEventListener(NOTIFICATION_WILL_DISPLAY, handler1);
+      expect(() => {
+        eventManager.removeEventListener(NOTIFICATION_WILL_DISPLAY, handler2);
+      }).not.toThrow();
+
+      const handlerArray = eventManager['eventListenerArrayMap'].get(
+        NOTIFICATION_WILL_DISPLAY,
+      );
+      expect(handlerArray).toContain(handler1);
+      expect(handlerArray?.length).toBe(1);
+    });
+  });
+
+  describe('generateEventListener', () => {
+    test('should return an EmitterSubscription', () => {
+      const listener =
+        eventManager['generateEventListener'](PERMISSION_CHANGED);
+      expect(listener).toBeDefined();
+      expect(listener.remove).toBeDefined();
+    });
+
+    test('should handle NOTIFICATION_WILL_DISPLAY events', () => {
+      const handler = vi.fn();
+      eventManager.addEventListener(NOTIFICATION_WILL_DISPLAY, handler);
+
+      const callback = getCallback(NOTIFICATION_WILL_DISPLAY);
+
+      const notificationPayload = {
+        notificationId: 'test-id',
+        body: 'test-body',
+        rawPayload: {},
+      };
+
+      callback!(notificationPayload);
+
+      expect(handler).toHaveBeenCalled();
+      const receivedEvent = handler.mock.calls[0][0];
+      expect(receivedEvent).toBeInstanceOf(NotificationWillDisplayEvent);
+    });
+
+    test('should handle PERMISSION_CHANGED events with boolean payload', () => {
+      const handler = vi.fn();
+      eventManager.addEventListener(PERMISSION_CHANGED, handler);
+
+      const callback = getCallback(PERMISSION_CHANGED);
+      callback!({ permission: true });
+
+      expect(handler).toHaveBeenCalledWith(true);
+    });
+
+    test('should handle generic events with object payload', () => {
+      const handler = vi.fn();
+      const payload = {
+        previous: {
+          id: 'previous-id',
+          token: 'previous-token',
+          optedIn: false,
+        },
+        current: {
+          id: 'current-id',
+          token: 'current-token',
+          optedIn: true,
+        },
+      } satisfies PushSubscriptionChangedState;
+
+      eventManager.addEventListener(SUBSCRIPTION_CHANGED, handler);
+
+      const callback = getCallback(SUBSCRIPTION_CHANGED);
+      callback!(payload);
+
+      expect(handler).toHaveBeenCalledWith(payload);
+    });
+
+    test('should call all handlers for an event', () => {
+      const handler1 = vi.fn();
+      const handler2 = vi.fn();
+      const handler3 = vi.fn();
+
+      eventManager.addEventListener(USER_STATE_CHANGED, handler1);
+      eventManager.addEventListener(USER_STATE_CHANGED, handler2);
+      eventManager.addEventListener(USER_STATE_CHANGED, handler3);
+
+      const callback = getCallback(USER_STATE_CHANGED);
+      const payload = {
+        current: { onesignalId: '123', externalId: '456' },
+      } satisfies UserChangedState;
+      callback!(payload);
+
+      expect(handler1).toHaveBeenCalledWith(payload);
+      expect(handler2).toHaveBeenCalledWith(payload);
+      expect(handler3).toHaveBeenCalledWith(payload);
+    });
+
+    test('should do nothing if no handlers are registered', () => {
+      const callback = getCallback(IN_APP_MESSAGE_WILL_DISPLAY);
+
+      expect(() => {
+        callback!({ message: { messageId: 'msg-123' } });
+      }).not.toThrow();
+    });
+
+    test('should handle IN_APP_MESSAGE_CLICKED events', () => {
+      const handler = vi.fn();
+      const payload = {
+        message: { messageId: 'msg-123' },
+        result: { closingMessage: false, actionId: 'action-1' },
+      };
+
+      eventManager.addEventListener(IN_APP_MESSAGE_CLICKED, handler);
+
+      const callback = getCallback(IN_APP_MESSAGE_CLICKED);
+      callback!(payload);
+
+      expect(handler).toHaveBeenCalledWith(payload);
+    });
+
+    test('should handle IN_APP_MESSAGE_WILL_DISPLAY events', () => {
+      const handler = vi.fn();
+      const payload = { message: { messageId: 'msg-123' } };
+
+      eventManager.addEventListener(IN_APP_MESSAGE_WILL_DISPLAY, handler);
+
+      const callback = getCallback(IN_APP_MESSAGE_WILL_DISPLAY);
+      callback!(payload);
+
+      expect(handler).toHaveBeenCalledWith(payload);
+    });
+
+    test('should handle IN_APP_MESSAGE_DID_DISPLAY events', () => {
+      const handler = vi.fn();
+      const payload = { message: { messageId: 'msg-123' } };
+
+      eventManager.addEventListener(IN_APP_MESSAGE_DID_DISPLAY, handler);
+
+      const callback = getCallback(IN_APP_MESSAGE_DID_DISPLAY);
+      callback!(payload);
+
+      expect(handler).toHaveBeenCalledWith(payload);
+    });
+
+    test('should handle IN_APP_MESSAGE_WILL_DISMISS events', () => {
+      const handler = vi.fn();
+      const payload = { message: { messageId: 'msg-123' } };
+
+      eventManager.addEventListener(IN_APP_MESSAGE_WILL_DISMISS, handler);
+
+      const callback = getCallback(IN_APP_MESSAGE_WILL_DISMISS);
+      callback!(payload);
+
+      expect(handler).toHaveBeenCalledWith(payload);
+    });
+
+    test('should handle IN_APP_MESSAGE_DID_DISMISS events', () => {
+      const handler = vi.fn();
+      const payload = { message: { messageId: 'msg-123' } };
+
+      eventManager.addEventListener(IN_APP_MESSAGE_DID_DISMISS, handler);
+
+      const callback = getCallback(IN_APP_MESSAGE_DID_DISMISS);
+      callback!(payload);
+
+      expect(handler).toHaveBeenCalledWith(payload);
+    });
+
+    test('should handle NOTIFICATION_CLICKED events', () => {
+      const handler = vi.fn();
+      const payload = { notificationId: 'notif-123', action: 'clicked' };
+
+      eventManager.addEventListener(NOTIFICATION_CLICKED, handler);
+
+      const callback = getCallback(NOTIFICATION_CLICKED);
+      callback!(payload);
+
+      expect(handler).toHaveBeenCalledWith(payload);
+    });
+  });
+
+  describe('integration scenarios', () => {
+    test('should handle add and remove listener lifecycle', () => {
+      const handler1 = vi.fn();
+      const handler2 = vi.fn();
+
+      // Add handlers
+      eventManager.addEventListener(PERMISSION_CHANGED, handler1);
+      eventManager.addEventListener(PERMISSION_CHANGED, handler2);
+
+      // Trigger event
+      const callback = getCallback(PERMISSION_CHANGED);
+      callback!({ permission: true });
+
+      expect(handler1).toHaveBeenCalledWith(true);
+      expect(handler2).toHaveBeenCalledWith(true);
+
+      // Remove one handler
+      eventManager.removeEventListener(PERMISSION_CHANGED, handler1);
+
+      // Reset mocks
+      handler1.mockClear();
+      handler2.mockClear();
+
+      // Trigger event again
+      callback!({ permission: false });
+
+      expect(handler1).not.toHaveBeenCalled();
+      expect(handler2).toHaveBeenCalledWith(false);
+    });
+
+    test('should handle complex event type scenarios', () => {
+      const permissionHandler = vi.fn();
+      const subscriptionHandler = vi.fn();
+      const notificationWillDisplayHandler = vi.fn();
+
+      eventManager.addEventListener(PERMISSION_CHANGED, permissionHandler);
+      eventManager.addEventListener(SUBSCRIPTION_CHANGED, subscriptionHandler);
+      eventManager.addEventListener(
+        NOTIFICATION_WILL_DISPLAY,
+        notificationWillDisplayHandler,
+      );
+
+      // Get callbacks
+      const permissionCallback = getCallback(PERMISSION_CHANGED);
+      const subscriptionCallback = getCallback(SUBSCRIPTION_CHANGED);
+      const notificationCallback = getCallback(NOTIFICATION_WILL_DISPLAY);
+
+      // Trigger different event types
+      permissionCallback!({ permission: true });
+      subscriptionCallback!({ id: 'sub-123' });
+      notificationCallback!({
+        notificationId: 'notif-123',
+        body: 'test',
+        rawPayload: {},
+      });
+
+      expect(permissionHandler).toHaveBeenCalledWith(true);
+      expect(subscriptionHandler).toHaveBeenCalledWith({ id: 'sub-123' });
+      expect(notificationWillDisplayHandler).toHaveBeenCalled();
+    });
+
+    test('should maintain separate handler arrays for different events', () => {
+      const handler1 = vi.fn();
+      const handler2 = vi.fn();
+      const handler3 = vi.fn();
+
+      eventManager.addEventListener(PERMISSION_CHANGED, handler1);
+      eventManager.addEventListener(SUBSCRIPTION_CHANGED, handler2);
+      eventManager.addEventListener(USER_STATE_CHANGED, handler3);
+
+      const permissionArray =
+        eventManager['eventListenerArrayMap'].get(PERMISSION_CHANGED);
+      const subscriptionArray =
+        eventManager['eventListenerArrayMap'].get(SUBSCRIPTION_CHANGED);
+      const userStateArray =
+        eventManager['eventListenerArrayMap'].get(USER_STATE_CHANGED);
+
+      expect(permissionArray).toEqual([handler1]);
+      expect(subscriptionArray).toEqual([handler2]);
+      expect(userStateArray).toEqual([handler3]);
+      expect(permissionArray).not.toEqual(subscriptionArray);
+    });
+
+    test('should handle multiple sequential add and remove operations', () => {
+      const handler1 = vi.fn();
+      const handler2 = vi.fn();
+      const handler3 = vi.fn();
+
+      eventManager.addEventListener(SUBSCRIPTION_CHANGED, handler1);
+      eventManager.addEventListener(SUBSCRIPTION_CHANGED, handler2);
+      eventManager.addEventListener(SUBSCRIPTION_CHANGED, handler3);
+
+      const callback = getCallback(SUBSCRIPTION_CHANGED);
+
+      callback!({ id: '1' });
+      expect(handler1).toHaveBeenCalledWith({ id: '1' });
+      expect(handler2).toHaveBeenCalledWith({ id: '1' });
+      expect(handler3).toHaveBeenCalledWith({ id: '1' });
+
+      eventManager.removeEventListener(SUBSCRIPTION_CHANGED, handler2);
+      handler1.mockClear();
+      handler2.mockClear();
+      handler3.mockClear();
+
+      callback!({ id: '2' });
+      expect(handler1).toHaveBeenCalledWith({ id: '2' });
+      expect(handler2).not.toHaveBeenCalled();
+      expect(handler3).toHaveBeenCalledWith({ id: '2' });
+    });
+  });
+});

--- a/src/events/EventManager.ts
+++ b/src/events/EventManager.ts
@@ -16,7 +16,30 @@ import {
   USER_STATE_CHANGED,
 } from '../constants/events';
 import OSNotification from '../OSNotification';
+import type {
+  InAppMessageClickEvent,
+  InAppMessageDidDismissEvent,
+  InAppMessageDidDisplayEvent,
+  InAppMessageWillDismissEvent,
+  InAppMessageWillDisplayEvent,
+} from '../types/inAppMessage';
+import type { NotificationClickEvent } from '../types/notificationEvents';
+import type { PushSubscriptionChangedState } from '../types/subscription';
+import type { UserChangedState } from '../types/user';
 import NotificationWillDisplayEvent from './NotificationWillDisplayEvent';
+
+export interface EventListenerMap {
+  [PERMISSION_CHANGED]: (event: { permission: boolean }) => void;
+  [SUBSCRIPTION_CHANGED]: (event: PushSubscriptionChangedState) => void;
+  [USER_STATE_CHANGED]: (event: UserChangedState) => void;
+  [NOTIFICATION_WILL_DISPLAY]: (event: NotificationWillDisplayEvent) => void;
+  [NOTIFICATION_CLICKED]: (event: NotificationClickEvent) => void;
+  [IN_APP_MESSAGE_CLICKED]: (event: InAppMessageClickEvent) => void;
+  [IN_APP_MESSAGE_WILL_DISPLAY]: (event: InAppMessageWillDisplayEvent) => void;
+  [IN_APP_MESSAGE_WILL_DISMISS]: (event: InAppMessageWillDismissEvent) => void;
+  [IN_APP_MESSAGE_DID_DISMISS]: (event: InAppMessageDidDismissEvent) => void;
+  [IN_APP_MESSAGE_DID_DISPLAY]: (event: InAppMessageDidDisplayEvent) => void;
+}
 
 const eventList = [
   PERMISSION_CHANGED,
@@ -29,7 +52,7 @@ const eventList = [
   IN_APP_MESSAGE_WILL_DISMISS,
   IN_APP_MESSAGE_DID_DISMISS,
   IN_APP_MESSAGE_DID_DISPLAY,
-];
+] as const;
 
 export default class EventManager {
   private RNOneSignal: NativeModule;
@@ -61,7 +84,10 @@ export default class EventManager {
    * @param  {function} handler
    * @returns void
    */
-  addEventListener<T>(eventName: string, handler: (event: T) => void) {
+  addEventListener<K extends keyof EventListenerMap>(
+    eventName: K,
+    handler: EventListenerMap[K],
+  ) {
     let handlerArray = this.eventListenerArrayMap.get(eventName);
     if (handlerArray && handlerArray.length > 0) {
       handlerArray.push(handler);
@@ -76,7 +102,10 @@ export default class EventManager {
    * @param  {function} handler
    * @returns void
    */
-  removeEventListener(eventName: string, handler: any) {
+  removeEventListener<K extends keyof EventListenerMap>(
+    eventName: K,
+    handler: EventListenerMap[K],
+  ) {
     const handlerArray = this.eventListenerArrayMap.get(eventName);
     if (!handlerArray) {
       return;
@@ -91,8 +120,10 @@ export default class EventManager {
   }
 
   // returns an event listener with the js to native mapping
-  generateEventListener(eventName: string): EmitterSubscription {
-    const addListenerCallback = (payload: object) => {
+  generateEventListener<K extends keyof EventListenerMap>(
+    eventName: K,
+  ): EmitterSubscription {
+    const addListenerCallback = (payload: unknown) => {
       let handlerArray = this.eventListenerArrayMap.get(eventName);
       if (handlerArray) {
         if (eventName === NOTIFICATION_WILL_DISPLAY) {
@@ -108,7 +139,7 @@ export default class EventManager {
           });
         } else {
           handlerArray.forEach((handler) => {
-            handler(payload);
+            handler(payload as EventListenerMap[K]);
           });
         }
       }

--- a/src/index.ts
+++ b/src/index.ts
@@ -407,10 +407,7 @@ export namespace OneSignal {
 
       isValidCallback(listener);
       RNOneSignal.addUserStateObserver();
-      eventManager.addEventListener<UserChangedState>(
-        USER_STATE_CHANGED,
-        listener,
-      );
+      eventManager.addEventListener(USER_STATE_CHANGED, listener);
     }
 
     /** Clears current user state observers. */

--- a/src/index.ts
+++ b/src/index.ts
@@ -165,13 +165,9 @@ export namespace OneSignal {
     export function enter(
       activityId: string,
       token: string,
-      handler?: Function,
+      handler: Function = () => {},
     ) {
       if (!isNativeModuleLoaded(RNOneSignal)) return;
-
-      if (!handler) {
-        handler = () => {};
-      }
 
       // Only Available on iOS
       if (Platform.OS === 'ios') {
@@ -186,12 +182,8 @@ export namespace OneSignal {
      *
      * @param activityId: The activity identifier the live activity on this device will no longer receive updates for.
      **/
-    export function exit(activityId: string, handler?: Function) {
+    export function exit(activityId: string, handler: Function = () => {}) {
       if (!isNativeModuleLoaded(RNOneSignal)) return;
-
-      if (!handler) {
-        handler = () => {};
-      }
 
       if (Platform.OS === 'ios') {
         RNOneSignal.exitLiveActivity(activityId, handler);
@@ -697,6 +689,7 @@ export namespace OneSignal {
       if (!isNativeModuleLoaded(RNOneSignal)) return;
       isValidCallback(listener);
 
+      /* v8 ignore else -- @preserve */
       if (event === 'click') {
         RNOneSignal.addNotificationClickListener();
         eventManager.addEventListener<NotificationClickEvent>(
@@ -725,14 +718,13 @@ export namespace OneSignal {
       event: K,
       listener: (event: NotificationEventTypeMap[K]) => void,
     ): void {
+      /* v8 ignore else -- @preserve */
       if (event === 'click') {
         eventManager.removeEventListener(NOTIFICATION_CLICKED, listener);
       } else if (event === 'foregroundWillDisplay') {
         eventManager.removeEventListener(NOTIFICATION_WILL_DISPLAY, listener);
       } else if (event === 'permissionChange') {
         eventManager.removeEventListener(PERMISSION_CHANGED, listener);
-      } else {
-        return;
       }
     }
 
@@ -799,6 +791,7 @@ export namespace OneSignal {
           listener as (event: InAppMessageClickEvent) => void,
         );
       } else {
+        /* v8 ignore else -- @preserve */
         if (event === 'willDisplay') {
           isValidCallback(listener);
           eventManager.addEventListener<InAppMessageWillDisplayEvent>(
@@ -840,6 +833,7 @@ export namespace OneSignal {
       if (event === 'click') {
         eventManager.removeEventListener(IN_APP_MESSAGE_CLICKED, listener);
       } else {
+        /* v8 ignore else -- @preserve */
         if (event === 'willDisplay') {
           eventManager.removeEventListener(
             IN_APP_MESSAGE_WILL_DISPLAY,
@@ -860,8 +854,6 @@ export namespace OneSignal {
             IN_APP_MESSAGE_DID_DISMISS,
             listener,
           );
-        } else {
-          return;
         }
       }
     }

--- a/src/types/inAppMessage.ts
+++ b/src/types/inAppMessage.ts
@@ -1,3 +1,5 @@
+import type { EventListenerMap } from '../events/EventManager';
+
 export type InAppMessageEventName =
   | 'click'
   | 'willDisplay'
@@ -5,13 +7,12 @@ export type InAppMessageEventName =
   | 'willDismiss'
   | 'didDismiss';
 
-export type InAppMessageEventTypeMap = {
-  click: InAppMessageClickEvent;
-  willDisplay: InAppMessageWillDisplayEvent;
-  didDisplay: InAppMessageDidDisplayEvent;
-  willDismiss: InAppMessageWillDismissEvent;
-  didDismiss: InAppMessageDidDismissEvent;
-};
+export type InAppMessageListeners =
+  | ['click', EventListenerMap['OneSignal-inAppMessageClicked']]
+  | ['willDisplay', EventListenerMap['OneSignal-inAppMessageWillDisplay']]
+  | ['didDisplay', EventListenerMap['OneSignal-inAppMessageDidDisplay']]
+  | ['willDismiss', EventListenerMap['OneSignal-inAppMessageWillDismiss']]
+  | ['didDismiss', EventListenerMap['OneSignal-inAppMessageDidDismiss']];
 
 export interface InAppMessage {
   messageId: string;

--- a/src/types/notificationEvents.ts
+++ b/src/types/notificationEvents.ts
@@ -1,16 +1,18 @@
 import OSNotification from '../OSNotification';
-import NotificationWillDisplayEvent from '../events/NotificationWillDisplayEvent';
+import type { EventListenerMap } from '../events/EventManager';
 
 export type NotificationEventName =
   | 'click'
   | 'foregroundWillDisplay'
   | 'permissionChange';
 
-export type NotificationEventTypeMap = {
-  click: NotificationClickEvent;
-  foregroundWillDisplay: NotificationWillDisplayEvent;
-  permissionChange: boolean;
-};
+export type NotificationListeners =
+  | ['click', EventListenerMap['OneSignal-notificationClicked']]
+  | [
+      'foregroundWillDisplay',
+      EventListenerMap['OneSignal-notificationWillDisplayInForeground'],
+    ]
+  | ['permissionChange', EventListenerMap['OneSignal-permissionChanged']];
 
 export interface NotificationClickEvent {
   result: NotificationClickResult;


### PR DESCRIPTION
# Description

## One Line Summary
- adds more tests and clean up event manager typings

## Details
- add tests for event manager
- improve typings for event manager by adding event listener map

### Motivation
- want to have more test coverage across all sdks

# Affected code checklist
- [ ] Notifications
  - [ ] Display
  - [ ] Open
  - [ ] Push Processing
  - [ ] Confirm Deliveries
- [ ] Outcomes
- [ ] Sessions
- [ ] In-App Messaging
- [ ] REST API requests
- [ ] Public API changes

# Checklist

## Overview

- [ ] I have filled out all **REQUIRED** sections above
- [ ] PR does one thing
  - If it is hard to explain how any codes changes are related to each other then it most likely needs to be more than one PR
- [ ] Any Public API changes are explained in the PR details and conform to existing APIs

## Testing

- [ ] I have included test coverage for these changes, or explained why they are not needed
- [ ] All automated tests pass, or I explained why that is not possible
- [ ] I have personally tested this on my device, or explained why that is not possible

## Final pass

- [ ] Code is as readable as possible.
  - Simplify with less code, followed by splitting up code into well named functions and variables, followed by adding comments to the code.
- [ ] I have reviewed this PR myself, ensuring it meets each checklist item
  - WIP (Work In Progress) is ok, but explain what is still in progress and what you would like feedback on. Start the PR title with "WIP" to indicate this.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/OneSignal/react-native-onesignal/1856)
<!-- Reviewable:end -->
