### PR TITLE
fix: [SDK-4346] resolve strict CodeGen rules preventing RN/Expo apps from building

### DIFF
--- a/examples/run-android.sh
+++ b/examples/run-android.sh
@@ -37,5 +37,4 @@ else
   selected="${devices[$idx]}"
 fi
 
-cd "$(dirname "$0")/demo"
 ANDROID_SERIAL="$selected" bunx react-native run-android --deviceId "$selected"

--- a/examples/run-ios.sh
+++ b/examples/run-ios.sh
@@ -70,5 +70,4 @@ name="${selected%%|*}"
 udid="${selected##*|}"
 echo "Using simulator: $name ($udid)"
 
-cd "$(dirname "$0")/demo"
 bunx react-native run-ios --udid "$udid"

--- a/src/NativeOneSignal.ts
+++ b/src/NativeOneSignal.ts
@@ -1,6 +1,7 @@
 /* eslint-disable @typescript-eslint/no-wrapper-object-types */
-import type { CodegenTypes, TurboModule } from 'react-native';
+import type { TurboModule } from 'react-native';
 import { TurboModuleRegistry } from 'react-native';
+import type { EventEmitter } from 'react-native/Libraries/Types/CodegenTypes';
 
 export interface Spec extends TurboModule {
   // OneSignal root
@@ -90,16 +91,16 @@ export interface Spec extends TurboModule {
   addOutcomeWithValue(name: string, value: number): void;
 
   // Events
-  readonly onPermissionChanged: CodegenTypes.EventEmitter<Object>;
-  readonly onSubscriptionChanged: CodegenTypes.EventEmitter<Object>;
-  readonly onUserStateChanged: CodegenTypes.EventEmitter<Object>;
-  readonly onNotificationWillDisplay: CodegenTypes.EventEmitter<Object>;
-  readonly onNotificationClicked: CodegenTypes.EventEmitter<Object>;
-  readonly onInAppMessageClicked: CodegenTypes.EventEmitter<Object>;
-  readonly onInAppMessageWillDisplay: CodegenTypes.EventEmitter<Object>;
-  readonly onInAppMessageDidDisplay: CodegenTypes.EventEmitter<Object>;
-  readonly onInAppMessageWillDismiss: CodegenTypes.EventEmitter<Object>;
-  readonly onInAppMessageDidDismiss: CodegenTypes.EventEmitter<Object>;
+  readonly onPermissionChanged: EventEmitter<Object>;
+  readonly onSubscriptionChanged: EventEmitter<Object>;
+  readonly onUserStateChanged: EventEmitter<Object>;
+  readonly onNotificationWillDisplay: EventEmitter<Object>;
+  readonly onNotificationClicked: EventEmitter<Object>;
+  readonly onInAppMessageClicked: EventEmitter<Object>;
+  readonly onInAppMessageWillDisplay: EventEmitter<Object>;
+  readonly onInAppMessageDidDisplay: EventEmitter<Object>;
+  readonly onInAppMessageWillDismiss: EventEmitter<Object>;
+  readonly onInAppMessageDidDismiss: EventEmitter<Object>;
 }
 
 export default TurboModuleRegistry.getEnforcing<Spec>('OneSignal');


### PR DESCRIPTION
## One Line Summary

Fix `EventEmitter` import path in `NativeOneSignal.ts` so React Native CodeGen doesn't fail for New Architecture builds on RN 0.76+.

See error:
```bash
> Task :react-native-onesignal:generateCodegenSchemaFromJavaScript FAILED
/Users/fadigeorge/Documents/Code/SDK/react-native-onesignal/examples/demo2/node_modules/@react-native/codegen/lib/parsers/parsers-commons.js:663
        throw parsingErrors[0];
        ^

UnsupportedModulePropertyParserError: Module NativeOneSignal: TypeScript interfaces extending TurboModule must only contain 'FunctionTypeAnnotation's or non nullable 'EventEmitter's. Property 'onPermissionChanged' refers to a 'TSTypeReference'.
```

## Motivation

React Native 0.76+ with New Architecture enabled uses stricter CodeGen module resolution. The previous `CodegenTypes.EventEmitter` import from `react-native` doesn't resolve correctly under these stricter rules, causing a CodeGen error that prevents the app from building entirely.

This affects any RN 0.76+ or Expo user with New Architecture enabled. Importing `EventEmitter` directly from `react-native/Libraries/Types/CodegenTypes` fixes the resolution and allows CodeGen to process the TurboModule spec successfully.

Linear: [SDK-4346](https://linear.app/onesignal/issue/SDK-4346)

## Scope

- **`src/NativeOneSignal.ts`** -- changed `EventEmitter` import from `CodegenTypes.EventEmitter` (via `react-native`) to a direct import from `react-native/Libraries/Types/CodegenTypes`. This resolves the CodeGen failure for New Architecture builds on RN 0.76+.
- **`examples/run-android.sh` / `examples/run-ios.sh`** -- removed stale `cd` into `demo` directory (unrelated cleanup)

## Testing

- Build the example app with New Architecture enabled on RN 0.76+ (`npx expo run:ios`) and confirm CodeGen no longer errors
- Verify push notifications still fire event callbacks at runtime

## Affected code checklist

- [x] TypeScript source (TurboModule spec)
- [x] Example app helper scripts
- [ ] Native Android
- [ ] Native iOS
- [ ] Tests/CI

## Checklist

- [x] Followed repo coding conventions
- [x] Changes are limited to what's described above
- [x] No secrets or credentials included