### PR TITLE
fix: Android prevent crash when cleaning up uninitialized SDK on destroy

### DIFF
--- a/android/src/main/java/com/onesignal/rnonesignalandroid/RNOneSignal.java
+++ b/android/src/main/java/com/onesignal/rnonesignalandroid/RNOneSignal.java
@@ -172,6 +172,11 @@ public class RNOneSignal extends ReactContextBaseJavaModule
     };
 
     private void removeObservers() {
+        if(!oneSignalInitDone) {
+            Logging.debug("OneSignal React-Native SDK not initialized yet. Could not remove observers.", null);
+            return;
+        }
+
         this.removePermissionObserver();
         this.removePushSubscriptionObserver();
         this.removeUserStateObserver();
@@ -226,8 +231,12 @@ public class RNOneSignal extends ReactContextBaseJavaModule
 
     @Override
     public void onHostDestroy() {
-        removeHandlers();
-        removeObservers();
+        try {
+            removeHandlers();
+            removeObservers();
+        } catch (Exception e) {
+            Logging.debug("OneSignal SDK not fully initialized. Could not remove handlers/observers: " + e.getMessage(), null);
+        }
     }
 
     @Override
@@ -238,8 +247,12 @@ public class RNOneSignal extends ReactContextBaseJavaModule
 
     @Override
     public void onCatalystInstanceDestroy() {
-        removeHandlers();
-        removeObservers();
+        try {
+            removeHandlers();
+            removeObservers();
+        } catch (Exception e) {
+            Logging.debug("OneSignal SDK not fully initialized. Could not remove handlers/observers: " + e.getMessage(), null);
+        }
     }
 
     // OneSignal namespace methods
@@ -254,8 +267,6 @@ public class RNOneSignal extends ReactContextBaseJavaModule
             return;
         }
 
-        oneSignalInitDone = true;
-
         if (context == null) {
             // in some cases, especially when react-native-navigation is installed,
             // the activity can be null, so we can initialize with the context instead
@@ -263,6 +274,7 @@ public class RNOneSignal extends ReactContextBaseJavaModule
         }
 
         OneSignal.initWithContext(context, appId);
+        oneSignalInitDone = true;
     }
 
     @ReactMethod

--- a/android/src/main/java/com/onesignal/rnonesignalandroid/RNOneSignal.java
+++ b/android/src/main/java/com/onesignal/rnonesignalandroid/RNOneSignal.java
@@ -180,9 +180,7 @@ public class RNOneSignal extends ReactContextBaseJavaModule
         this.removePermissionObserver();
         this.removePushSubscriptionObserver();
         this.removeUserStateObserver();
-    }
 
-    private void removeHandlers() {
         if (hasAddedInAppMessageClickListener) {
             OneSignal.getInAppMessages().removeClickListener(rnInAppClickListener);
             hasAddedInAppMessageClickListener = false;
@@ -217,7 +215,6 @@ public class RNOneSignal extends ReactContextBaseJavaModule
 
         // Clean up previous instance if it exists (handles reload scenario)
         if (currentInstance != null && currentInstance != this) {
-            currentInstance.removeHandlers();
             currentInstance.removeObservers();
         }
         currentInstance = this;
@@ -231,12 +228,7 @@ public class RNOneSignal extends ReactContextBaseJavaModule
 
     @Override
     public void onHostDestroy() {
-        try {
-            removeHandlers();
-            removeObservers();
-        } catch (Exception e) {
-            Logging.debug("OneSignal SDK not fully initialized. Could not remove handlers/observers: " + e.getMessage(), null);
-        }
+        removeObservers();
     }
 
     @Override
@@ -247,12 +239,7 @@ public class RNOneSignal extends ReactContextBaseJavaModule
 
     @Override
     public void onCatalystInstanceDestroy() {
-        try {
-            removeHandlers();
-            removeObservers();
-        } catch (Exception e) {
-            Logging.debug("OneSignal SDK not fully initialized. Could not remove handlers/observers: " + e.getMessage(), null);
-        }
+        removeObservers();
     }
 
     // OneSignal namespace methods


### PR DESCRIPTION
# Description

## One Line Summary
Fix reported crashes when handlers / observers are removed on destroy and the SDK is uninitialized or cleaned up already.

## Details
To address https://github.com/OneSignal/react-native-onesignal/issues/1554

* When the activity is destroyed, the code tries to remove handlers by calling OneSignal.getInAppMessages(), but the native OneSignal SDK may not be fully initialized yet (or may have been cleaned up), causing it to throw "Must call 'initWithContext' before use".
* Also move the `oneSignalInitDone` flag further down past the native `OneSignal.initWithContext(context, appId)` call. The native SDK already handles if initWithContext is called while it is still initializing.

### Motivation
Bug fix, fix crash

### Scope
When activity being destroyed

# Testing
## Manual testing
Manually ran app in Android 35 emulator, app initializes, gets IAMs, get notifications.

# Affected code checklist

- [ ] Notifications
  - [ ] Display
  - [ ] Open
  - [ ] Push Processing
  - [ ] Confirm Deliveries
- [ ] Outcomes
- [ ] Sessions
- [ ] In-App Messaging
- [ ] REST API requests
- [ ] Public API changes

# Checklist

## Overview

- [x] I have filled out all **REQUIRED** sections above
- [x] PR does one thing
- [ ] Any Public API changes are explained in the PR details and conform to existing APIs

## Testing

- [ ] I have included test coverage for these changes, or explained why they are not needed
- [ ] All automated tests pass, or I explained why that is not possible
- [x] I have personally tested this on my device, or explained why that is not possible

## Final pass

- [x] Code is as readable as possible.
- [x] I have reviewed this PR myself, ensuring it meets each checklist item

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/OneSignal/react-native-onesignal/1871)
<!-- Reviewable:end -->
