### PR TITLE
chore: Release 5.2.17

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -31,7 +31,7 @@ dependencies {
 
     // api is used instead of implementation so the parent :app project can access any of the OneSignal Java
     //   classes if needed. Such as com.onesignal.NotificationExtenderService
-    api 'com.onesignal:OneSignal:5.1.38'
+    api 'com.onesignal:OneSignal:5.4.2-beta1'
     
     testImplementation 'junit:junit:4.12'
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-native-onesignal",
-  "version": "5.2.16",
+  "version": "5.2.17",
   "description": "React Native OneSignal SDK",
   "files": [
     "dist",


### PR DESCRIPTION
Channels: Current


### 🛠️ Native Dependency Updates

- Update Android SDK from 5.1.38 to 5.4.2-beta1
  - feat: Enable docs ([#2507](https://github.com/OneSignal/OneSignal-Android-SDK/pull/2507))
  - feature: Exposing accessors thru suspend ([#2502](https://github.com/OneSignal/OneSignal-Android-SDK/pull/2502))
  - bug: catch exception if opening a notification fails ([#2508](https://github.com/OneSignal/OneSignal-Android-SDK/pull/2508))
  - fix: a rare NPE from PermissionViewModel introduced in 5.4.0 ([#2504](https://github.com/OneSignal/OneSignal-Android-SDK/pull/2504))
  - fix: IAM with NOT_EQUAL_TO trigger always shows up ([#2509](https://github.com/OneSignal/OneSignal-Android-SDK/pull/2509))
  - fix: NPE in SyncJobService since 5.4 ([#2500](https://github.com/OneSignal/OneSignal-Android-SDK/pull/2500))
  - fix: NPE when setting timezone on app focus ([#2505](https://github.com/OneSignal/OneSignal-Android-SDK/pull/2505))
  - fix: Rare User and Subscription creates and updates processing out of order (introduced in 5.4.0) ([#2419](https://github.com/OneSignal/OneSignal-Android-SDK/pull/2419))
  - fix: Remove throwing "initWithContext was not called or timed out", introduced in 5.4.0 ([#2408](https://github.com/OneSignal/OneSignal-Android-SDK/pull/2408))
  - Improvement: failure message shows that appID is missing ([#2506](https://github.com/OneSignal/OneSignal-Android-SDK/pull/2506))
  - improvement: Offloaded work on background threads. ([#2394](https://github.com/OneSignal/OneSignal-Android-SDK/pull/2394))
  - chore: Kotlin 1.9 update ([#2403](https://github.com/OneSignal/OneSignal-Android-SDK/pull/2403))
  - chore: Bump firebase-messaging to 24.0.0 ([#2149](https://github.com/OneSignal/OneSignal-Android-SDK/pull/2149))
  - - -
  - This version same as [5.1.38](https://github.com/OneSignal/OneSignal-Android-SDK/releases/tag/5.1.38)
  - 5.2.x - Identity Verification (JWT) - Feature is still in beta
  - 5.3.x - Custom Outcomes - Feature is still in beta
  - improvement: Offloaded work on background threads. ([#2394](https://github.com/OneSignal/OneSignal-Android-SDK/pull/2394))
  - improvement: Using a OneSignal Threadpool to execute all OneSignal related operations
  - improvement: Added newer suspend methods that could be used in ViewModels to init the SDK, login and logout
  - improvement: Improved code quality around PermissionsActivity.
  - Feat: Detect for timezone changes and update the user ([#2378](https://github.com/OneSignal/OneSignal-Android-SDK/pull/2378))
  - add: security hardening around webview javaScriptEnabled ([#2377](https://github.com/OneSignal/OneSignal-Android-SDK/pull/2377))
  - Fix: ANR on POST to Outcomes endpoint ([#2371](https://github.com/OneSignal/OneSignal-Android-SDK/pull/2371))
  - ANR GmsLocationController timing out ([#2396]https://github.com/OneSignal/OneSignal-Android-SDK/issues/2396)
  - ANR https://github.com/OneSignal/OneSignal-Android-SDK/issues/2335
  - ANR https://github.com/OneSignal/OneSignal-Android-SDK/issues/2266
  - ANR https://github.com/OneSignal/OneSignal-Android-SDK/issues/2397
  - ANR https://github.com/OneSignal/OneSignal-Android-SDK/issues/2399
  - ANR https://github.com/OneSignal/OneSignal-Android-SDK/issues/2400
  - Crash/ANR https://github.com/OneSignal/OneSignal-Android-SDK/issues/2192
  - - -
  - Feat: Detect for timezone changes and update the user ([#2378](https://github.com/OneSignal/OneSignal-Android-SDK/pull/2378))
  - Fix: ANR on POST to Outcomes endpoint ([#2371](https://github.com/OneSignal/OneSignal-Android-SDK/pull/2371))
  - add: security hardening around webview javaScriptEnabled ([#2377](https://github.com/OneSignal/OneSignal-Android-SDK/pull/2377))
  - - -
  - feat: Add Kotlin MainApplication and suspend initialization support ([#2374](https://github.com/OneSignal/OneSignal-Android-SDK/pull/2374))
  - - -
  - **Non-blocking initialization**
  - OneSignal.initWithContext has been refactored so heavy disk and network work are moved off the main thread. ANRs related to initialization should now be effectively eliminated when the SDK is used in the recommended way (see Notes below).
  - **Performance Improvements**
  - In our testing, the time spent on the main thread during initialization dropped by ~80% (e.g., from ~47–49 ms down to ~8 ms on a cold start in debug builds).
  - If your app calls OneSignal accessors (ex. OneSignal.User.oneSignalID) immediately after initWithContext, we recommend moving all OneSignal accessor calls off the main thread.
  - No breaking API changes; existing initWithContext(context) continues to work as before.
  - JWT: Resolve IAM conditions after user create to allow fetching of IAMs in https://github.com/OneSignal/OneSignal-Android-SDK/pull/2337
  - rebased with 5.1.35 which include the following:
  - #2327
  - #2329
  - #2328
  - #2330
  - #2332
  - #2333
  - This limitation will be addressed in the next version
  - Switched publishing to use the Central Publisher Portal
  - _No changes to those using the SDK in their project_
  - Rebased to 5.1.34 for more bug fixes and stability improvements.
  - Adds the following new public methods #2311:
  - `OneSignal.Debug.addLogListener`
  - `OneSignal.Debug.removeLogListener`
  - Rebased to 5.1.33 for more bug fixes and stability improvement.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/OneSignal/react-native-onesignal/1891)
<!-- Reviewable:end -->
