### PR TITLE
chore: Release 5.3.6

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -36,7 +36,7 @@ dependencies {
     // Exclude OkHttp from OneSignal's transitive deps: the 5.7.x otel module pulls in OkHttp 5.x
     // (via opentelemetry-exporter-sender-okhttp) which is binary-incompatible with React Native's
     // networking stack (okhttp3.internal.Util removed in 5.x). React Native already provides OkHttp 4.x.
-    api('com.onesignal:OneSignal:5.7.2') {
+    api('com.onesignal:OneSignal:5.7.3') {
         exclude group: 'com.squareup.okhttp3', module: 'okhttp'
     }
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-native-onesignal",
-  "version": "5.3.5",
+  "version": "5.3.6",
   "description": "React Native OneSignal SDK",
   "files": [
     "dist",


### PR DESCRIPTION
Channels: Current


### 🛠️ Native Dependency Updates

- Update Android SDK from 5.7.2 to 5.7.3
  - fix: add otel consumer R8 rule for optional jackson classes ([#2580](https://github.com/OneSignal/OneSignal-Android-SDK/pull/2580))

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/OneSignal/react-native-onesignal/1923)
<!-- Reviewable:end -->
