### PR TITLE
chore: Release 5.2.17

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -31,7 +31,7 @@ dependencies {
 
     // api is used instead of implementation so the parent :app project can access any of the OneSignal Java
     //   classes if needed. Such as com.onesignal.NotificationExtenderService
-    api 'com.onesignal:OneSignal:5.5.0-beta'
+    api 'com.onesignal:OneSignal:5.4.2'
     
     testImplementation 'junit:junit:4.12'
 }

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -31,7 +31,7 @@ dependencies {
 
     // api is used instead of implementation so the parent :app project can access any of the OneSignal Java
     //   classes if needed. Such as com.onesignal.NotificationExtenderService
-    api 'com.onesignal:OneSignal:5.4.2'
+    api 'com.onesignal:OneSignal:5.5.0-beta'
     
     testImplementation 'junit:junit:4.12'
 }

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -31,7 +31,7 @@ dependencies {
 
     // api is used instead of implementation so the parent :app project can access any of the OneSignal Java
     //   classes if needed. Such as com.onesignal.NotificationExtenderService
-    api 'com.onesignal:OneSignal:5.4.2-beta1'
+    api 'com.onesignal:OneSignal:5.4.2'
     
     testImplementation 'junit:junit:4.12'
 }

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -31,7 +31,7 @@ dependencies {
 
     // api is used instead of implementation so the parent :app project can access any of the OneSignal Java
     //   classes if needed. Such as com.onesignal.NotificationExtenderService
-    api 'com.onesignal:OneSignal:5.1.38'
+    api 'com.onesignal:OneSignal:5.4.2-beta1'
     
     testImplementation 'junit:junit:4.12'
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-native-onesignal",
-  "version": "5.2.16",
+  "version": "5.2.17",
   "description": "React Native OneSignal SDK",
   "files": [
     "dist",


### PR DESCRIPTION
Channels: Current


### 🛠️ Native Dependency Updates

- Update Android SDK from 5.1.38 to 5.4.2
  - feat: Enable docs ([#2507](https://github.com/OneSignal/OneSignal-Android-SDK/pull/2507))
  - bug: catch exception if opening a notification fails ([#2508](https://github.com/OneSignal/OneSignal-Android-SDK/pull/2508))
  - fix: IAM with NOT_EQUAL_TO trigger always shows up ([#2509](https://github.com/OneSignal/OneSignal-Android-SDK/pull/2509))
  - fix: NPE when setting timezone on app focus ([#2505](https://github.com/OneSignal/OneSignal-Android-SDK/pull/2505))
  - fix: send receive receipt even when preventDefault is called ([#2512](https://github.com/OneSignal/OneSignal-Android-SDK/pull/2512))
  - chore: Kotlin 1.9 update ([#2403](https://github.com/OneSignal/OneSignal-Android-SDK/pull/2403))
  - chore: Bump firebase-messaging to 24.0.0 ([#2149](https://github.com/OneSignal/OneSignal-Android-SDK/pull/2149))

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/OneSignal/react-native-onesignal/1896)
<!-- Reviewable:end -->
