### PR TITLE
chore: Release 5.2.17

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -31,7 +31,7 @@ dependencies {
 
     // api is used instead of implementation so the parent :app project can access any of the OneSignal Java
     //   classes if needed. Such as com.onesignal.NotificationExtenderService
-    api 'com.onesignal:OneSignal:5.1.38'
+    api 'com.onesignal:OneSignal:5.4.2'
     
     testImplementation 'junit:junit:4.12'
 }

--- a/examples/RNOneSignalTS/OSDemo.tsx
+++ b/examples/RNOneSignalTS/OSDemo.tsx
@@ -1,7 +1,6 @@
 import { useFocusEffect } from '@react-navigation/native';
 import React, { useCallback, useEffect, useState } from 'react';
 import {
-  Alert,
   ScrollView,
   StyleSheet,
   Text,
@@ -9,7 +8,12 @@ import {
   TouchableOpacity,
   View,
 } from 'react-native';
-import { LogLevel, OneSignal } from 'react-native-onesignal';
+import {
+  LogLevel,
+  NotificationClickEvent,
+  NotificationWillDisplayEvent,
+  OneSignal,
+} from 'react-native-onesignal';
 import { SafeAreaView } from 'react-native-safe-area-context';
 import OSButtons from './OSButtons';
 import OSConsole from './OSConsole';
@@ -37,44 +41,51 @@ const OSDemo: React.FC = () => {
   }, []);
 
   const onForegroundWillDisplay = useCallback(
-    (event: unknown) => {
-      OSLog('OneSignal: notification will show in foreground:', event);
-      const notif = (
-        event as { getNotification: () => { title: string } }
-      ).getNotification();
+    (event: NotificationWillDisplayEvent) => {
+      const notif = event.getNotification();
+      OSLog('OneSignal: notification will show in foreground:', notif.title);
+      console.log('Will display notification event:', notif);
 
-      const cancelButton = {
-        text: 'Cancel',
-        onPress: () => {
-          (event as { preventDefault: () => void }).preventDefault();
-        },
-        style: 'cancel' as const,
-      };
+      event.preventDefault();
 
-      const completeButton = {
-        text: 'Display',
-        onPress: () => {
-          (event as { getNotification: () => { display: () => void } })
-            .getNotification()
-            .display();
-        },
-      };
+      setTimeout(() => {
+        notif.display();
+      }, 5000);
 
-      Alert.alert(
-        'Display notification?',
-        notif.title,
-        [cancelButton, completeButton],
-        {
-          cancelable: true,
-        },
-      );
+      // const cancelButton = {
+      //   text: 'Cancel',
+      //   onPress: () => {
+      //     (event as { preventDefault: () => void }).preventDefault();
+      //   },
+      //   style: 'cancel' as const,
+      // };
+
+      // const completeButton = {
+      //   text: 'Display',
+      //   onPress: () => {
+      //     (event as { getNotification: () => { display: () => void } })
+      //       .getNotification()
+      //       .display();
+      //   },
+      // };
+
+      // Alert.alert(
+      //   'Display notification?',
+      //   notif.title,
+      //   [cancelButton, completeButton],
+      //   {
+      //     cancelable: true,
+      //   },
+      // );
     },
     [OSLog],
   );
 
   const onNotificationClick = useCallback(
-    (event: unknown) => {
-      OSLog('OneSignal: notification clicked:', event);
+    (event: NotificationClickEvent) => {
+      const notif = event.notification;
+      OSLog('OneSignal: notification clicked:', notif.title);
+      console.log('Notification clicked event:', notif);
     },
     [OSLog],
   );

--- a/examples/RNOneSignalTS/ios/Podfile.lock
+++ b/examples/RNOneSignalTS/ios/Podfile.lock
@@ -8,9 +8,9 @@ PODS:
   - hermes-engine (0.82.1):
     - hermes-engine/Pre-built (= 0.82.1)
   - hermes-engine/Pre-built (0.82.1)
-  - OneSignalXCFramework (5.2.15):
-    - OneSignalXCFramework/OneSignalComplete (= 5.2.15)
-  - OneSignalXCFramework/OneSignal (5.2.15):
+  - OneSignalXCFramework (5.2.16):
+    - OneSignalXCFramework/OneSignalComplete (= 5.2.16)
+  - OneSignalXCFramework/OneSignal (5.2.16):
     - OneSignalXCFramework/OneSignalCore
     - OneSignalXCFramework/OneSignalExtension
     - OneSignalXCFramework/OneSignalLiveActivities
@@ -18,38 +18,38 @@ PODS:
     - OneSignalXCFramework/OneSignalOSCore
     - OneSignalXCFramework/OneSignalOutcomes
     - OneSignalXCFramework/OneSignalUser
-  - OneSignalXCFramework/OneSignalComplete (5.2.15):
+  - OneSignalXCFramework/OneSignalComplete (5.2.16):
     - OneSignalXCFramework/OneSignal
     - OneSignalXCFramework/OneSignalInAppMessages
     - OneSignalXCFramework/OneSignalLocation
-  - OneSignalXCFramework/OneSignalCore (5.2.15)
-  - OneSignalXCFramework/OneSignalExtension (5.2.15):
+  - OneSignalXCFramework/OneSignalCore (5.2.16)
+  - OneSignalXCFramework/OneSignalExtension (5.2.16):
     - OneSignalXCFramework/OneSignalCore
     - OneSignalXCFramework/OneSignalOutcomes
-  - OneSignalXCFramework/OneSignalInAppMessages (5.2.15):
+  - OneSignalXCFramework/OneSignalInAppMessages (5.2.16):
     - OneSignalXCFramework/OneSignalCore
     - OneSignalXCFramework/OneSignalNotifications
     - OneSignalXCFramework/OneSignalOSCore
     - OneSignalXCFramework/OneSignalOutcomes
     - OneSignalXCFramework/OneSignalUser
-  - OneSignalXCFramework/OneSignalLiveActivities (5.2.15):
+  - OneSignalXCFramework/OneSignalLiveActivities (5.2.16):
     - OneSignalXCFramework/OneSignalCore
     - OneSignalXCFramework/OneSignalOSCore
     - OneSignalXCFramework/OneSignalUser
-  - OneSignalXCFramework/OneSignalLocation (5.2.15):
+  - OneSignalXCFramework/OneSignalLocation (5.2.16):
     - OneSignalXCFramework/OneSignalCore
     - OneSignalXCFramework/OneSignalNotifications
     - OneSignalXCFramework/OneSignalOSCore
     - OneSignalXCFramework/OneSignalUser
-  - OneSignalXCFramework/OneSignalNotifications (5.2.15):
+  - OneSignalXCFramework/OneSignalNotifications (5.2.16):
     - OneSignalXCFramework/OneSignalCore
     - OneSignalXCFramework/OneSignalExtension
     - OneSignalXCFramework/OneSignalOutcomes
-  - OneSignalXCFramework/OneSignalOSCore (5.2.15):
+  - OneSignalXCFramework/OneSignalOSCore (5.2.16):
     - OneSignalXCFramework/OneSignalCore
-  - OneSignalXCFramework/OneSignalOutcomes (5.2.15):
+  - OneSignalXCFramework/OneSignalOutcomes (5.2.16):
     - OneSignalXCFramework/OneSignalCore
-  - OneSignalXCFramework/OneSignalUser (5.2.15):
+  - OneSignalXCFramework/OneSignalUser (5.2.16):
     - OneSignalXCFramework/OneSignalCore
     - OneSignalXCFramework/OneSignalNotifications
     - OneSignalXCFramework/OneSignalOSCore
@@ -1828,8 +1828,8 @@ PODS:
     - React-RCTFBReactNativeSpec
     - ReactCommon/turbomodule/core
     - SocketRocket
-  - react-native-onesignal (5.2.16):
-    - OneSignalXCFramework (= 5.2.15)
+  - react-native-onesignal (5.2.17):
+    - OneSignalXCFramework (= 5.2.16)
     - React (< 1.0.0, >= 0.13.0)
   - react-native-safe-area-context (5.6.2):
     - boost
@@ -2768,7 +2768,7 @@ SPEC CHECKSUMS:
   fmt: a40bb5bd0294ea969aaaba240a927bd33d878cdd
   glog: 5683914934d5b6e4240e497e0f4a3b42d1854183
   hermes-engine: 273e30e7fb618279934b0b95ffab60ecedb7acf5
-  OneSignalXCFramework: ea9e14a95b92ad48d9b35037cbae88a9542bdea3
+  OneSignalXCFramework: 8ed6648481bee0bd973a138fecd80331b798524f
   RCT-Folly: 846fda9475e61ec7bcbf8a3fe81edfcaeb090669
   RCTDeprecation: f17e2ebc07876ca9ab8eb6e4b0a4e4647497ae3a
   RCTRequired: e2c574c1b45231f7efb0834936bd609d75072b63
@@ -2802,7 +2802,7 @@ SPEC CHECKSUMS:
   React-logger: 500f2fa5697d224e63c33d913c8a4765319e19bf
   React-Mapbuffer: 06d59c448da7e34eb05b3fb2189e12f6a30fec57
   React-microtasksnativemodule: d1ee999dc9052e23f6488b730fa2d383a4ea40e5
-  react-native-onesignal: 1634e96223d6a666b76f38f4a20fec6c87bbb0c4
+  react-native-onesignal: 3b6cd199ec0db87166ef7fb595715627a35b3244
   react-native-safe-area-context: c00143b4823773bba23f2f19f85663ae89ceb460
   React-NativeModulesApple: 46690a0fe94ec28fc6fc686ec797b911d251ded0
   React-oscompat: 95875e81f5d4b3c7b2c888d5bd2c9d83450d8bdb

--- a/examples/RNOneSignalTS/ios/RNOneSignalTS.xcodeproj/project.pbxproj
+++ b/examples/RNOneSignalTS/ios/RNOneSignalTS.xcodeproj/project.pbxproj
@@ -282,7 +282,7 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = "set -e\n\nWITH_ENVIRONMENT=\"$REACT_NATIVE_PATH/scripts/xcode/with-environment.sh\"\nREACT_NATIVE_XCODE=\"$REACT_NATIVE_PATH/scripts/react-native-xcode.sh\"\n\n/bin/sh -c \"$WITH_ENVIRONMENT $REACT_NATIVE_XCODE\"\n";
+			shellScript = "set -e\n\nWITH_ENVIRONMENT=\"$REACT_NATIVE_PATH/scripts/xcode/with-environment.sh\"\nREACT_NATIVE_XCODE=\"$REACT_NATIVE_PATH/scripts/react-native-xcode.sh\"\n\n/bin/sh -c \"\\\"$WITH_ENVIRONMENT\\\" \\\"$REACT_NATIVE_XCODE\\\"\"\n";
 		};
 		00EEFC60759A1932668264C0 /* [CP] Embed Pods Frameworks */ = {
 			isa = PBXShellScriptBuildPhase;

--- a/examples/RNOneSignalTS/setup.sh
+++ b/examples/RNOneSignalTS/setup.sh
@@ -9,6 +9,6 @@ bun pm pack
 mv react-native-onesignal-*.tgz react-native-onesignal.tgz
 
 # Use fresh install of the package
-cd $ORIGINAL_DIR
+cd "$ORIGINAL_DIR"
 bun pm cache rm
 bun i

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-native-onesignal",
-  "version": "5.2.16",
+  "version": "5.2.17",
   "description": "React Native OneSignal SDK",
   "files": [
     "dist",

--- a/react-native-onesignal.podspec
+++ b/react-native-onesignal.podspec
@@ -22,5 +22,5 @@ Pod::Spec.new do |s|
   # pod 'React', :path => '../node_modules/react-native/'
 
   # The Native OneSignal-iOS-SDK XCFramework from cocoapods.
-  s.dependency 'OneSignalXCFramework', '5.2.15'
+  s.dependency 'OneSignalXCFramework', '5.2.16'
 end


### PR DESCRIPTION
Channels: Current


### 🛠️ Native Dependency Updates
- Update Android SDK from 5.1.38 to 5.4.2
  - feat: Enable docs ([#2507](https://github.com/OneSignal/OneSignal-Android-SDK/pull/2507))
  - bug: catch exception if opening a notification fails ([#2508](https://github.com/OneSignal/OneSignal-Android-SDK/pull/2508))
  - fix: IAM with NOT_EQUAL_TO trigger always shows up ([#2509](https://github.com/OneSignal/OneSignal-Android-SDK/pull/2509))
  - fix: NPE when setting timezone on app focus ([#2505](https://github.com/OneSignal/OneSignal-Android-SDK/pull/2505))
  - fix: send receive receipt even when preventDefault is called ([#2512](https://github.com/OneSignal/OneSignal-Android-SDK/pull/2512))
  - chore: Kotlin 1.9 update ([#2403](https://github.com/OneSignal/OneSignal-Android-SDK/pull/2403))
  - chore: Bump firebase-messaging to 24.0.0 ([#2149](https://github.com/OneSignal/OneSignal-Android-SDK/pull/2149))
- Update iOS SDK from 5.2.15 to 5.2.16
  - Feat: live activities click events ([OneSignal-iOS-SDK#1593](https://github.com/OneSignal/OneSignal-iOS-SDK/pull/1593))
  - fix: Retry IAM fetch when OneSignal ID becomes available ([OneSignal-iOS-SDK#1626](https://github.com/OneSignal/OneSignal-iOS-SDK/pull/1626))
  - fix: NotEqualTo trigger no longer matches non-existent properties ([OneSignal-iOS-SDK#1625](https://github.com/OneSignal/OneSignal-iOS-SDK/pull/1625))
  - fix: Remove exposing var and let macros ([OneSignal-iOS-SDK#1622](https://github.com/OneSignal/OneSignal-iOS-SDK/pull/1622))
  - fix: forward declarations for Objective-C++ compatibility ([OneSignal-iOS-SDK#1621](https://github.com/OneSignal/OneSignal-iOS-SDK/pull/1621))

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/OneSignal/react-native-onesignal/1898)
<!-- Reviewable:end -->
