### PR TITLE
fix: [SDK-4342] guard against missing EventEmitter to prevent crash on Old Architecture

### DIFF
--- a/examples/demo/bun.lock
+++ b/examples/demo/bun.lock
@@ -1010,7 +1010,7 @@
 
     "react-native-dotenv": ["react-native-dotenv@3.4.11", "", { "dependencies": { "dotenv": "^16.4.5" }, "peerDependencies": { "@babel/runtime": "^7.20.6" } }, "sha512-6vnIE+WHABSeHCaYP6l3O1BOEhWxKH6nHAdV7n/wKn/sciZ64zPPp2NUdEUf1m7g4uuzlLbjgr+6uDt89q2DOg=="],
 
-    "react-native-onesignal": ["react-native-onesignal@../../react-native-onesignal.tgz", { "dependencies": { "invariant": "^2.2.4" }, "peerDependencies": { "react-native": ">=0.76.0" } }, "sha512-gc/KSxGWHWszNWwjZXzRoP3iHiWO5ucpG1Uyj+Y/qiAfU44eXznmHzYZTb61sAJxPakI+yKd3dhAHhbjolGB1g=="],
+    "react-native-onesignal": ["react-native-onesignal@../../react-native-onesignal.tgz", { "dependencies": { "invariant": "^2.2.4" }, "peerDependencies": { "react-native": ">=0.76.0" } }, "sha512-0OG4WHEAUy3JoiBzV7pqUwSoWO+gqKwZO1LyZ/FCnjFOXYMAnYzqiizVnbfU5dr7hIXe5KO9EvT8wn5SVsDlzA=="],
 
     "react-native-safe-area-context": ["react-native-safe-area-context@5.6.2", "", { "peerDependencies": { "react": "*", "react-native": "*" } }, "sha512-4XGqMNj5qjUTYywJqpdWZ9IG8jgkS3h06sfVjfw5yZQZfWnRFXczi0GnYyFyCc2EBps/qFmoCH8fez//WumdVg=="],
 

--- a/src/events/EventManager.test.ts
+++ b/src/events/EventManager.test.ts
@@ -93,6 +93,18 @@ describe('EventManager', () => {
       new EventManager(null as never);
       expect(freshModule.onPermissionChanged).not.toHaveBeenCalled();
     });
+
+    test('should not crash when event emitters are unavailable (Old Architecture)', () => {
+      const consoleSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+      const moduleWithoutEmitters = {} as never;
+
+      expect(() => new EventManager(moduleWithoutEmitters)).not.toThrow();
+      expect(consoleSpy).toHaveBeenCalledWith(
+        expect.stringContaining('Native event emitters are not available'),
+      );
+
+      consoleSpy.mockRestore();
+    });
   });
 
   describe('addEventListener', () => {

--- a/src/events/EventManager.ts
+++ b/src/events/EventManager.ts
@@ -60,6 +60,14 @@ export default class EventManager {
   setupListeners() {
     if (this.RNOneSignal == null) return;
 
+    if (typeof this.RNOneSignal.onPermissionChanged !== 'function') {
+      console.error(
+        'OneSignal: Native event emitters are not available. ' +
+          'Ensure the New Architecture (TurboModules) is enabled and the native module is rebuilt.',
+      );
+      return;
+    }
+
     this.nativeSubscriptions.push(
       this.RNOneSignal.onPermissionChanged((payload) => {
         const typed = payload as { permission: boolean };


### PR DESCRIPTION
# Description

## One Line Summary

Add a guard in `EventManager.setupListeners()` to prevent a crash when codegen EventEmitter functions are unavailable (Old Architecture).

## Details

### Motivation

Since v5.4.0, the SDK uses `CodegenTypes.EventEmitter` (TurboModules) for native events. If a user's app doesn't have the New Architecture enabled, `onPermissionChanged` and other EventEmitter properties are `undefined` on the native module object. Because `EventManager` is constructed at module import time, this causes a `TypeError` crash that prevents the **entire** SDK from loading — not just events, but all functions including `initialize()`.

Reported in https://github.com/OneSignal/react-native-onesignal/issues/1930

### Scope

- `EventManager.setupListeners()` now checks `typeof this.RNOneSignal.onPermissionChanged !== 'function'` before subscribing to any emitters.
- If the check fails, a clear `console.error` is logged directing the user to enable New Architecture, and the method returns early.
- All non-event SDK functionality (`initialize`, `login`, `requestPermission`, etc.) continues to work normally even without event emitters.
- No changes to native code (Android/iOS).

# Testing

## Unit testing

Added a test case verifying that `EventManager` does not throw when constructed with a module object that lacks EventEmitter functions, and that the appropriate error message is logged.

## Manual testing

All 245 unit tests pass. Lint, type checks, and production build (`vp pack`) all succeed.

# Affected code checklist

- [x] Notifications
- [x] In-App Messaging
- [x] Public API changes

# Checklist

## Overview

- [x] I have filled out all **REQUIRED** sections above
- [x] PR does one thing
- [x] Any Public API changes are explained in the PR details and conform to existing APIs

## Testing

- [x] I have included test coverage for these changes, or explained why they are not needed
- [x] All automated tests pass, or I explained why that is not possible
- [ ] I have personally tested this on my device, or explained why that is not possible

## Final pass

- [x] Code is as readable as possible.
- [x] I have reviewed this PR myself, ensuring it meets each checklist item


Made with [Cursor](https://cursor.com)