### PR TITLE
fix: migrate Android namespace from AndroidManifest.xml to build.gradle

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -5,6 +5,7 @@ def safeExtGet(prop, fallback) {
 }
 
 android {
+    namespace "com.onesignal.rnonesignalandroid"
     compileSdkVersion safeExtGet('compileSdkVersion', 28)
     buildToolsVersion safeExtGet('buildToolsVersion', '28.0.3')
 

--- a/android/src/main/AndroidManifest.xml
+++ b/android/src/main/AndroidManifest.xml
@@ -1,3 +1,2 @@
-<manifest xmlns:android="http://schemas.android.com/apk/res/android"
-    package="com.onesignal.rnonesignalandroid">
+<manifest xmlns:android="http://schemas.android.com/apk/res/android">
 </manifest>


### PR DESCRIPTION
# Description

## One Line Summary

Migrate the Android namespace declaration from the deprecated `package` attribute in `AndroidManifest.xml` to `build.gradle`.

## Details

### Motivation

The `package` attribute in `AndroidManifest.xml` was deprecated starting with AGP 7.0 and causes a hard build failure on AGP 8.3.0. On newer AGP versions (8.12+) it produces a warning. Moving the namespace to `build.gradle` resolves both cases.

Fixes #1913

### Scope

Android build configuration only. No runtime behavior changes.

# Testing

## Manual testing

Verified on Gradle 8.13 + AGP 8.12.0 that the `package` attribute warning for `react-native-onesignal` disappears after the fix. Build succeeds on both Gradle 8.x and 9.x.

# Affected code checklist

- [ ] Notifications
- [ ] Outcomes
- [ ] Sessions
- [ ] In-App Messaging
- [ ] REST API requests
- [ ] Public API changes

# Checklist

## Overview

- [x] I have filled out all **REQUIRED** sections above
- [x] PR does one thing
- [x] Any Public API changes are explained in the PR details and conform to existing APIs

## Testing

- [x] I have included test coverage for these changes, or explained why they are not needed
- [x] All automated tests pass, or I explained why that is not possible
- [x] I have personally tested this on my device, or explained why that is not possible

## Final pass

- [x] Code is as readable as possible.
- [x] I have reviewed this PR myself, ensuring it meets each checklist item


Made with [Cursor](https://cursor.com)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/OneSignal/react-native-onesignal/1917)
<!-- Reviewable:end -->
