### PR TITLE
chore: Release 5.2.17

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -31,7 +31,7 @@ dependencies {
 
     // api is used instead of implementation so the parent :app project can access any of the OneSignal Java
     //   classes if needed. Such as com.onesignal.NotificationExtenderService
-    api 'com.onesignal:OneSignal:5.4.2'
+    api 'com.onesignal:OneSignal:5.5.0-beta'
     
     testImplementation 'junit:junit:4.12'
 }

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -31,7 +31,7 @@ dependencies {
 
     // api is used instead of implementation so the parent :app project can access any of the OneSignal Java
     //   classes if needed. Such as com.onesignal.NotificationExtenderService
-    api 'com.onesignal:OneSignal:5.4.2-beta1'
+    api 'com.onesignal:OneSignal:5.4.2'
     
     testImplementation 'junit:junit:4.12'
 }

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -31,7 +31,7 @@ dependencies {
 
     // api is used instead of implementation so the parent :app project can access any of the OneSignal Java
     //   classes if needed. Such as com.onesignal.NotificationExtenderService
-    api 'com.onesignal:OneSignal:5.1.38'
+    api 'com.onesignal:OneSignal:5.4.2-beta1'
     
     testImplementation 'junit:junit:4.12'
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-native-onesignal",
-  "version": "5.2.16",
+  "version": "5.2.17",
   "description": "React Native OneSignal SDK",
   "files": [
     "dist",


### PR DESCRIPTION
Channels: Current


### 🛠️ Native Dependency Updates

- Update Android SDK from 5.4.2 to 5.5.0-beta
  - feature: Exposing accessors thru suspend ([#2502](https://github.com/OneSignal/OneSignal-Android-SDK/pull/2502))
  - fix: a rare NPE from PermissionViewModel introduced in 5.4.0 ([#2504](https://github.com/OneSignal/OneSignal-Android-SDK/pull/2504))
  - fix: NPE in SyncJobService since 5.4 ([#2500](https://github.com/OneSignal/OneSignal-Android-SDK/pull/2500))
  - fix: Rare User and Subscription creates and updates processing out of order (introduced in 5.4.0) ([#2419](https://github.com/OneSignal/OneSignal-Android-SDK/pull/2419))
  - fix: Remove throwing "initWithContext was not called or timed out", introduced in 5.4.0 ([#2408](https://github.com/OneSignal/OneSignal-Android-SDK/pull/2408))
  - Improvement: failure message shows that appID is missing ([#2506](https://github.com/OneSignal/OneSignal-Android-SDK/pull/2506))
  - improvement: Offloaded work on background threads. ([#2394](https://github.com/OneSignal/OneSignal-Android-SDK/pull/2394))
  - - -

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/OneSignal/react-native-onesignal/1894)
<!-- Reviewable:end -->
