### PR TITLE
chore: Release 5.2.17

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -31,7 +31,7 @@ dependencies {
 
     // api is used instead of implementation so the parent :app project can access any of the OneSignal Java
     //   classes if needed. Such as com.onesignal.NotificationExtenderService
-    api 'com.onesignal:OneSignal:5.5.0-beta'
+    api 'com.onesignal:OneSignal:5.4.2'
     
     testImplementation 'junit:junit:4.12'
 }

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -31,7 +31,7 @@ dependencies {
 
     // api is used instead of implementation so the parent :app project can access any of the OneSignal Java
     //   classes if needed. Such as com.onesignal.NotificationExtenderService
-    api 'com.onesignal:OneSignal:5.4.2'
+    api 'com.onesignal:OneSignal:5.5.0-beta'
     
     testImplementation 'junit:junit:4.12'
 }

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -31,7 +31,7 @@ dependencies {
 
     // api is used instead of implementation so the parent :app project can access any of the OneSignal Java
     //   classes if needed. Such as com.onesignal.NotificationExtenderService
-    api 'com.onesignal:OneSignal:5.4.2-beta1'
+    api 'com.onesignal:OneSignal:5.4.2'
     
     testImplementation 'junit:junit:4.12'
 }

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -31,7 +31,7 @@ dependencies {
 
     // api is used instead of implementation so the parent :app project can access any of the OneSignal Java
     //   classes if needed. Such as com.onesignal.NotificationExtenderService
-    api 'com.onesignal:OneSignal:5.1.38'
+    api 'com.onesignal:OneSignal:5.4.2-beta1'
     
     testImplementation 'junit:junit:4.12'
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-native-onesignal",
-  "version": "5.2.16",
+  "version": "5.2.17",
   "description": "React Native OneSignal SDK",
   "files": [
     "dist",

--- a/react-native-onesignal.podspec
+++ b/react-native-onesignal.podspec
@@ -22,5 +22,5 @@ Pod::Spec.new do |s|
   # pod 'React', :path => '../node_modules/react-native/'
 
   # The Native OneSignal-iOS-SDK XCFramework from cocoapods.
-  s.dependency 'OneSignalXCFramework', '5.2.15'
+  s.dependency 'OneSignalXCFramework', '5.2.16'
 end


### PR DESCRIPTION
Channels: Current


### 🛠️ Native Dependency Updates

- Update iOS SDK from 5.2.15 to 5.2.16
  - Feat: live activities click events ([OneSignal-iOS-SDK#1593](https://github.com/OneSignal/OneSignal-iOS-SDK/pull/1593))
  - fix: Retry IAM fetch when OneSignal ID becomes available ([OneSignal-iOS-SDK#1626](https://github.com/OneSignal/OneSignal-iOS-SDK/pull/1626))
  - fix: NotEqualTo trigger no longer matches non-existent properties ([OneSignal-iOS-SDK#1625](https://github.com/OneSignal/OneSignal-iOS-SDK/pull/1625))
  - fix: Remove exposing var and let macros ([OneSignal-iOS-SDK#1622](https://github.com/OneSignal/OneSignal-iOS-SDK/pull/1622))
  - fix: forward declarations for Objective-C++ compatibility ([OneSignal-iOS-SDK#1621](https://github.com/OneSignal/OneSignal-iOS-SDK/pull/1621))

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/OneSignal/react-native-onesignal/1897)
<!-- Reviewable:end -->
