### PR TITLE
fix: removes listeners when app is reloaded on ios

### DIFF
--- a/android/src/main/java/com/onesignal/rnonesignalandroid/RNOneSignal.java
+++ b/android/src/main/java/com/onesignal/rnonesignalandroid/RNOneSignal.java
@@ -178,19 +178,22 @@ public class RNOneSignal extends ReactContextBaseJavaModule
     }
 
     private void removeHandlers() {
-        if (!oneSignalInitDone) {
-            Logging.debug("OneSignal React-Native SDK not initialized yet. Could not remove handlers.", null);
-            return;
+        if (hasAddedInAppMessageClickListener) {
+            OneSignal.getInAppMessages().removeClickListener(rnInAppClickListener);
+            hasAddedInAppMessageClickListener = false;
         }
-
-        OneSignal.getInAppMessages().removeClickListener(rnInAppClickListener);
-        hasAddedInAppMessageClickListener = false;
-        OneSignal.getInAppMessages().removeLifecycleListener(rnInAppLifecycleListener);
-        hasAddedInAppMessageLifecycleListener = false;
-        OneSignal.getNotifications().removeClickListener(rnNotificationClickListener);
-        hasAddedNotificationClickListener = false;
-        OneSignal.getNotifications().removeForegroundLifecycleListener(this);
-        hasAddedNotificationForegroundListener = false;
+        if (hasAddedInAppMessageLifecycleListener) {
+            OneSignal.getInAppMessages().removeLifecycleListener(rnInAppLifecycleListener);
+            hasAddedInAppMessageLifecycleListener = false;
+        }
+        if (hasAddedNotificationClickListener) {
+            OneSignal.getNotifications().removeClickListener(rnNotificationClickListener);
+            hasAddedNotificationClickListener = false;
+        }
+        if (hasAddedNotificationForegroundListener) {
+            OneSignal.getNotifications().removeForegroundLifecycleListener(this);
+            hasAddedNotificationForegroundListener = false;
+        }
     }
 
     private void sendEvent(String eventName, Object params) {

--- a/ios/RCTOneSignal/RCTOneSignalEventEmitter.m
+++ b/ios/RCTOneSignal/RCTOneSignalEventEmitter.m
@@ -19,6 +19,8 @@
 }
 
 static BOOL _didStartObserving = false;
+// Static reference to track current instance for cleanup on reload
+static RCTOneSignalEventEmitter *_currentInstance = nil;
 
 + (BOOL)hasSetBridge {
   return _didStartObserving;
@@ -48,6 +50,13 @@ RCT_EXPORT_MODULE(RCTOneSignal)
                                                selector:@selector(emitEvent:)
                                                    name:eventName
                                                  object:nil];
+
+    // Clean up previous instance if it exists (handles reload scenario)
+    if (_currentInstance != nil && _currentInstance != self) {
+      [_currentInstance removeHandlers];
+      [_currentInstance removeObservers];
+    }
+    _currentInstance = self;
   }
 
   return self;
@@ -64,6 +73,8 @@ RCT_EXPORT_MODULE(RCTOneSignal)
 
 - (void)stopObserving {
   _hasListeners = false;
+  [self removeHandlers];
+  [self removeObservers];
 }
 
 - (NSArray<NSString *> *)supportedEvents {
@@ -582,6 +593,30 @@ RCT_EXPORT_METHOD(displayNotification : (NSString *)notificationId) {
 
 RCT_EXPORT_METHOD(initInAppMessageClickHandlerParams) {
   // iOS Stub
+}
+
+- (void)removeObservers {
+  [self removePermissionObserver];
+  [self removePushSubscriptionObserver];
+  [self removeUserStateObserver];
+}
+
+- (void)removeHandlers {
+  [OneSignal.InAppMessages removeClickListener:[RCTOneSignal sharedInstance]];
+  _hasAddedInAppMessageClickListener = false;
+  [OneSignal.InAppMessages removeLifecycleListener:[RCTOneSignal sharedInstance]];
+  _hasAddedInAppMessageLifecycleListener = false;
+  [OneSignal.Notifications removeClickListener:[RCTOneSignal sharedInstance]];
+  _hasAddedNotificationClickListener = false;
+  [OneSignal.Notifications removeForegroundLifecycleListener:self];
+  _hasAddedNotificationForegroundLifecycleListener = false;
+}
+
+- (void)removeUserStateObserver {
+  if (_hasSetUserStateObserver) {
+    [OneSignal.User removeObserver:[RCTOneSignal sharedInstance]];
+    _hasSetUserStateObserver = false;
+  }
 }
 
 @end

--- a/ios/RCTOneSignal/RCTOneSignalEventEmitter.m
+++ b/ios/RCTOneSignal/RCTOneSignalEventEmitter.m
@@ -602,15 +602,23 @@ RCT_EXPORT_METHOD(initInAppMessageClickHandlerParams) {
 }
 
 - (void)removeHandlers {
-  [OneSignal.InAppMessages removeClickListener:[RCTOneSignal sharedInstance]];
-  _hasAddedInAppMessageClickListener = false;
-  [OneSignal.InAppMessages
-      removeLifecycleListener:[RCTOneSignal sharedInstance]];
-  _hasAddedInAppMessageLifecycleListener = false;
-  [OneSignal.Notifications removeClickListener:[RCTOneSignal sharedInstance]];
-  _hasAddedNotificationClickListener = false;
-  [OneSignal.Notifications removeForegroundLifecycleListener:self];
-  _hasAddedNotificationForegroundLifecycleListener = false;
+  if (_hasAddedInAppMessageClickListener) {
+    [OneSignal.InAppMessages removeClickListener:[RCTOneSignal sharedInstance]];
+    _hasAddedInAppMessageClickListener = false;
+  }
+  if (_hasAddedInAppMessageLifecycleListener) {
+    [OneSignal.InAppMessages
+        removeLifecycleListener:[RCTOneSignal sharedInstance]];
+    _hasAddedInAppMessageLifecycleListener = false;
+  }
+  if (_hasAddedNotificationClickListener) {
+    [OneSignal.Notifications removeClickListener:[RCTOneSignal sharedInstance]];
+    _hasAddedNotificationClickListener = false;
+  }
+  if (_hasAddedNotificationForegroundLifecycleListener) {
+    [OneSignal.Notifications removeForegroundLifecycleListener:self];
+    _hasAddedNotificationForegroundLifecycleListener = false;
+  }
 }
 
 - (void)removeUserStateObserver {

--- a/ios/RCTOneSignal/RCTOneSignalEventEmitter.m
+++ b/ios/RCTOneSignal/RCTOneSignalEventEmitter.m
@@ -604,7 +604,8 @@ RCT_EXPORT_METHOD(initInAppMessageClickHandlerParams) {
 - (void)removeHandlers {
   [OneSignal.InAppMessages removeClickListener:[RCTOneSignal sharedInstance]];
   _hasAddedInAppMessageClickListener = false;
-  [OneSignal.InAppMessages removeLifecycleListener:[RCTOneSignal sharedInstance]];
+  [OneSignal.InAppMessages
+      removeLifecycleListener:[RCTOneSignal sharedInstance]];
   _hasAddedInAppMessageLifecycleListener = false;
   [OneSignal.Notifications removeClickListener:[RCTOneSignal sharedInstance]];
   _hasAddedNotificationClickListener = false;


### PR DESCRIPTION
# Description

## One Line Summary
- addresses this comment (https://github.com/OneSignal/react-native-onesignal/issues/1610#issuecomment-3019420760) where when app is reloaded, the old listeners arent properly removed

Bug:
https://drive.google.com/file/d/1xryp5XAyJEfz7ZogrS5fQPK-mALf5Iyh/view?usp=drive_link

Fix:
https://drive.google.com/file/d/1Uz_lrnhXHSs0S4vgp9FP_9oXBKady-wg/view?usp=drive_link

## Details
- updates event emitter to mimic logic from RNOneSignal java code where I use static instance and call removeHandlers + Observers on the old instance.

### Motivation
When doing a reload on the terminal or devtools window, previously any added listeners would just linger so for each reload you would seen an extra log.

## Manual testing
Update OSDemo to have:
```tsx
  useEffect(() => {
    console.log('Initializing OneSignall');
    OneSignal.Debug.setLogLevel(LogLevel.Debug);
    OneSignal.initialize(APP_ID);
  }, []);

  useFocusEffect(
    useCallback(() => {
      const eventMethod = (event: NotificationWillDisplayEvent) => {
        console.log('Event listener called');
        let notification = event.getNotification();
        const data = notification.additionalData as {
          refresh_messages: string;
        };
        console.log('Data:', data);

        if (data?.refresh_messages === 'true') {
          console.log('Preventing default');
          event.preventDefault();
        } else {
          event.getNotification().display();
        }
      };

      OneSignal.Notifications.addEventListener(
        'foregroundWillDisplay',
        eventMethod,
      );

      return () => {
        console.log('Removing event listener');
        OneSignal.Notifications.removeEventListener(
          'foregroundWillDisplay',
          eventMethod,
        );
      };
    }, []),
  );
```

Run bun run ios in the example project.
Send a test notification to some test subscription.
Click on the react-native terminal.
Should see 1 log per notification.

I also tested w/ additional data (refresh_messages like in issue report). Prevent default should work.

# Affected code checklist

- [ ] Notifications
  - [ ] Display
  - [ ] Open
  - [ ] Push Processing
  - [ ] Confirm Deliveries
- [ ] Outcomes
- [ ] Sessions
- [ ] In-App Messaging
- [ ] REST API requests
- [ ] Public API changes

# Checklist

## Overview

- [ ] I have filled out all **REQUIRED** sections above
- [ ] PR does one thing
  - If it is hard to explain how any codes changes are related to each other then it most likely needs to be more than one PR
- [ ] Any Public API changes are explained in the PR details and conform to existing APIs

## Testing

- [ ] I have included test coverage for these changes, or explained why they are not needed
- [ ] All automated tests pass, or I explained why that is not possible
- [ ] I have personally tested this on my device, or explained why that is not possible

## Final pass

- [ ] Code is as readable as possible.
  - Simplify with less code, followed by splitting up code into well named functions and variables, followed by adding comments to the code.
- [ ] I have reviewed this PR myself, ensuring it meets each checklist item
  - WIP (Work In Progress) is ok, but explain what is still in progress and what you would like feedback on. Start the PR title with "WIP" to indicate this.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/OneSignal/react-native-onesignal/1878)
<!-- Reviewable:end -->
