### PR TITLE
chore: Release 5.3.0

### DIFF
--- a/__mocks__/react-native.ts
+++ b/__mocks__/react-native.ts
@@ -86,6 +86,7 @@ const mockRNOneSignal = {
   addOutcomeWithValue: vi.fn(),
   displayNotification: vi.fn(),
   preventDefault: vi.fn(),
+  trackEvent: vi.fn(),
 };
 
 const mockPlatform = {

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -31,7 +31,7 @@ dependencies {
 
     // api is used instead of implementation so the parent :app project can access any of the OneSignal Java
     //   classes if needed. Such as com.onesignal.NotificationExtenderService
-    api 'com.onesignal:OneSignal:5.4.2'
+    api 'com.onesignal:OneSignal:5.6.0'
     
     testImplementation 'junit:junit:4.12'
 }

--- a/android/src/main/java/com/onesignal/rnonesignalandroid/RNOneSignal.java
+++ b/android/src/main/java/com/onesignal/rnonesignalandroid/RNOneSignal.java
@@ -35,6 +35,9 @@ Authors:
 
 package com.onesignal.rnonesignalandroid;
 
+import java.util.HashMap;
+import java.util.Map;
+
 import android.content.Context;
 import com.facebook.react.bridge.Arguments;
 import com.facebook.react.bridge.LifecycleEventListener;
@@ -753,5 +756,11 @@ public class RNOneSignal extends ReactContextBaseJavaModule
     @ReactMethod
     public void removeListeners(int count) {
         // Keep: Required for RN built in Event Emitter Calls.
+    }
+
+
+    @ReactMethod
+    public void trackEvent(String name, @Nullable ReadableMap properties) {
+        OneSignal.getUser().trackEvent(name, properties != null ? RNUtils.convertReadableMapToMap(properties) : null);
     }
 }

--- a/android/src/main/java/com/onesignal/rnonesignalandroid/RNOneSignal.java
+++ b/android/src/main/java/com/onesignal/rnonesignalandroid/RNOneSignal.java
@@ -35,10 +35,8 @@ Authors:
 
 package com.onesignal.rnonesignalandroid;
 
-import java.util.HashMap;
-import java.util.Map;
-
 import android.content.Context;
+import androidx.annotation.Nullable;
 import com.facebook.react.bridge.Arguments;
 import com.facebook.react.bridge.LifecycleEventListener;
 import com.facebook.react.bridge.Promise;
@@ -758,9 +756,11 @@ public class RNOneSignal extends ReactContextBaseJavaModule
         // Keep: Required for RN built in Event Emitter Calls.
     }
 
-
     @ReactMethod
     public void trackEvent(String name, @Nullable ReadableMap properties) {
-        OneSignal.getUser().trackEvent(name, properties != null ? RNUtils.convertReadableMapToMap(properties) : null);
+        OneSignal.getUser()
+                .trackEvent(
+                        name,
+                        properties != null ? RNUtils.convertReadableMapToMap(properties) : new java.util.HashMap<>());
     }
 }

--- a/android/src/main/java/com/onesignal/rnonesignalandroid/RNUtils.java
+++ b/android/src/main/java/com/onesignal/rnonesignalandroid/RNUtils.java
@@ -271,46 +271,58 @@ public class RNUtils {
     public static Map<String, Object> convertReadableMapToMap(ReadableMap readableMap) {
         Map<String, Object> map = new HashMap<>();
         ReadableMapKeySetIterator iterator = readableMap.keySetIterator();
-    
+
         while (iterator.hasNextKey()) {
             String key = iterator.nextKey();
             ReadableType type = readableMap.getType(key);
             map.put(key, convertValue(type, readableMap, key));
         }
-    
+
         return map;
     }
-    
+
     public static List<Object> convertReadableArrayToList(ReadableArray readableArray) {
         List<Object> list = new ArrayList<>();
-    
+
         for (int i = 0; i < readableArray.size(); i++) {
             ReadableType type = readableArray.getType(i);
             list.add(convertValue(type, readableArray, i));
         }
-    
+
         return list;
     }
-    
+
     private static Object convertValue(ReadableType type, ReadableMap map, String key) {
         switch (type) {
-            case Boolean: return map.getBoolean(key);
-            case Number: return map.getDouble(key);
-            case String: return map.getString(key);
-            case Map: return convertReadableMapToMap(map.getMap(key));
-            case Array: return convertReadableArrayToList(map.getArray(key));
-            default: return null;
+            case Boolean:
+                return map.getBoolean(key);
+            case Number:
+                return map.getDouble(key);
+            case String:
+                return map.getString(key);
+            case Map:
+                return convertReadableMapToMap(map.getMap(key));
+            case Array:
+                return convertReadableArrayToList(map.getArray(key));
+            default:
+                return null;
         }
     }
-    
+
     private static Object convertValue(ReadableType type, ReadableArray array, int index) {
         switch (type) {
-            case Boolean: return array.getBoolean(index);
-            case Number: return array.getDouble(index);
-            case String: return array.getString(index);
-            case Map: return convertReadableMapToMap(array.getMap(index));
-            case Array: return convertReadableArrayToList(array.getArray(index));
-            default: return null;
+            case Boolean:
+                return array.getBoolean(index);
+            case Number:
+                return array.getDouble(index);
+            case String:
+                return array.getString(index);
+            case Map:
+                return convertReadableMapToMap(array.getMap(index));
+            case Array:
+                return convertReadableArrayToList(array.getArray(index));
+            default:
+                return null;
         }
     }
 

--- a/android/src/main/java/com/onesignal/rnonesignalandroid/RNUtils.java
+++ b/android/src/main/java/com/onesignal/rnonesignalandroid/RNUtils.java
@@ -268,6 +268,52 @@ public class RNUtils {
         return stringMap;
     }
 
+    public static Map<String, Object> convertReadableMapToMap(ReadableMap readableMap) {
+        Map<String, Object> map = new HashMap<>();
+        ReadableMapKeySetIterator iterator = readableMap.keySetIterator();
+    
+        while (iterator.hasNextKey()) {
+            String key = iterator.nextKey();
+            ReadableType type = readableMap.getType(key);
+            map.put(key, convertValue(type, readableMap, key));
+        }
+    
+        return map;
+    }
+    
+    public static List<Object> convertReadableArrayToList(ReadableArray readableArray) {
+        List<Object> list = new ArrayList<>();
+    
+        for (int i = 0; i < readableArray.size(); i++) {
+            ReadableType type = readableArray.getType(i);
+            list.add(convertValue(type, readableArray, i));
+        }
+    
+        return list;
+    }
+    
+    private static Object convertValue(ReadableType type, ReadableMap map, String key) {
+        switch (type) {
+            case Boolean: return map.getBoolean(key);
+            case Number: return map.getDouble(key);
+            case String: return map.getString(key);
+            case Map: return convertReadableMapToMap(map.getMap(key));
+            case Array: return convertReadableArrayToList(map.getArray(key));
+            default: return null;
+        }
+    }
+    
+    private static Object convertValue(ReadableType type, ReadableArray array, int index) {
+        switch (type) {
+            case Boolean: return array.getBoolean(index);
+            case Number: return array.getDouble(index);
+            case String: return array.getString(index);
+            case Map: return convertReadableMapToMap(array.getMap(index));
+            case Array: return convertReadableArrayToList(array.getArray(index));
+            default: return null;
+        }
+    }
+
     public static HashMap<String, Object> convertPermissionToMap(boolean granted) {
         HashMap<String, Object> hash = new HashMap<>();
 

--- a/android/src/main/java/com/onesignal/rnonesignalandroid/RNUtils.java
+++ b/android/src/main/java/com/onesignal/rnonesignalandroid/RNUtils.java
@@ -275,7 +275,10 @@ public class RNUtils {
         while (iterator.hasNextKey()) {
             String key = iterator.nextKey();
             ReadableType type = readableMap.getType(key);
-            map.put(key, convertValue(type, readableMap, key));
+            Object value = convertValue(type, readableMap, key);
+            if (value != null) {
+                map.put(key, value);
+            }
         }
 
         return map;
@@ -286,7 +289,10 @@ public class RNUtils {
 
         for (int i = 0; i < readableArray.size(); i++) {
             ReadableType type = readableArray.getType(i);
-            list.add(convertValue(type, readableArray, i));
+            Object value = convertValue(type, readableArray, i);
+            if (value != null) {
+                list.add(value);
+            }
         }
 
         return list;

--- a/build.gradle
+++ b/build.gradle
@@ -19,7 +19,7 @@ spotless {
   java {
     target 'android/**/*.java', 'examples/RNOneSignalTS/android/app/src/**/*.java'
     targetExclude '**/build/**'
-    palantirJavaFormat('2.47.0')
+    palantirJavaFormat('2.85.0')
     removeUnusedImports()
     trimTrailingWhitespace()
     endWithNewline()

--- a/build.gradle
+++ b/build.gradle
@@ -19,7 +19,7 @@ spotless {
   java {
     target 'android/**/*.java', 'examples/RNOneSignalTS/android/app/src/**/*.java'
     targetExclude '**/build/**'
-    palantirJavaFormat('2.28.0')
+    palantirJavaFormat('2.47.0')
     removeUnusedImports()
     trimTrailingWhitespace()
     endWithNewline()

--- a/examples/RNOneSignalTS/OSButtons.tsx
+++ b/examples/RNOneSignalTS/OSButtons.tsx
@@ -396,11 +396,33 @@ const OSButtons: React.FC<Props> = ({ loggingFunction, inputFieldValue }) => {
       },
     );
 
+    const trackEventButton = renderButtonView('Track Event', () => {
+      loggingFunction('Tracking event: ', 'ReactNative');
+      const platform = Platform.OS; // This will be 'ios' or 'android'
+      OneSignal.User.trackEvent(`ReactNative-${platform}-noprops`);
+      OneSignal.User.trackEvent(`ReactNative-${platform}`, {
+        someNum: 123,
+        someFloat: 3.14159,
+        someString: 'abc',
+        someBool: true,
+        someObject: {
+          abc: '123',
+          nested: {
+            def: '456',
+          },
+        },
+        someArray: [1, 2],
+        someMixedArray: [1, '2', { abc: '123' }],
+        someNull: null,
+      });
+    });
+
     return [
       loginButton,
       logoutButton,
       addEmailButton,
       removeEmailButton,
+      trackEventButton,
       sendTagWithKeyButton,
       deleteTagWithKeyButton,
       addTagsButton,

--- a/examples/RNOneSignalTS/OSButtons.tsx
+++ b/examples/RNOneSignalTS/OSButtons.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { Text, View } from 'react-native';
+import { Platform, Text, View } from 'react-native';
 import { OneSignal } from 'react-native-onesignal';
 import { renderButtonView } from './Helpers';
 // Remove: import {Text, Divider} from '@react-native-material/core';
@@ -410,9 +410,10 @@ const OSButtons: React.FC<Props> = ({ loggingFunction, inputFieldValue }) => {
           nested: {
             def: '456',
           },
+          ghi: null,
         },
         someArray: [1, 2],
-        someMixedArray: [1, '2', { abc: '123' }],
+        someMixedArray: [1, '2', { abc: '123' }, null],
         someNull: null,
       });
     });

--- a/examples/RNOneSignalTS/ios/Podfile.lock
+++ b/examples/RNOneSignalTS/ios/Podfile.lock
@@ -8,9 +8,9 @@ PODS:
   - hermes-engine (0.82.1):
     - hermes-engine/Pre-built (= 0.82.1)
   - hermes-engine/Pre-built (0.82.1)
-  - OneSignalXCFramework (5.2.16):
-    - OneSignalXCFramework/OneSignalComplete (= 5.2.16)
-  - OneSignalXCFramework/OneSignal (5.2.16):
+  - OneSignalXCFramework (5.4.0):
+    - OneSignalXCFramework/OneSignalComplete (= 5.4.0)
+  - OneSignalXCFramework/OneSignal (5.4.0):
     - OneSignalXCFramework/OneSignalCore
     - OneSignalXCFramework/OneSignalExtension
     - OneSignalXCFramework/OneSignalLiveActivities
@@ -18,38 +18,38 @@ PODS:
     - OneSignalXCFramework/OneSignalOSCore
     - OneSignalXCFramework/OneSignalOutcomes
     - OneSignalXCFramework/OneSignalUser
-  - OneSignalXCFramework/OneSignalComplete (5.2.16):
+  - OneSignalXCFramework/OneSignalComplete (5.4.0):
     - OneSignalXCFramework/OneSignal
     - OneSignalXCFramework/OneSignalInAppMessages
     - OneSignalXCFramework/OneSignalLocation
-  - OneSignalXCFramework/OneSignalCore (5.2.16)
-  - OneSignalXCFramework/OneSignalExtension (5.2.16):
+  - OneSignalXCFramework/OneSignalCore (5.4.0)
+  - OneSignalXCFramework/OneSignalExtension (5.4.0):
     - OneSignalXCFramework/OneSignalCore
     - OneSignalXCFramework/OneSignalOutcomes
-  - OneSignalXCFramework/OneSignalInAppMessages (5.2.16):
+  - OneSignalXCFramework/OneSignalInAppMessages (5.4.0):
     - OneSignalXCFramework/OneSignalCore
     - OneSignalXCFramework/OneSignalNotifications
     - OneSignalXCFramework/OneSignalOSCore
     - OneSignalXCFramework/OneSignalOutcomes
     - OneSignalXCFramework/OneSignalUser
-  - OneSignalXCFramework/OneSignalLiveActivities (5.2.16):
+  - OneSignalXCFramework/OneSignalLiveActivities (5.4.0):
     - OneSignalXCFramework/OneSignalCore
     - OneSignalXCFramework/OneSignalOSCore
     - OneSignalXCFramework/OneSignalUser
-  - OneSignalXCFramework/OneSignalLocation (5.2.16):
+  - OneSignalXCFramework/OneSignalLocation (5.4.0):
     - OneSignalXCFramework/OneSignalCore
     - OneSignalXCFramework/OneSignalNotifications
     - OneSignalXCFramework/OneSignalOSCore
     - OneSignalXCFramework/OneSignalUser
-  - OneSignalXCFramework/OneSignalNotifications (5.2.16):
+  - OneSignalXCFramework/OneSignalNotifications (5.4.0):
     - OneSignalXCFramework/OneSignalCore
     - OneSignalXCFramework/OneSignalExtension
     - OneSignalXCFramework/OneSignalOutcomes
-  - OneSignalXCFramework/OneSignalOSCore (5.2.16):
+  - OneSignalXCFramework/OneSignalOSCore (5.4.0):
     - OneSignalXCFramework/OneSignalCore
-  - OneSignalXCFramework/OneSignalOutcomes (5.2.16):
+  - OneSignalXCFramework/OneSignalOutcomes (5.4.0):
     - OneSignalXCFramework/OneSignalCore
-  - OneSignalXCFramework/OneSignalUser (5.2.16):
+  - OneSignalXCFramework/OneSignalUser (5.4.0):
     - OneSignalXCFramework/OneSignalCore
     - OneSignalXCFramework/OneSignalNotifications
     - OneSignalXCFramework/OneSignalOSCore
@@ -1828,8 +1828,8 @@ PODS:
     - React-RCTFBReactNativeSpec
     - ReactCommon/turbomodule/core
     - SocketRocket
-  - react-native-onesignal (5.2.17):
-    - OneSignalXCFramework (= 5.2.16)
+  - react-native-onesignal (5.3.0):
+    - OneSignalXCFramework (= 5.4.0)
     - React (< 1.0.0, >= 0.13.0)
   - react-native-safe-area-context (5.6.2):
     - boost
@@ -2768,7 +2768,7 @@ SPEC CHECKSUMS:
   fmt: a40bb5bd0294ea969aaaba240a927bd33d878cdd
   glog: 5683914934d5b6e4240e497e0f4a3b42d1854183
   hermes-engine: 273e30e7fb618279934b0b95ffab60ecedb7acf5
-  OneSignalXCFramework: 8ed6648481bee0bd973a138fecd80331b798524f
+  OneSignalXCFramework: 95b6391df5a91b448003149c1a633ade42ceca1e
   RCT-Folly: 846fda9475e61ec7bcbf8a3fe81edfcaeb090669
   RCTDeprecation: f17e2ebc07876ca9ab8eb6e4b0a4e4647497ae3a
   RCTRequired: e2c574c1b45231f7efb0834936bd609d75072b63
@@ -2802,7 +2802,7 @@ SPEC CHECKSUMS:
   React-logger: 500f2fa5697d224e63c33d913c8a4765319e19bf
   React-Mapbuffer: 06d59c448da7e34eb05b3fb2189e12f6a30fec57
   React-microtasksnativemodule: d1ee999dc9052e23f6488b730fa2d383a4ea40e5
-  react-native-onesignal: 3b6cd199ec0db87166ef7fb595715627a35b3244
+  react-native-onesignal: 68c8423063cc8ead827e09bc71d139c14850feaf
   react-native-safe-area-context: c00143b4823773bba23f2f19f85663ae89ceb460
   React-NativeModulesApple: 46690a0fe94ec28fc6fc686ec797b911d251ded0
   React-oscompat: 95875e81f5d4b3c7b2c888d5bd2c9d83450d8bdb

--- a/ios/RCTOneSignal/RCTOneSignalEventEmitter.m
+++ b/ios/RCTOneSignal/RCTOneSignalEventEmitter.m
@@ -628,4 +628,8 @@ RCT_EXPORT_METHOD(initInAppMessageClickHandlerParams) {
   }
 }
 
+RCT_EXPORT_METHOD(trackEvent:(NSString *)name withProperties:(NSDictionary * _Nullable)properties) {
+    [OneSignal.User trackEventWithName:name properties:properties];
+}
+
 @end

--- a/ios/RCTOneSignal/RCTOneSignalEventEmitter.m
+++ b/ios/RCTOneSignal/RCTOneSignalEventEmitter.m
@@ -628,8 +628,9 @@ RCT_EXPORT_METHOD(initInAppMessageClickHandlerParams) {
   }
 }
 
-RCT_EXPORT_METHOD(trackEvent:(NSString *)name withProperties:(NSDictionary * _Nullable)properties) {
-    [OneSignal.User trackEventWithName:name properties:properties];
+RCT_EXPORT_METHOD(trackEvent : (NSString *)name withProperties : (
+    NSDictionary *_Nullable)properties) {
+  [OneSignal.User trackEventWithName:name properties:properties];
 }
 
 @end

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-native-onesignal",
-  "version": "5.2.17",
+  "version": "5.3.0",
   "description": "React Native OneSignal SDK",
   "files": [
     "dist",

--- a/react-native-onesignal.podspec
+++ b/react-native-onesignal.podspec
@@ -22,5 +22,5 @@ Pod::Spec.new do |s|
   # pod 'React', :path => '../node_modules/react-native/'
 
   # The Native OneSignal-iOS-SDK XCFramework from cocoapods.
-  s.dependency 'OneSignalXCFramework', '5.2.16'
+  s.dependency 'OneSignalXCFramework', '5.4.0'
 end

--- a/src/helpers.test.ts
+++ b/src/helpers.test.ts
@@ -1,6 +1,10 @@
 import type { NativeModule } from 'react-native';
 import type { MockInstance } from 'vitest';
-import { isNativeModuleLoaded, isValidCallback } from './helpers';
+import {
+  isNativeModuleLoaded,
+  isObjectSerializable,
+  isValidCallback,
+} from './helpers';
 
 describe('helpers', () => {
   let errorSpy: MockInstance;
@@ -56,6 +60,44 @@ describe('helpers', () => {
     test('should return true when module is loaded', () => {
       const result = isNativeModuleLoaded({} as NativeModule);
       expect(result).toBe(true);
+    });
+  });
+
+  describe('isObjectSerializable', () => {
+    test.each([
+      { description: 'an empty object', value: {} },
+      { description: 'an object with string values', value: { key: 'value' } },
+      { description: 'an object with number values', value: { count: 42 } },
+      { description: 'an object with boolean values', value: { active: true } },
+      { description: 'an object with null values', value: { data: null } },
+      {
+        description: 'a nested object',
+        value: { outer: { inner: 'value' } },
+      },
+      {
+        description: 'an object with array values',
+        value: { items: [1, 2, 3] },
+      },
+    ])('should return true for $description', ({ value }) => {
+      expect(isObjectSerializable(value)).toBe(true);
+    });
+
+    test.each([
+      { description: 'null', value: null },
+      { description: 'undefined', value: undefined },
+      { description: 'a string', value: 'string' },
+      { description: 'a number', value: 123 },
+      { description: 'a boolean', value: true },
+      { description: 'an array', value: [1, 2, 3] },
+      { description: 'a function', value: () => {} },
+    ])('should return false for $description', ({ value }) => {
+      expect(isObjectSerializable(value)).toBe(false);
+    });
+
+    test('should return false for objects with circular references', () => {
+      const circular: Record<string, unknown> = {};
+      circular.self = circular;
+      expect(isObjectSerializable(circular)).toBe(false);
     });
   });
 });

--- a/src/helpers.ts
+++ b/src/helpers.ts
@@ -16,3 +16,18 @@ export function isNativeModuleLoaded(module: NativeModule): boolean {
 
   return true;
 }
+
+/**
+ * Returns true if the value is a JSON-serializable object.
+ */
+export function isObjectSerializable(value: unknown): boolean {
+  if (!(typeof value === 'object' && value !== null && !Array.isArray(value))) {
+    return false;
+  }
+  try {
+    JSON.stringify(value);
+    return true;
+  } catch {
+    return false;
+  }
+}

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -894,6 +894,49 @@ describe('OneSignal', () => {
       });
     });
 
+    describe('trackEvent', () => {
+      test('should track event with name and properties', () => {
+        const properties = { key: 'value', count: 42 };
+        OneSignal.User.trackEvent('purchase', properties);
+        expect(mockRNOneSignal.trackEvent).toHaveBeenCalledWith(
+          'purchase',
+          properties,
+        );
+      });
+
+      test('should track event with just name using default empty properties', () => {
+        OneSignal.User.trackEvent('page_view');
+        expect(mockRNOneSignal.trackEvent).toHaveBeenCalledWith('page_view', {});
+      });
+
+      test('should not track event if native module is not loaded', () => {
+        isNativeLoadedSpy.mockReturnValue(false);
+        OneSignal.User.trackEvent('event');
+        expect(mockRNOneSignal.trackEvent).not.toHaveBeenCalled();
+      });
+
+      test('should not track event if properties are not serializable', () => {
+        const circular: Record<string, unknown> = {};
+        circular.self = circular;
+        OneSignal.User.trackEvent('event', circular);
+        expect(errorSpy).toHaveBeenCalledWith(
+          'Properties must be a JSON-serializable object',
+        );
+        expect(mockRNOneSignal.trackEvent).not.toHaveBeenCalled();
+      });
+
+      test('should not track event if properties is not an object', () => {
+        OneSignal.User.trackEvent(
+          'event',
+          'invalid' as unknown as Record<string, unknown>,
+        );
+        expect(errorSpy).toHaveBeenCalledWith(
+          'Properties must be a JSON-serializable object',
+        );
+        expect(mockRNOneSignal.trackEvent).not.toHaveBeenCalled();
+      });
+    });
+
     describe('Notifications', () => {
       describe('hasPermission (deprecated)', () => {
         test('should log deprecation warning', () => {

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -906,7 +906,10 @@ describe('OneSignal', () => {
 
       test('should track event with just name using default empty properties', () => {
         OneSignal.User.trackEvent('page_view');
-        expect(mockRNOneSignal.trackEvent).toHaveBeenCalledWith('page_view', {});
+        expect(mockRNOneSignal.trackEvent).toHaveBeenCalledWith(
+          'page_view',
+          {},
+        );
       });
 
       test('should not track event if native module is not loaded', () => {

--- a/src/index.ts
+++ b/src/index.ts
@@ -590,6 +590,24 @@ export namespace OneSignal {
 
       return RNOneSignal.getTags();
     }
+
+    /**
+     * Track custom events for the current user.
+     * Note: Currently, null values will be omitted for Android.
+     * */
+    export function trackEvent(
+      name: string,
+      properties: Record<string, unknown> = {},
+    ) {
+      if (!isNativeModuleLoaded(RNOneSignal)) return;
+
+      if (!isObjectSerializable(properties)) {
+        console.error('Properties must be JSON-serializable');
+        return;
+      }
+
+      RNOneSignal.trackEvent(name, properties);
+    }
   }
 
   export namespace Notifications {

--- a/src/index.ts
+++ b/src/index.ts
@@ -956,6 +956,21 @@ export namespace OneSignal {
   }
 }
 
+/**
+ * Returns true if the value is a JSON-serializable object.
+ */
+function isObjectSerializable(value: unknown): boolean {
+  if (!(typeof value === 'object' && value !== null && !Array.isArray(value))) {
+    return false;
+  }
+  try {
+    JSON.stringify(value);
+    return true;
+  } catch (e) {
+    return false;
+  }
+}
+
 export { OSNotificationPermission } from './constants/subscription';
 export {
   NotificationWillDisplayEvent,

--- a/src/index.ts
+++ b/src/index.ts
@@ -14,7 +14,11 @@ import {
 import type { OSNotificationPermission } from './constants/subscription';
 import EventManager from './events/EventManager';
 import NotificationWillDisplayEvent from './events/NotificationWillDisplayEvent';
-import { isNativeModuleLoaded, isValidCallback } from './helpers';
+import {
+  isNativeModuleLoaded,
+  isObjectSerializable,
+  isValidCallback,
+} from './helpers';
 import type {
   InAppMessage,
   InAppMessageClickEvent,
@@ -602,7 +606,7 @@ export namespace OneSignal {
       if (!isNativeModuleLoaded(RNOneSignal)) return;
 
       if (!isObjectSerializable(properties)) {
-        console.error('Properties must be JSON-serializable');
+        console.error('Properties must be a JSON-serializable object');
         return;
       }
 
@@ -953,21 +957,6 @@ export namespace OneSignal {
 
       RNOneSignal.addOutcomeWithValue(name, Number(value));
     }
-  }
-}
-
-/**
- * Returns true if the value is a JSON-serializable object.
- */
-function isObjectSerializable(value: unknown): boolean {
-  if (!(typeof value === 'object' && value !== null && !Array.isArray(value))) {
-    return false;
-  }
-  try {
-    JSON.stringify(value);
-    return true;
-  } catch (e) {
-    return false;
   }
 }
 


### PR DESCRIPTION
Channels: Current

### 🎉 Custom Events Support
This beta release introduces Custom Events support for the react native sdk.

Please see documentation on [Custom Events](https://documentation.onesignal.com/docs/mobile-sdk-reference#trackevent).

We appreciate your experience and feedback using this beta version!


### 🛠️ Native Dependency Updates

- Update Android SDK from 5.4.2 to 5.6.0
  - feat: 🎉 introduces Custom Events Support for the Android SDK. To get started with using Custom Events, please contact [support@onesignal.com](mailto:support@onesignal.com) to enable this feature for your app. Please see documentation on [Custom Events](https://documentation.onesignal.com/docs/mobile-sdk-reference#trackevent).
  - feat: IAMs now display when triggers added before first fetch  ([#2528](https://github.com/OneSignal/OneSignal-Android-SDK/issues/2528))
  - fix: end initialization early if device storage is locked ([#2520](https://github.com/OneSignal/OneSignal-Android-SDK/issues/2520))
  - - -
  - feature: Exposing accessors thru suspend ([#2502](https://github.com/OneSignal/OneSignal-Android-SDK/pull/2502))
  - fix: a rare NPE from PermissionViewModel introduced in 5.4.0 ([#2504](https://github.com/OneSignal/OneSignal-Android-SDK/pull/2504))
  - fix: NPE in SyncJobService since 5.4 ([#2500](https://github.com/OneSignal/OneSignal-Android-SDK/pull/2500))
  - fix: Rare User and Subscription creates and updates processing out of order (introduced in 5.4.0) ([#2419](https://github.com/OneSignal/OneSignal-Android-SDK/pull/2419))
  - fix: Remove throwing "initWithContext was not called or timed out", introduced in 5.4.0 ([#2408](https://github.com/OneSignal/OneSignal-Android-SDK/pull/2408))
  - Improvement: failure message shows that appID is missing ([#2506](https://github.com/OneSignal/OneSignal-Android-SDK/pull/2506))
  - improvement: Offloaded work on background threads. ([#2394](https://github.com/OneSignal/OneSignal-Android-SDK/pull/2394))
  - - -
- Update iOS SDK from 5.2.16 to 5.4.0
  - feat: IAMs now display when triggers added before first fetch ([OneSignal-iOS-SDK#1635](https://github.com/OneSignal/OneSignal-iOS-SDK/pull/1635))
  - fix: use locale-independent formatting for purchase prices ([OneSignal-iOS-SDK#1634](https://github.com/OneSignal/OneSignal-iOS-SDK/pull/1634))
  - It is recommended to test this beta version with a new iOS-only app, as Identity Verification is not yet supported on the OneSignal Android and Web SDKs.
  - Enabling Identity Verification in the dashboard will affect all existing app installations using the OneSignal user model SDKs.
  - Please test thoroughly prior to production use, and reach out with any questions, feedback, or concerns.
  - While emails and sms numbers can be added using the SDK, removing them is not yet supported.
  - Live Activities is not yet supported.
  - Rebased to 5.2.14 for more bug fixes and stability improvement.
  - add public log listener methods (see PR for usage) #1576
  - It is recommended to test this beta version with a new iOS-only app, as Identity Verification is not yet supported on the OneSignal Android and Web SDKs.
  - Enabling Identity Verification in the dashboard will affect all existing app installations using the OneSignal user model SDKs.
  - Please test thoroughly prior to production use, and reach out with any questions, feedback, or concerns.
  - While emails and sms numbers can be added using the SDK, removing them is not yet supported.
  - Live Activities is not yet supported.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/OneSignal/react-native-onesignal/1902)
<!-- Reviewable:end -->
