### PR TITLE
fix: removes listeners when app is reloaded on android

### DIFF
--- a/android/src/main/java/com/onesignal/rnonesignalandroid/RNOneSignal.java
+++ b/android/src/main/java/com/onesignal/rnonesignalandroid/RNOneSignal.java
@@ -179,20 +179,20 @@ public class RNOneSignal extends ReactContextBaseJavaModule
 
     private void removeHandlers() {
         if (hasAddedInAppMessageClickListener) {
-          OneSignal.getInAppMessages().removeClickListener(rnInAppClickListener);
-          hasAddedInAppMessageClickListener = false;
+            OneSignal.getInAppMessages().removeClickListener(rnInAppClickListener);
+            hasAddedInAppMessageClickListener = false;
         }
         if (hasAddedInAppMessageLifecycleListener) {
-          OneSignal.getInAppMessages().removeLifecycleListener(rnInAppLifecycleListener);
-          hasAddedInAppMessageLifecycleListener = false;
+            OneSignal.getInAppMessages().removeLifecycleListener(rnInAppLifecycleListener);
+            hasAddedInAppMessageLifecycleListener = false;
         }
         if (hasAddedNotificationClickListener) {
-          OneSignal.getNotifications().removeClickListener(rnNotificationClickListener);
-          hasAddedNotificationClickListener = false;
+            OneSignal.getNotifications().removeClickListener(rnNotificationClickListener);
+            hasAddedNotificationClickListener = false;
         }
         if (hasAddedNotificationForegroundListener) {
-          OneSignal.getNotifications().removeForegroundLifecycleListener(this);
-          hasAddedNotificationForegroundListener = false;
+            OneSignal.getNotifications().removeForegroundLifecycleListener(this);
+            hasAddedNotificationForegroundListener = false;
         }
     }
 

--- a/android/src/main/java/com/onesignal/rnonesignalandroid/RNOneSignal.java
+++ b/android/src/main/java/com/onesignal/rnonesignalandroid/RNOneSignal.java
@@ -178,22 +178,19 @@ public class RNOneSignal extends ReactContextBaseJavaModule
     }
 
     private void removeHandlers() {
-        if (hasAddedInAppMessageClickListener) {
-            OneSignal.getInAppMessages().removeClickListener(rnInAppClickListener);
-            hasAddedInAppMessageClickListener = false;
+        if (!oneSignalInitDone) {
+            Logging.debug("OneSignal React-Native SDK not initialized yet. Could not remove handlers.", null);
+            return;
         }
-        if (hasAddedInAppMessageLifecycleListener) {
-            OneSignal.getInAppMessages().removeLifecycleListener(rnInAppLifecycleListener);
-            hasAddedInAppMessageLifecycleListener = false;
-        }
-        if (hasAddedNotificationClickListener) {
-            OneSignal.getNotifications().removeClickListener(rnNotificationClickListener);
-            hasAddedNotificationClickListener = false;
-        }
-        if (hasAddedNotificationForegroundListener) {
-            OneSignal.getNotifications().removeForegroundLifecycleListener(this);
-            hasAddedNotificationForegroundListener = false;
-        }
+
+        OneSignal.getInAppMessages().removeClickListener(rnInAppClickListener);
+        hasAddedInAppMessageClickListener = false;
+        OneSignal.getInAppMessages().removeLifecycleListener(rnInAppLifecycleListener);
+        hasAddedInAppMessageLifecycleListener = false;
+        OneSignal.getNotifications().removeClickListener(rnNotificationClickListener);
+        hasAddedNotificationClickListener = false;
+        OneSignal.getNotifications().removeForegroundLifecycleListener(this);
+        hasAddedNotificationForegroundListener = false;
     }
 
     private void sendEvent(String eventName, Object params) {

--- a/examples/RNOneSignalTS/OSDemo.tsx
+++ b/examples/RNOneSignalTS/OSDemo.tsx
@@ -135,16 +135,13 @@ const OSDemo: React.FC = () => {
   );
 
   useEffect(() => {
-    const initializeOneSignal = async () => {
-      OneSignal.initialize(APP_ID);
-      OneSignal.Debug.setLogLevel(LogLevel.None);
+    OneSignal.initialize(APP_ID);
+    OneSignal.Debug.setLogLevel(LogLevel.None);
+  }, []);
 
+  useEffect(() => {
+    const setup = async () => {
       OneSignal.LiveActivities.setupDefault();
-      // OneSignal.LiveActivities.setupDefault({
-      //   enablePushToStart: false,
-      //   enablePushToUpdate: true,
-      // });
-
       OneSignal.Notifications.addEventListener(
         'foregroundWillDisplay',
         onForegroundWillDisplay,
@@ -166,7 +163,7 @@ const OSDemo: React.FC = () => {
       OneSignal.User.addEventListener('change', onUserChange);
     };
 
-    initializeOneSignal();
+    setup();
 
     return () => {
       // Clean up all event listeners

--- a/examples/RNOneSignalTS/ios/Podfile.lock
+++ b/examples/RNOneSignalTS/ios/Podfile.lock
@@ -2665,7 +2665,7 @@ SPEC CHECKSUMS:
   React-logger: a3cb5b29c32b8e447b5a96919340e89334062b48
   React-Mapbuffer: 9d2434a42701d6144ca18f0ca1c4507808ca7696
   React-microtasksnativemodule: 75b6604b667d297292345302cc5bfb6b6aeccc1b
-  react-native-onesignal: 6c5758aa56975db4bca9956d18d83dd62444c931
+  react-native-onesignal: b68c981956150f288c1585889871affcef3c0b8b
   react-native-safe-area-context: c00143b4823773bba23f2f19f85663ae89ceb460
   React-NativeModulesApple: 879fbdc5dcff7136abceb7880fe8a2022a1bd7c3
   React-oscompat: 93b5535ea7f7dff46aaee4f78309a70979bdde9d


### PR DESCRIPTION
# Description

## One Line Summary
- addresses this comment (https://github.com/OneSignal/react-native-onesignal/issues/1610#issuecomment-3019420760) where when app is reloaded, the old listeners arent properly removed

Bug:
https://drive.google.com/file/d/1TOP4Wcm92Z7HsW-ElALr_tqsQYO6IGYU/view?usp=drive_link

Fix:
https://drive.google.com/file/d/1mz56DI5mfIN0tnfME0QQmiVpQt6hXUeO/view?usp=drive_link

## Details
- adds RN static instance to RNOneSignal java class so we can clean up its old handlers when a new instance is created

### Motivation
- When doing a reload on the terminal or devtools window, previously any added listeners would just linger so for each reload you would seen an extra log. 

## Manual testing
Update OSDemo to have:
```ts
  const handleForegroundNotification = useCallback(
    (event: NotificationWillDisplayEvent) => {
      const notification = event.getNotification();
      console.log('Arrived', notification);
    },
    [],
  );

  useEffect(() => {
    const setup = async () => {
      OneSignal.Debug.setLogLevel(LogLevel.Verbose);
      OneSignal.initialize(APP_ID);
      OneSignal.Notifications.addEventListener(
        'foregroundWillDisplay',
        handleForegroundNotification,
      );
    };
    setup();

    return () => {
      OneSignal.Notifications.removeEventListener(
        'foregroundWillDisplay',
        handleForegroundNotification,
      );
    };
  }, [handleForegroundNotification]);

```
Run `bun run android` in the example project.
Send a test notification to some test subscription. 
Click on the react-native terminal.
Should see 1 log per notification.

Compare against the video in the description where you see multiple logs per sent notification.

# Affected code checklist

- [ ] Notifications
  - [ ] Display
  - [ ] Open
  - [ ] Push Processing
  - [ ] Confirm Deliveries
- [ ] Outcomes
- [ ] Sessions
- [ ] In-App Messaging
- [ ] REST API requests
- [ ] Public API changes

# Checklist

## Overview

- [ ] I have filled out all **REQUIRED** sections above
- [ ] PR does one thing
  - If it is hard to explain how any codes changes are related to each other then it most likely needs to be more than one PR
- [ ] Any Public API changes are explained in the PR details and conform to existing APIs

## Testing

- [ ] I have included test coverage for these changes, or explained why they are not needed
- [ ] All automated tests pass, or I explained why that is not possible
- [ ] I have personally tested this on my device, or explained why that is not possible

## Final pass

- [ ] Code is as readable as possible.
  - Simplify with less code, followed by splitting up code into well named functions and variables, followed by adding comments to the code.
- [ ] I have reviewed this PR myself, ensuring it meets each checklist item
  - WIP (Work In Progress) is ok, but explain what is still in progress and what you would like feedback on. Start the PR title with "WIP" to indicate this.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/OneSignal/react-native-onesignal/1874)
<!-- Reviewable:end -->
