### PR TITLE
chore: Release 5.4.1

### DIFF
--- a/.github/workflows/create-release-pr.yml
+++ b/.github/workflows/create-release-pr.yml
@@ -79,13 +79,11 @@ jobs:
       - name: Setup Git User
         uses: OneSignal/sdk-shared/.github/actions/setup-git-user@main
 
-      - name: Setup Bun
-        uses: oven-sh/setup-bun@v2
+      - name: Set up Vite+
+        uses: voidzero-dev/setup-vp@v1
         with:
-          bun-version: latest
-
-      - name: Install
-        run: bun install --frozen-lockfile
+          cache: true
+          run-install: true
 
       - name: Get current native SDK versions from target branch
         id: current_versions
@@ -152,7 +150,7 @@ jobs:
           NEW_VERSION="${{ inputs.rn_version }}"
 
           # Update package.json version
-          bun pm pkg set version="$NEW_VERSION"
+          npm pkg set version="$NEW_VERSION"
 
           # Only commit if there are changes
           git add -A

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -33,7 +33,7 @@ dependencies {
     // Exclude OkHttp from OneSignal's transitive deps: the 5.7.x otel module pulls in OkHttp 5.x
     // (via opentelemetry-exporter-sender-okhttp) which is binary-incompatible with React Native's
     // networking stack (okhttp3.internal.Util removed in 5.x). React Native already provides OkHttp 4.x.
-    api('com.onesignal:OneSignal:5.7.4') {
+    api('com.onesignal:OneSignal:5.7.6') {
         exclude group: 'com.squareup.okhttp3', module: 'okhttp'
     }
 

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -33,7 +33,7 @@ dependencies {
     // Exclude OkHttp from OneSignal's transitive deps: the 5.7.x otel module pulls in OkHttp 5.x
     // (via opentelemetry-exporter-sender-okhttp) which is binary-incompatible with React Native's
     // networking stack (okhttp3.internal.Util removed in 5.x). React Native already provides OkHttp 4.x.
-    api('com.onesignal:OneSignal:5.7.3') {
+    api('com.onesignal:OneSignal:5.7.4') {
         exclude group: 'com.squareup.okhttp3', module: 'okhttp'
     }
 

--- a/package.json
+++ b/package.json
@@ -57,6 +57,12 @@
     "react-native": ">=0.76.0"
   },
   "packageManager": "pnpm@10.32.1",
+  "pnpm": {
+    "overrides": {
+      "vite": "npm:@voidzero-dev/vite-plus-core@latest",
+      "vitest": "npm:@voidzero-dev/vite-plus-test@latest"
+    }
+  },
   "codegenConfig": {
     "name": "RNOneSignalSpec",
     "type": "modules",
@@ -69,9 +75,5 @@
         "OneSignal": "RCTOneSignalEventEmitter"
       }
     }
-  },
-  "overrides": {
-    "vite": "npm:@voidzero-dev/vite-plus-core@latest",
-    "vitest": "npm:@voidzero-dev/vite-plus-test@latest"
   }
 }

--- a/package.json
+++ b/package.json
@@ -40,8 +40,8 @@
     "format": "vp fmt && npm run format:spotless",
     "format:check:spotless": "./examples/demo/android/gradlew spotlessCheck",
     "format:check": "vp fmt --check && npm run format:check:spotless",
-    "lint": "vp check && npm run format:check:spotless",
-    "lint:fix": "vp check --fix && npm run format:spotless",
+    "lint": "vp check src && npm run format:check:spotless",
+    "lint:fix": "vp check --fix src && npm run format:spotless",
     "test": "vp test"
   },
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -57,12 +57,6 @@
     "react-native": ">=0.76.0"
   },
   "packageManager": "pnpm@10.32.1",
-  "pnpm": {
-    "overrides": {
-      "vite": "npm:@voidzero-dev/vite-plus-core@latest",
-      "vitest": "npm:@voidzero-dev/vite-plus-test@latest"
-    }
-  },
   "codegenConfig": {
     "name": "RNOneSignalSpec",
     "type": "modules",
@@ -75,5 +69,9 @@
         "OneSignal": "RCTOneSignalEventEmitter"
       }
     }
+  },
+  "overrides": {
+    "vite": "npm:@voidzero-dev/vite-plus-core@latest",
+    "vitest": "npm:@voidzero-dev/vite-plus-test@latest"
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-native-onesignal",
-  "version": "5.4.0",
+  "version": "5.4.1",
   "description": "React Native OneSignal SDK",
   "keywords": [
     "android",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,12 @@
+{
+  "compilerOptions": {
+    "target": "ES2020",
+    "module": "ES2020",
+    "moduleResolution": "bundler",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true
+  },
+  "include": ["src/**/*.ts"],
+  "exclude": ["node_modules", "dist"]
+}


### PR DESCRIPTION
Channels: Current

### 🛠️ Native Dependency Updates

- Update Android SDK from 5.7.3 to 5.7.6
  - fix: R8 AutoValue + Huawei CI (cherry-pick #2592) ([#2593](https://github.com/OneSignal/OneSignal-Android-SDK/pull/2593))
  - fix: R8 InputMerger + minified demo + CI (#2589 → 5.7-main) ([#2590](https://github.com/OneSignal/OneSignal-Android-SDK/pull/2590))
  - fix: [SDK-4190] PermissionsActivity does not follow app theme ([#2584](https://github.com/OneSignal/OneSignal-Android-SDK/pull/2584))
  - fix: [SDK-4185] keep OneSignal WorkManager workers in consumer R8 rules ([#2585](https://github.com/OneSignal/OneSignal-Android-SDK/pull/2585))
