### PR TITLE
Improves notification display logic

### DIFF
--- a/android/src/main/java/com/onesignal/rnonesignalandroid/RNOneSignal.java
+++ b/android/src/main/java/com/onesignal/rnonesignalandroid/RNOneSignal.java
@@ -424,6 +424,18 @@ public class RNOneSignal extends ReactContextBaseJavaModule
     @ReactMethod
     private void displayNotification(String notificationId) {
         INotificationWillDisplayEvent event = notificationWillDisplayCache.get(notificationId);
+
+        // If not found in notificationWillDisplayCache, check preventDefaultCache
+        // This handles the case where preventDefault() was called first
+        if (event == null) {
+            event = preventDefaultCache.get(notificationId);
+            if (event != null) {
+                Logging.debug(
+                        "displayNotification called after preventDefault for notification with id: " + notificationId
+                                + ". Displaying notification anyway.", null);
+            }
+        }
+
         if (event == null) {
             Logging.error(
                     "Could not find onWillDisplayNotification event for notification with id: " + notificationId, null);

--- a/examples/RNOneSignalTS/OSDemo.tsx
+++ b/examples/RNOneSignalTS/OSDemo.tsx
@@ -48,41 +48,6 @@ const OSDemo: React.FC = () => {
     },
     [],
   );
-  // const onForegroundWillDisplay = useCallback(
-  //   (event: unknown) => {
-  //     OSLog('OneSignal: notification will show in foreground:', event);
-  //     // const notif = (
-  //     //   event as { getNotification: () => { title: string } }
-  //     // ).getNotification();
-
-  //     // const cancelButton = {
-  //     //   text: 'Cancel',
-  //     //   onPress: () => {
-  //     //     (event as { preventDefault: () => void }).preventDefault();
-  //     //   },
-  //     //   style: 'cancel' as const,
-  //     // };
-
-  //     // const completeButton = {
-  //     //   text: 'Display',
-  //     //   onPress: () => {
-  //     //     (event as { getNotification: () => { display: () => void } })
-  //     //       .getNotification()
-  //     //       .display();
-  //     //   },
-  //     // };
-
-  //     // Alert.alert(
-  //     //   'Display notification?',
-  //     //   notif.title,
-  //     //   [cancelButton, completeButton],
-  //     //   {
-  //     //     cancelable: true,
-  //     //   },
-  //     // );
-  //   },
-  //   [OSLog],
-  // );
 
   const onNotificationClick = useCallback(
     (event: unknown) => {
@@ -157,8 +122,12 @@ const OSDemo: React.FC = () => {
       console.log('Setting up event listeners');
 
       const setup = async () => {
+        // OneSignal.login('fadi-rna-11');
+        const onesignalID = await OneSignal.User.getOnesignalId();
+        console.log('OneSignal ID:', onesignalID);
         const externalID = await OneSignal.User.getExternalId();
         console.log('External ID:', externalID);
+
         OneSignal.LiveActivities.setupDefault();
         OneSignal.Notifications.addEventListener(
           'foregroundWillDisplay',
@@ -229,18 +198,7 @@ const OSDemo: React.FC = () => {
         );
         OneSignal.User.removeEventListener('change', onUserChange);
       };
-    }, [
-      onForegroundWillDisplay,
-      onNotificationClick,
-      onIAMClick,
-      onIAMWillDisplay,
-      onIAMDidDisplay,
-      onIAMWillDismiss,
-      onIAMDidDismiss,
-      onSubscriptionChange,
-      onPermissionChange,
-      onUserChange,
-    ]),
+    }, []),
   );
 
   const inputChange = useCallback((text: string) => {

--- a/examples/RNOneSignalTS/OSDemo.tsx
+++ b/examples/RNOneSignalTS/OSDemo.tsx
@@ -1,7 +1,6 @@
 import { useFocusEffect } from '@react-navigation/native';
 import React, { useCallback, useEffect, useState } from 'react';
 import {
-  Alert,
   ScrollView,
   StyleSheet,
   Text,
@@ -9,7 +8,11 @@ import {
   TouchableOpacity,
   View,
 } from 'react-native';
-import { LogLevel, OneSignal } from 'react-native-onesignal';
+import {
+  LogLevel,
+  NotificationWillDisplayEvent,
+  OneSignal,
+} from 'react-native-onesignal';
 import { SafeAreaView } from 'react-native-safe-area-context';
 import OSButtons from './OSButtons';
 import OSConsole from './OSConsole';
@@ -37,40 +40,49 @@ const OSDemo: React.FC = () => {
   }, []);
 
   const onForegroundWillDisplay = useCallback(
-    (event: unknown) => {
-      OSLog('OneSignal: notification will show in foreground:', event);
-      const notif = (
-        event as { getNotification: () => { title: string } }
-      ).getNotification();
+    (event: NotificationWillDisplayEvent) => {
+      console.log('OneSignal: notification will show in foreground:', event);
 
-      const cancelButton = {
-        text: 'Cancel',
-        onPress: () => {
-          (event as { preventDefault: () => void }).preventDefault();
-        },
-        style: 'cancel' as const,
-      };
-
-      const completeButton = {
-        text: 'Display',
-        onPress: () => {
-          (event as { getNotification: () => { display: () => void } })
-            .getNotification()
-            .display();
-        },
-      };
-
-      Alert.alert(
-        'Display notification?',
-        notif.title,
-        [cancelButton, completeButton],
-        {
-          cancelable: true,
-        },
-      );
+      // console.log('Preventing display');
+      // event.preventDefault();
     },
-    [OSLog],
+    [],
   );
+  // const onForegroundWillDisplay = useCallback(
+  //   (event: unknown) => {
+  //     OSLog('OneSignal: notification will show in foreground:', event);
+  //     // const notif = (
+  //     //   event as { getNotification: () => { title: string } }
+  //     // ).getNotification();
+
+  //     // const cancelButton = {
+  //     //   text: 'Cancel',
+  //     //   onPress: () => {
+  //     //     (event as { preventDefault: () => void }).preventDefault();
+  //     //   },
+  //     //   style: 'cancel' as const,
+  //     // };
+
+  //     // const completeButton = {
+  //     //   text: 'Display',
+  //     //   onPress: () => {
+  //     //     (event as { getNotification: () => { display: () => void } })
+  //     //       .getNotification()
+  //     //       .display();
+  //     //   },
+  //     // };
+
+  //     // Alert.alert(
+  //     //   'Display notification?',
+  //     //   notif.title,
+  //     //   [cancelButton, completeButton],
+  //     //   {
+  //     //     cancelable: true,
+  //     //   },
+  //     // );
+  //   },
+  //   [OSLog],
+  // );
 
   const onNotificationClick = useCallback(
     (event: unknown) => {
@@ -145,6 +157,8 @@ const OSDemo: React.FC = () => {
       console.log('Setting up event listeners');
 
       const setup = async () => {
+        const externalID = await OneSignal.User.getExternalId();
+        console.log('External ID:', externalID);
         OneSignal.LiveActivities.setupDefault();
         OneSignal.Notifications.addEventListener(
           'foregroundWillDisplay',
@@ -173,6 +187,7 @@ const OSDemo: React.FC = () => {
         OneSignal.User.addEventListener('change', onUserChange);
       };
 
+      console.log('Setup');
       setup();
 
       return () => {

--- a/examples/RNOneSignalTS/OSDemo.tsx
+++ b/examples/RNOneSignalTS/OSDemo.tsx
@@ -41,12 +41,16 @@ const OSDemo: React.FC = () => {
 
   const onForegroundWillDisplay = useCallback(
     (event: NotificationWillDisplayEvent) => {
-      console.log('OneSignal: notification will show in foreground:', event);
+      OSLog('OneSignal: notification will show in foreground:', event);
 
-      // console.log('Preventing display');
-      // event.preventDefault();
+      OSLog('Preventing display??????');
+      event.preventDefault();
+
+      // display the notification
+      OSLog('Displaying notification');
+      event.getNotification().display();
     },
-    [],
+    [OSLog],
   );
 
   const onNotificationClick = useCallback(
@@ -114,7 +118,7 @@ const OSDemo: React.FC = () => {
 
   useEffect(() => {
     OneSignal.initialize(APP_ID);
-    OneSignal.Debug.setLogLevel(LogLevel.None);
+    OneSignal.Debug.setLogLevel(LogLevel.Debug);
   }, []);
 
   useFocusEffect(
@@ -127,6 +131,8 @@ const OSDemo: React.FC = () => {
         console.log('OneSignal ID:', onesignalID);
         const externalID = await OneSignal.User.getExternalId();
         console.log('External ID:', externalID);
+        const pushID = await OneSignal.User.pushSubscription.getIdAsync();
+        console.log('Push ID:', pushID);
 
         OneSignal.LiveActivities.setupDefault();
         OneSignal.Notifications.addEventListener(

--- a/examples/RNOneSignalTS/OSDemo.tsx
+++ b/examples/RNOneSignalTS/OSDemo.tsx
@@ -39,84 +39,8 @@ const OSDemo: React.FC = () => {
     });
   }, []);
 
-  const onForegroundWillDisplay = useCallback(
-    (event: NotificationWillDisplayEvent) => {
-      OSLog('OneSignal: notification will show in foreground:', event);
-
-      OSLog('Preventing display??????');
-      event.preventDefault();
-
-      // display the notification
-      OSLog('Displaying notification');
-      event.getNotification().display();
-    },
-    [OSLog],
-  );
-
-  const onNotificationClick = useCallback(
-    (event: unknown) => {
-      OSLog('OneSignal: notification clicked:', event);
-    },
-    [OSLog],
-  );
-
-  const onIAMClick = useCallback(
-    (event: unknown) => {
-      OSLog('OneSignal IAM clicked:', event);
-    },
-    [OSLog],
-  );
-
-  const onIAMWillDisplay = useCallback(
-    (event: unknown) => {
-      OSLog('OneSignal: will display IAM: ', event);
-    },
-    [OSLog],
-  );
-
-  const onIAMDidDisplay = useCallback(
-    (event: unknown) => {
-      OSLog('OneSignal: did display IAM: ', event);
-    },
-    [OSLog],
-  );
-
-  const onIAMWillDismiss = useCallback(
-    (event: unknown) => {
-      OSLog('OneSignal: will dismiss IAM: ', event);
-    },
-    [OSLog],
-  );
-
-  const onIAMDidDismiss = useCallback(
-    (event: unknown) => {
-      OSLog('OneSignal: did dismiss IAM: ', event);
-    },
-    [OSLog],
-  );
-
-  const onSubscriptionChange = useCallback(
-    (subscription: unknown) => {
-      OSLog('OneSignal: subscription changed:', subscription);
-    },
-    [OSLog],
-  );
-
-  const onPermissionChange = useCallback(
-    (granted: unknown) => {
-      OSLog('OneSignal: permission changed:', granted);
-    },
-    [OSLog],
-  );
-
-  const onUserChange = useCallback(
-    (event: unknown) => {
-      OSLog('OneSignal: user changed: ', event);
-    },
-    [OSLog],
-  );
-
   useEffect(() => {
+    console.log('Initializing OneSignal');
     OneSignal.initialize(APP_ID);
     OneSignal.Debug.setLogLevel(LogLevel.Debug);
   }, []);
@@ -124,6 +48,64 @@ const OSDemo: React.FC = () => {
   useFocusEffect(
     useCallback(() => {
       console.log('Setting up event listeners');
+
+      const onForegroundWillDisplay = (event: NotificationWillDisplayEvent) => {
+        OSLog(
+          'OneSignal: notification will show in foreground:',
+          event.getNotification().title,
+        );
+
+        OSLog('Should show after 25 seconds:');
+        let i = 1;
+        const interval = setInterval(() => {
+          OSLog('Seconds passed:', i);
+          i++;
+          if (i > 25) {
+            clearInterval(interval);
+          }
+        }, 1000);
+        // OSLog('Preventing display');
+        // event.preventDefault();
+
+        // OSLog('Displaying notification');
+        // event.getNotification().display();
+      };
+
+      const onNotificationClick = (event: unknown) => {
+        OSLog('OneSignal: notification clicked:', event);
+      };
+
+      const onIAMClick = (event: unknown) => {
+        OSLog('OneSignal IAM clicked:', event);
+      };
+
+      const onIAMWillDisplay = (event: unknown) => {
+        OSLog('OneSignal: will display IAM: ', event);
+      };
+
+      const onIAMDidDisplay = (event: unknown) => {
+        OSLog('OneSignal: did display IAM: ', event);
+      };
+
+      const onIAMWillDismiss = (event: unknown) => {
+        OSLog('OneSignal: will dismiss IAM: ', event);
+      };
+
+      const onIAMDidDismiss = (event: unknown) => {
+        OSLog('OneSignal: did dismiss IAM: ', event);
+      };
+
+      const onSubscriptionChange = (subscription: unknown) => {
+        OSLog('OneSignal: subscription changed:', subscription);
+      };
+
+      const onPermissionChange = (granted: unknown) => {
+        OSLog('OneSignal: permission changed:', granted);
+      };
+
+      const onUserChange = (event: unknown) => {
+        OSLog('OneSignal: user changed: ', event);
+      };
 
       const setup = async () => {
         // OneSignal.login('fadi-rna-11');
@@ -134,32 +116,32 @@ const OSDemo: React.FC = () => {
         const pushID = await OneSignal.User.pushSubscription.getIdAsync();
         console.log('Push ID:', pushID);
 
-        OneSignal.LiveActivities.setupDefault();
         OneSignal.Notifications.addEventListener(
           'foregroundWillDisplay',
           onForegroundWillDisplay,
         );
-        OneSignal.Notifications.addEventListener('click', onNotificationClick);
-        OneSignal.InAppMessages.addEventListener('click', onIAMClick);
-        OneSignal.InAppMessages.addEventListener(
-          'willDisplay',
-          onIAMWillDisplay,
-        );
-        OneSignal.InAppMessages.addEventListener('didDisplay', onIAMDidDisplay);
-        OneSignal.InAppMessages.addEventListener(
-          'willDismiss',
-          onIAMWillDismiss,
-        );
-        OneSignal.InAppMessages.addEventListener('didDismiss', onIAMDidDismiss);
-        OneSignal.User.pushSubscription.addEventListener(
-          'change',
-          onSubscriptionChange,
-        );
-        OneSignal.Notifications.addEventListener(
-          'permissionChange',
-          onPermissionChange,
-        );
-        OneSignal.User.addEventListener('change', onUserChange);
+        // OneSignal.LiveActivities.setupDefault();
+        // OneSignal.Notifications.addEventListener('click', onNotificationClick);
+        // OneSignal.InAppMessages.addEventListener('click', onIAMClick);
+        // OneSignal.InAppMessages.addEventListener(
+        //   'willDisplay',
+        //   onIAMWillDisplay,
+        // );
+        // OneSignal.InAppMessages.addEventListener('didDisplay', onIAMDidDisplay);
+        // OneSignal.InAppMessages.addEventListener(
+        //   'willDismiss',
+        //   onIAMWillDismiss,
+        // );
+        // OneSignal.InAppMessages.addEventListener('didDismiss', onIAMDidDismiss);
+        // OneSignal.User.pushSubscription.addEventListener(
+        //   'change',
+        //   onSubscriptionChange,
+        // );
+        // OneSignal.Notifications.addEventListener(
+        //   'permissionChange',
+        //   onPermissionChange,
+        // );
+        // OneSignal.User.addEventListener('change', onUserChange);
       };
 
       console.log('Setup');
@@ -204,7 +186,7 @@ const OSDemo: React.FC = () => {
         );
         OneSignal.User.removeEventListener('change', onUserChange);
       };
-    }, []),
+    }, [OSLog]),
   );
 
   const inputChange = useCallback((text: string) => {

--- a/examples/RNOneSignalTS/package.json
+++ b/examples/RNOneSignalTS/package.json
@@ -9,6 +9,8 @@
     "preios": "bun run setup && bun run update:pod",
     "android": "react-native run-android",
     "ios": "react-native run-ios",
+    "log:android": "react-native log-android",
+    "log:ios": "react-native log-ios",
     "start": "react-native start"
   },
   "dependencies": {


### PR DESCRIPTION
# READ AND DELETE THIS SECTION BEFORE SUBMITTING PR

- **Fill out each _REQUIRED_ section**
- **Fill out _OPTIONAL_ sections, remove section if it doesn't apply to your PR**
- **Read and fill out each of the checklists below**
- **Remove this section after reading**


# Description

## One Line Summary

**REQUIRED** - Very short description that summaries the changes in this PR.

Improves the notification display logic by adding a timeout and handling cases where `preventDefault` is called before `displayNotification`.

## Details

### Motivation

**REQUIRED -** Why is this code change being made? Or what is the goal of this PR? Examples: Fixes a specific bug, provides additional logging to debug future issues, feature to allow X.

This change addresses issues where notifications might not display correctly, especially when `preventDefault` is used. It ensures that notifications are displayed after a timeout if the JavaScript bridge doesn't respond, preventing indefinite waiting. Additionally, it handles scenarios where `preventDefault` is called before `displayNotification`. This improves the reliability and predictability of notification delivery. Fixes issue #1592.

### Scope

**RECOMMEND - OPTIONAL -** What is intended to be effected. What is known not to change. Example: Notifications are grouped when parameter X is set, not enabled by default.

This change primarily affects the `onWillDisplayNotification` event handling on both Android and iOS. It ensures notifications are displayed even if the JS context is slow to respond or if `preventDefault` is called before `displayNotification`. This change does not affect other OneSignal functionalities, such as user subscriptions or IAMs.

### OPTIONAL - Other

**OPTIONAL -** Feel free to add any other sections or sub-sections that can explain your PR better.

# Testing

## Unit testing

**OPTIONAL -** Explain unit tests added, if not clear in the code.

No unit tests were added as part of this change.

## Manual testing

**RECOMMEND - OPTIONAL -** Explain what scenarios were tested and the environment.
Example: Tested opening a notification while the app was foregrounded, app build with Android Studio 2020.3 with a fresh install of the OneSignal example app on a Pixel 6 with Android 12.

The following scenarios were manually tested on both Android and iOS:
- Receiving a notification while the app is in the foreground.
- Calling `preventDefault` from the JavaScript context and verifying that the notification is not immediately displayed.
- Calling `displayNotification` from the JavaScript context after calling `preventDefault`, ensuring the notification is displayed.
- Verifying that notifications are displayed automatically after a 25-second timeout if no action is taken from the JavaScript context.

# Affected code checklist

- [x] Notifications
  - [x] Display
  - [ ] Open
  - [ ] Push Processing
  - [ ] Confirm Deliveries
- [ ] Outcomes
- [ ] Sessions
- [ ] In-App Messaging
- [ ] REST API requests
- [ ] Public API changes

# Checklist

## Overview

- [x] I have filled out all **REQUIRED** sections above
- [x] PR does one thing
  - If it is hard to explain how any codes changes are related to each other then it most likely needs to be more than one PR
- [ ] Any Public API changes are explained in the PR details and conform to existing APIs

## Testing

- [ ] I have included test coverage for these changes, or explained why they are not needed
- [ ] All automated tests pass, or I explained why that is not possible
- [x] I have personally tested this on my device, or explained why that is not possible

## Final pass

- [x] Code is as readable as possible.
  - Simplify with less code, followed by splitting up code into well named functions and variables, followed by adding comments to the code.
- [x] I have reviewed this PR myself, ensuring it meets each checklist item
  - WIP (Work In Progress) is ok, but explain what is still in progress and what you would like feedback on. Start the PR title with "WIP" to indicate this.

Fixes #1592

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/OneSignal/react-native-onesignal/1887)
<!-- Reviewable:end -->
