### PR TITLE
refactor(demo): [SDK-4217] remove stop-updating button and deprecate exit API

### DIFF
--- a/examples/demo/bun.lock
+++ b/examples/demo/bun.lock
@@ -1010,7 +1010,7 @@
 
     "react-native-dotenv": ["react-native-dotenv@3.4.11", "", { "dependencies": { "dotenv": "^16.4.5" }, "peerDependencies": { "@babel/runtime": "^7.20.6" } }, "sha512-6vnIE+WHABSeHCaYP6l3O1BOEhWxKH6nHAdV7n/wKn/sciZ64zPPp2NUdEUf1m7g4uuzlLbjgr+6uDt89q2DOg=="],
 
-    "react-native-onesignal": ["react-native-onesignal@../../react-native-onesignal.tgz", { "dependencies": { "invariant": "^2.2.4" }, "peerDependencies": { "react-native": ">=0.76.0" } }, "sha512-TQjsbxq8AF3JQv5csMkmsE/ie8LVFjj2pJBela9u+QyzT5ixNLOYzq+yVUfEnSYwbAGLlqTklswMmvaJacHy8Q=="],
+    "react-native-onesignal": ["react-native-onesignal@../../react-native-onesignal.tgz", { "dependencies": { "invariant": "^2.2.4" }, "peerDependencies": { "react-native": ">=0.76.0" } }, "sha512-J59lLLkeG/At0U6A2A+uZcfelosOPVPGKy2im7W9V3ru02UQgaTo/juZZnx1lol+1bBqRYqUACTgIxw7LehQEw=="],
 
     "react-native-safe-area-context": ["react-native-safe-area-context@5.6.2", "", { "peerDependencies": { "react": "*", "react-native": "*" } }, "sha512-4XGqMNj5qjUTYywJqpdWZ9IG8jgkS3h06sfVjfw5yZQZfWnRFXczi0GnYyFyCc2EBps/qFmoCH8fez//WumdVg=="],
 

--- a/examples/demo/src/components/ActionButton.tsx
+++ b/examples/demo/src/components/ActionButton.tsx
@@ -6,7 +6,7 @@ import { AppColors, AppSpacing } from '../theme';
 interface Props {
   label: string;
   onPress: () => void;
-  variant?: 'primary' | 'destructive' | 'outlined';
+  variant?: 'primary' | 'outlined';
   disabled?: boolean;
   loading?: boolean;
   testID?: string;
@@ -29,12 +29,9 @@ export default function ActionButton({
   const bgColor = variant === 'primary' ? AppColors.osPrimary : 'transparent';
 
   const borderStyle =
-    variant === 'outlined' || variant === 'destructive'
-      ? { borderWidth: 1, borderColor: AppColors.osPrimary }
-      : {};
+    variant === 'outlined' ? { borderWidth: 1, borderColor: AppColors.osPrimary } : {};
 
-  const textColor =
-    variant === 'outlined' || variant === 'destructive' ? AppColors.osPrimary : AppColors.white;
+  const textColor = variant === 'outlined' ? AppColors.osPrimary : AppColors.white;
 
   return (
     <TouchableOpacity

--- a/examples/demo/src/components/sections/LiveActivitySection.tsx
+++ b/examples/demo/src/components/sections/LiveActivitySection.tsx
@@ -15,17 +15,10 @@ interface Props {
   onStart: (activityId: string, attributes: object, content: object) => void;
   onUpdate: (activityId: string, eventUpdates: Record<string, unknown>) => Promise<void>;
   onEnd: (activityId: string) => Promise<void>;
-  onStopUpdating: (activityId: string) => void;
   onInfoTap?: () => void;
 }
 
-export default function LiveActivitySection({
-  onStart,
-  onUpdate,
-  onEnd,
-  onStopUpdating,
-  onInfoTap,
-}: Props) {
+export default function LiveActivitySection({ onStart, onUpdate, onEnd, onInfoTap }: Props) {
   const [activityId, setActivityId] = useState('order-1');
   const [orderNumber, setOrderNumber] = useState('ORD-1234');
   const [statusIndex, setStatusIndex] = useState(0);
@@ -97,20 +90,12 @@ export default function LiveActivitySection({
           testID="update_live_activity_button"
         />
 
-        <ActionButton
-          label="STOP UPDATING LIVE ACTIVITY"
-          onPress={() => onStopUpdating(activityId)}
-          disabled={!activityId.trim()}
-          variant="outlined"
-          testID="stop_updating_live_activity_button"
-        />
-
         {/* Requires API key */}
         <ActionButton
           label="END LIVE ACTIVITY"
           onPress={() => onEnd(activityId)}
           disabled={!activityId.trim()}
-          variant="destructive"
+          variant="outlined"
           testID="end_live_activity_button"
         />
       </View>

--- a/examples/demo/src/context/AppContext.tsx
+++ b/examples/demo/src/context/AppContext.tsx
@@ -266,7 +266,6 @@ type AppContextValue = {
   startDefaultLiveActivity: (activityId: string, attributes: object, content: object) => void;
   updateLiveActivity: (activityId: string, eventUpdates: Record<string, unknown>) => Promise<void>;
   endLiveActivity: (activityId: string) => Promise<void>;
-  stopUpdatingLiveActivity: (activityId: string) => void;
 };
 
 const AppContext = createContext<AppContextValue | null>(null);
@@ -715,12 +714,6 @@ export function AppContextProvider({ children }: Props) {
     Toast.show({ type: success ? 'info' : 'error', text1: msg });
   }, []);
 
-  const stopUpdatingLiveActivity = useCallback((activityId: string) => {
-    repository.exitLiveActivity(activityId);
-    log.i(TAG, `Exited Live Activity: ${activityId}`);
-    Toast.show({ type: 'info', text1: `Exited Live Activity: ${activityId}` });
-  }, []);
-
   const contextValue = useMemo<AppContextValue>(
     () => ({
       state,
@@ -757,7 +750,6 @@ export function AppContextProvider({ children }: Props) {
       startDefaultLiveActivity: startDefaultLiveActivity,
       updateLiveActivity,
       endLiveActivity,
-      stopUpdatingLiveActivity,
     }),
     [
       state,
@@ -794,7 +786,6 @@ export function AppContextProvider({ children }: Props) {
       startDefaultLiveActivity,
       updateLiveActivity,
       endLiveActivity,
-      stopUpdatingLiveActivity,
     ],
   );
 

--- a/examples/demo/src/repositories/OneSignalRepository.ts
+++ b/examples/demo/src/repositories/OneSignalRepository.ts
@@ -193,10 +193,6 @@ class OneSignalRepository {
   ): Promise<boolean> {
     return this.apiService.updateLiveActivity(activityId, event, eventUpdates);
   }
-
-  exitLiveActivity(activityId: string): void {
-    OneSignal.LiveActivities.exit(activityId);
-  }
 }
 
 export default OneSignalRepository;

--- a/examples/demo/src/screens/HomeScreen.tsx
+++ b/examples/demo/src/screens/HomeScreen.tsx
@@ -163,7 +163,6 @@ export default function HomeScreen() {
             onStart={app.startDefaultLiveActivity}
             onUpdate={app.updateLiveActivity}
             onEnd={app.endLiveActivity}
-            onStopUpdating={app.stopUpdatingLiveActivity}
             onInfoTap={() => showTooltipModal('liveActivities')}
           />
         )}

--- a/src/NativeOneSignal.ts
+++ b/src/NativeOneSignal.ts
@@ -17,7 +17,7 @@ export interface Spec extends TurboModule {
   // Live Activities (iOS only, stubs on Android)
   enterLiveActivity(activityId: string, token: string, callback: (result: Object) => void): void;
 
-  /** @deprecated Use REST API to end live activities instead. */
+  /** @deprecated Currently unsupported, avoid using this method. */
   exitLiveActivity(activityId: string, callback: (result: Object) => void): void;
 
   setPushToStartToken(activityType: string, token: string): void;

--- a/src/NativeOneSignal.ts
+++ b/src/NativeOneSignal.ts
@@ -16,7 +16,10 @@ export interface Spec extends TurboModule {
 
   // Live Activities (iOS only, stubs on Android)
   enterLiveActivity(activityId: string, token: string, callback: (result: Object) => void): void;
+
+  /** @deprecated Use REST API to end live activities instead. */
   exitLiveActivity(activityId: string, callback: (result: Object) => void): void;
+
   setPushToStartToken(activityType: string, token: string): void;
   removePushToStartToken(activityType: string): void;
   setupDefaultLiveActivity(options: Object | null): void;

--- a/src/index.ts
+++ b/src/index.ts
@@ -175,6 +175,7 @@ export namespace OneSignal {
      *
      * Only applies to iOS
      *
+     * @deprecated Use the REST API to end live activities instead.
      * @param activityId: The activity identifier the live activity on this device will no longer receive updates for.
      **/
     export function exit(activityId: string, handler: (result: object) => void = () => {}) {

--- a/src/index.ts
+++ b/src/index.ts
@@ -175,7 +175,7 @@ export namespace OneSignal {
      *
      * Only applies to iOS
      *
-     * @deprecated Use the REST API to end live activities instead.
+     * @deprecated Currently unsupported, avoid using this method.
      * @param activityId: The activity identifier the live activity on this device will no longer receive updates for.
      **/
     export function exit(activityId: string, handler: (result: object) => void = () => {}) {


### PR DESCRIPTION
# Description

## One Line Summary

Remove the "Stop Updating Live Activity" button from the demo app and deprecate `LiveActivities.exit()` in the SDK public API.

## Details

### Motivation

The `exit` / `exitLiveActivity` method unsubscribes a device from future updates for a given activity ID, but ending a Live Activity via the REST API (which the demo already supports) is the recommended approach. Removing the button simplifies the demo UI and aligns with the updated shared build spec.

### Scope

- **Demo app**: Remove the "STOP UPDATING LIVE ACTIVITY" button and its entire call chain (`LiveActivitySection` → `HomeScreen` → `AppContext` → `OneSignalRepository`)
- **SDK**: Add `@deprecated` JSDoc annotations to `exitLiveActivity` in `NativeOneSignal.ts` and `LiveActivities.exit()` in `index.ts`
- **ActionButton**: Remove unused `destructive` variant (only `primary` and `outlined` remain)
- No behavioral changes to the SDK itself

# Testing

## Unit testing

All 244 existing tests pass via `vp test`. No test changes needed — `exit` tests remain to cover the deprecated-but-still-functional API.

## Manual testing

- [ ] Verify the Live Activities section shows only 3 buttons: Start, Update, End
- [ ] Verify `LiveActivities.exit()` still works but shows as deprecated in IDE

# Affected code checklist

- [ ] Notifications
- [ ] Outcomes
- [ ] Sessions
- [ ] In-App Messaging
- [ ] REST API requests
- [x] Public API changes

# Checklist

## Overview

- [x] I have filled out all **REQUIRED** sections above
- [x] PR does one thing
- [x] Any Public API changes are explained in the PR details and conform to existing APIs

## Testing

- [x] I have included test coverage for these changes, or explained why they are not needed
- [x] All automated tests pass, or I explained why that is not possible
- [ ] I have personally tested this on my device, or explained why that is not possible

## Final pass

- [x] Code is as readable as possible.
- [x] I have reviewed this PR myself, ensuring it meets each checklist item


Made with [Cursor](https://cursor.com)