### PR TITLE
chore: Release 5.3.5

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-native-onesignal",
-  "version": "5.3.4",
+  "version": "5.3.5",
   "description": "React Native OneSignal SDK",
   "files": [
     "dist",


### PR DESCRIPTION
Channels: Current

### 🐛 Bug Fixes

- fix: exclude OkHttp 5.x from OneSignal transitive dependencies (#1921)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/OneSignal/react-native-onesignal/1922)
<!-- Reviewable:end -->
