### PR TITLE
chore: Release 5.4.2

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -33,7 +33,7 @@ dependencies {
     // Exclude OkHttp from OneSignal's transitive deps: the 5.7.x otel module pulls in OkHttp 5.x
     // (via opentelemetry-exporter-sender-okhttp) which is binary-incompatible with React Native's
     // networking stack (okhttp3.internal.Util removed in 5.x). React Native already provides OkHttp 4.x.
-    api('com.onesignal:OneSignal:5.7.6') {
+    api('com.onesignal:OneSignal:5.7.7') {
         exclude group: 'com.squareup.okhttp3', module: 'okhttp'
     }
 

--- a/examples/demo/bun.lock
+++ b/examples/demo/bun.lock
@@ -1010,7 +1010,7 @@
 
     "react-native-dotenv": ["react-native-dotenv@3.4.11", "", { "dependencies": { "dotenv": "^16.4.5" }, "peerDependencies": { "@babel/runtime": "^7.20.6" } }, "sha512-6vnIE+WHABSeHCaYP6l3O1BOEhWxKH6nHAdV7n/wKn/sciZ64zPPp2NUdEUf1m7g4uuzlLbjgr+6uDt89q2DOg=="],
 
-    "react-native-onesignal": ["react-native-onesignal@../../react-native-onesignal.tgz", { "dependencies": { "invariant": "^2.2.4" }, "peerDependencies": { "react-native": ">=0.76.0" } }, "sha512-J59lLLkeG/At0U6A2A+uZcfelosOPVPGKy2im7W9V3ru02UQgaTo/juZZnx1lol+1bBqRYqUACTgIxw7LehQEw=="],
+    "react-native-onesignal": ["react-native-onesignal@../../react-native-onesignal.tgz", { "dependencies": { "invariant": "^2.2.4" }, "peerDependencies": { "react-native": ">=0.76.0" } }, "sha512-gc/KSxGWHWszNWwjZXzRoP3iHiWO5ucpG1Uyj+Y/qiAfU44eXznmHzYZTb61sAJxPakI+yKd3dhAHhbjolGB1g=="],
 
     "react-native-safe-area-context": ["react-native-safe-area-context@5.6.2", "", { "peerDependencies": { "react": "*", "react-native": "*" } }, "sha512-4XGqMNj5qjUTYywJqpdWZ9IG8jgkS3h06sfVjfw5yZQZfWnRFXczi0GnYyFyCc2EBps/qFmoCH8fez//WumdVg=="],
 

--- a/examples/demo/ios/Podfile.lock
+++ b/examples/demo/ios/Podfile.lock
@@ -1446,7 +1446,7 @@ PODS:
     - React-RCTFBReactNativeSpec
     - ReactCommon/turbomodule/core
     - ReactNativeDependencies
-  - react-native-onesignal (5.4.1):
+  - react-native-onesignal (5.4.2):
     - hermes-engine
     - OneSignalXCFramework (= 5.5.0)
     - RCTRequired
@@ -2349,7 +2349,7 @@ SPEC CHECKSUMS:
   React-logger: 9e51e01455f15cb3ef87a09a1ec773cdb22d56c1
   React-Mapbuffer: 92b99e450e8ff598b27d6e4db3a75e04fd45e9a9
   React-microtasksnativemodule: 2fe0f2bd2840dedbd66c0ac249c64f977f39cc18
-  react-native-onesignal: 21bb718c560cd7e6e763594ace7a4599606d0452
+  react-native-onesignal: 426b38a83b1f4f60d540c3c240dfa2e64dc10520
   react-native-safe-area-context: 37e680fc4cace3c0030ee46e8987d24f5d3bdab2
   React-NativeModulesApple: 44a9474594566cd03659f92e38f42599c6b9dee4
   React-networking: db73d91466cb134fcbdaaa579fb2de14e2c2ea01

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-native-onesignal",
-  "version": "5.4.1",
+  "version": "5.4.2",
   "description": "React Native OneSignal SDK",
   "keywords": [
     "android",


### PR DESCRIPTION
Channels: Current

### 🚀 New Features

- feat(demo): [SDK-4217] add Live Activities demp example (#1933)

### 🐛 Bug Fixes

- fix: [SDK-4217] add live activity example and deprecate live activity exit API (#1935)


### 🛠️ Native Dependency Updates

- Update Android SDK from 5.7.6 to 5.7.7
  - fix: [SDK-4192] downgrade Kotlin from 2.2.0 to 1.9.25 ([#2601](https://github.com/OneSignal/OneSignal-Android-SDK/pull/2601))


