### PR TITLE
chore: Release 5.4.4

### DIFF
--- a/.github/actions/setup-demo/action.yml
+++ b/.github/actions/setup-demo/action.yml
@@ -45,8 +45,8 @@ runs:
     - name: Update CocoaPods
       if: inputs.install-pods == 'true'
       shell: bash
-      working-directory: examples/demo
-      run: vp run update:pods
+      working-directory: examples/demo/ios
+      run: pod update OneSignalXCFramework --no-repo-update
 
     - name: Create demo .env
       shell: bash

--- a/.github/actions/setup-demo/action.yml
+++ b/.github/actions/setup-demo/action.yml
@@ -20,9 +20,6 @@ runs:
         cache: true
         run-install: true
 
-    - name: Set up Bun
-      uses: oven-sh/setup-bun@v2
-
     - name: Cache bun dependencies
       uses: actions/cache@v5
       with:

--- a/.github/actions/setup-demo/action.yml
+++ b/.github/actions/setup-demo/action.yml
@@ -55,3 +55,4 @@ runs:
         echo "ONESIGNAL_APP_ID=${{ inputs.onesignal-app-id }}" > .env
         echo "ONESIGNAL_API_KEY=${{ inputs.onesignal-api-key }}" >> .env
         echo "E2E_MODE=true" >> .env
+        echo "ONESIGNAL_ANDROID_CHANNEL_ID=7ec2ece9-c538-4656-9516-1316f48a005c" >> .env

--- a/.github/actions/setup-demo/action.yml
+++ b/.github/actions/setup-demo/action.yml
@@ -31,8 +31,8 @@ runs:
       shell: bash
       working-directory: examples/demo
       run: |
-        bun run setup
-        bun install
+        vp run setup
+        vp install
 
     - name: Cache CocoaPods
       if: inputs.install-pods == 'true'
@@ -46,7 +46,7 @@ runs:
       if: inputs.install-pods == 'true'
       shell: bash
       working-directory: examples/demo
-      run: bun run update:pods
+      run: vp run update:pods
 
     - name: Create demo .env
       shell: bash

--- a/.github/workflows/create-release-pr.yml
+++ b/.github/workflows/create-release-pr.yml
@@ -92,8 +92,8 @@ jobs:
 
           # Get versions from target branch (not the release branch)
           CURRENT_VERSION=$(git show origin/${{ inputs.target_branch }}:package.json | jq -r .version)
-          ANDROID_VERSION=$(git show origin/${{ inputs.target_branch }}:android/build.gradle | grep "com.onesignal:OneSignal:" | sed -E "s/.*OneSignal:([0-9.]+).*/\1/")
-          IOS_VERSION=$(git show origin/${{ inputs.target_branch }}:react-native-onesignal.podspec | grep "OneSignalXCFramework" | sed -E "s/.*'([0-9.]+)'.*/\1/")
+          ANDROID_VERSION=$(git show origin/${{ inputs.target_branch }}:android/build.gradle | grep "com.onesignal:OneSignal:" | sed -E "s/.*OneSignal:([^\"']+).*/\1/")
+          IOS_VERSION=$(git show origin/${{ inputs.target_branch }}:react-native-onesignal.podspec | grep "OneSignalXCFramework" | sed -E "s/.*'([^']+)'.*/\1/")
 
           echo "rn_from=$CURRENT_VERSION" >> $GITHUB_OUTPUT
           echo "android_from=$ANDROID_VERSION" >> $GITHUB_OUTPUT
@@ -115,7 +115,7 @@ jobs:
           fi
 
           # Update Android SDK version in build.gradle (handles both api '...' and api('...') syntax)
-          sed -i '' -E "s/(com\.onesignal:OneSignal:)[0-9.]+/\1$VERSION/" android/build.gradle
+          sed -i '' -E "s/(com\.onesignal:OneSignal:)[^\"']+/\1$VERSION/" android/build.gradle
           echo "✓ Updated android/build.gradle with Android SDK ${VERSION}"
 
           # Only commit if there are changes

--- a/.github/workflows/create-release-pr.yml
+++ b/.github/workflows/create-release-pr.yml
@@ -140,6 +140,19 @@ jobs:
           sed -i '' "s/s\.dependency 'OneSignalXCFramework', '[^']*'/s.dependency 'OneSignalXCFramework', '$VERSION'/" react-native-onesignal.podspec
           echo "✓ Updated react-native-onesignal.podspec with iOS SDK ${VERSION}"
 
+          # Update demo app's Podfile.lock with the new iOS SDK version.
+          # setup.sh repacks the SDK tarball (so node_modules sees the new pin),
+          # then pod update rewrites the OneSignalXCFramework lock entry only.
+          # --no-repo-update is fine because trunk is a CDN and serves the new
+          # spec on demand without a local refresh.
+          (
+            cd examples/demo
+            vp run setup
+            cd ios
+            pod update OneSignalXCFramework --no-repo-update
+          )
+          echo "✓ Updated examples/demo/ios/Podfile.lock to OneSignalXCFramework ${VERSION}"
+
           # Only commit if there are changes
           git add -A
           git diff --staged --quiet && exit 0

--- a/.github/workflows/create-release-pr.yml
+++ b/.github/workflows/create-release-pr.yml
@@ -159,12 +159,20 @@ jobs:
           IFS='.' read -r MAJOR MINOR PATCH <<< "$CORE_VERSION"
           PADDED_VERSION=$(printf "%02d%02d%02d" "$MAJOR" "$MINOR" "$PATCH")
 
-          sed -i '' -E "s/(OneSignalWrapper\.setSdkVersion\(\")[0-9]+(\"\))/\1${PADDED_VERSION}\2/" \
-            android/src/main/java/com/onesignal/rnonesignalandroid/RNOneSignal.java
+          ANDROID_FILE=android/src/main/java/com/onesignal/rnonesignalandroid/RNOneSignal.java
+          sed -i '' -E "s/(OneSignalWrapper\.setSdkVersion\(\")[0-9]+(\"\))/\1${PADDED_VERSION}\2/" "$ANDROID_FILE"
+          if ! grep -q "OneSignalWrapper.setSdkVersion(\"${PADDED_VERSION}\")" "$ANDROID_FILE"; then
+            echo "::error::Failed to update wrapper version in ${ANDROID_FILE} to ${PADDED_VERSION}"
+            exit 1
+          fi
           echo "✓ Updated RNOneSignal.java wrapper version to ${PADDED_VERSION}"
 
-          sed -i '' -E "s/(OneSignalWrapper\.sdkVersion = @\")[0-9]+(\";)/\1${PADDED_VERSION}\2/" \
-            ios/RCTOneSignal/RCTOneSignal.mm
+          IOS_FILE=ios/RCTOneSignal/RCTOneSignal.mm
+          sed -i '' -E "s/(OneSignalWrapper\.sdkVersion = @\")[0-9]+(\";)/\1${PADDED_VERSION}\2/" "$IOS_FILE"
+          if ! grep -q "OneSignalWrapper.sdkVersion = @\"${PADDED_VERSION}\";" "$IOS_FILE"; then
+            echo "::error::Failed to update wrapper version in ${IOS_FILE} to ${PADDED_VERSION}"
+            exit 1
+          fi
           echo "✓ Updated RCTOneSignal.mm wrapper version to ${PADDED_VERSION}"
 
           # Only commit if there are changes

--- a/.github/workflows/create-release-pr.yml
+++ b/.github/workflows/create-release-pr.yml
@@ -140,19 +140,6 @@ jobs:
           sed -i '' "s/s\.dependency 'OneSignalXCFramework', '[^']*'/s.dependency 'OneSignalXCFramework', '$VERSION'/" react-native-onesignal.podspec
           echo "✓ Updated react-native-onesignal.podspec with iOS SDK ${VERSION}"
 
-          # Update demo app's Podfile.lock with the new iOS SDK version.
-          # setup.sh repacks the SDK tarball (so node_modules sees the new pin),
-          # then pod update rewrites the OneSignalXCFramework lock entry only.
-          # --no-repo-update is fine because trunk is a CDN and serves the new
-          # spec on demand without a local refresh.
-          (
-            cd examples/demo
-            vp run setup
-            cd ios
-            pod update OneSignalXCFramework --no-repo-update
-          )
-          echo "✓ Updated examples/demo/ios/Podfile.lock to OneSignalXCFramework ${VERSION}"
-
           # Only commit if there are changes
           git add -A
           git diff --staged --quiet && exit 0
@@ -192,6 +179,26 @@ jobs:
           git add -A
           git diff --staged --quiet && exit 0
           git commit -m "Release $NEW_VERSION" && git push
+
+      - name: Refresh demo Podfile.lock
+        run: |
+          # Runs after all version edits (package.json + podspec) so the
+          # repacked SDK tarball and OneSignalXCFramework pin both reflect
+          # the new release. pod install regenerates Podfile.lock entries
+          # for the path-based react-native-onesignal pod and any changed
+          # native pins in a single resolve.
+          (
+            cd examples/demo
+            vp run setup
+            cd ios
+            pod install
+          )
+          echo "✓ Refreshed examples/demo/ios/Podfile.lock"
+
+          # Only commit if there are changes
+          git add -A
+          git diff --staged --quiet && exit 0
+          git commit -m "Update demo Podfile.lock" && git push
 
   create-pr:
     needs: [prep, update_version]

--- a/.github/workflows/create-release-pr.yml
+++ b/.github/workflows/create-release-pr.yml
@@ -152,6 +152,21 @@ jobs:
           # Update package.json version
           npm pkg set version="$NEW_VERSION"
 
+          # Update the wrapper version literal reported to OneSignal's backend.
+          # Format is MMmmpp (zero-padded major/minor/patch); strip any pre-release suffix.
+          CORE_VERSION=${NEW_VERSION%%-*}
+          CORE_VERSION=${CORE_VERSION%%+*}
+          IFS='.' read -r MAJOR MINOR PATCH <<< "$CORE_VERSION"
+          PADDED_VERSION=$(printf "%02d%02d%02d" "$MAJOR" "$MINOR" "$PATCH")
+
+          sed -i '' -E "s/(OneSignalWrapper\.setSdkVersion\(\")[0-9]+(\"\))/\1${PADDED_VERSION}\2/" \
+            android/src/main/java/com/onesignal/rnonesignalandroid/RNOneSignal.java
+          echo "✓ Updated RNOneSignal.java wrapper version to ${PADDED_VERSION}"
+
+          sed -i '' -E "s/(OneSignalWrapper\.sdkVersion = @\")[0-9]+(\";)/\1${PADDED_VERSION}\2/" \
+            ios/RCTOneSignal/RCTOneSignal.mm
+          echo "✓ Updated RCTOneSignal.mm wrapper version to ${PADDED_VERSION}"
+
           # Only commit if there are changes
           git add -A
           git diff --staged --quiet && exit 0

--- a/.github/workflows/create-release-pr.yml
+++ b/.github/workflows/create-release-pr.yml
@@ -105,8 +105,11 @@ jobs:
           VERSION="${{ inputs.android_version }}"
 
           # Validate version exists on GitHub
-          RELEASE=$(curl -s -H "Authorization: token ${{ github.token }}" \
-            "https://api.github.com/repos/OneSignal/OneSignal-Android-SDK/releases/tags/${VERSION}")
+          # -sf: silent + fail on HTTP >= 400 so RELEASE stays empty
+          # on 404, otherwise GitHub's JSON error body would defeat the
+          # `[ -z ]` guard below.
+          RELEASE=$(curl -sf -H "Authorization: token ${{ github.token }}" \
+            "https://api.github.com/repos/OneSignal/OneSignal-Android-SDK/releases/tags/${VERSION}" || true)
 
 
           if [ -z "$RELEASE" ]; then
@@ -129,8 +132,11 @@ jobs:
           VERSION="${{ inputs.ios_version }}"
 
           # Validate version exists on GitHub
-          RELEASE=$(curl -s -H "Authorization: token ${{ github.token }}" \
-            "https://api.github.com/repos/OneSignal/OneSignal-iOS-SDK/releases/tags/${VERSION}")
+          # -sf: silent + fail on HTTP >= 400 so RELEASE stays empty
+          # on 404, otherwise GitHub's JSON error body would defeat the
+          # `[ -z ]` guard below.
+          RELEASE=$(curl -sf -H "Authorization: token ${{ github.token }}" \
+            "https://api.github.com/repos/OneSignal/OneSignal-iOS-SDK/releases/tags/${VERSION}" || true)
 
           if [ -z "$RELEASE" ]; then
             echo "✗ iOS SDK version ${VERSION} not found"

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -49,7 +49,7 @@ jobs:
       - name: Resolve OneSignal Android SDK version
         id: android-sdk-version
         run: |
-          VERSION=$(grep "com.onesignal:OneSignal:" android/build.gradle | sed -E "s/.*OneSignal:([0-9.]+).*/\1/")
+          VERSION=$(grep "com.onesignal:OneSignal:" android/build.gradle | sed -E "s/.*OneSignal:([^\"']+).*/\1/")
           echo "version=${VERSION}" >> "$GITHUB_OUTPUT"
 
       - name: Wait for OneSignal Android SDK on Maven Central

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -46,6 +46,17 @@ jobs:
           onesignal-app-id: ${{ vars.APPIUM_ONESIGNAL_APP_ID }}
           onesignal-api-key: ${{ secrets.APPIUM_ONESIGNAL_API_KEY }}
 
+      - name: Resolve OneSignal Android SDK version
+        id: android-sdk-version
+        run: |
+          VERSION=$(grep "com.onesignal:OneSignal:" android/build.gradle | sed -E "s/.*OneSignal:([0-9.]+).*/\1/")
+          echo "version=${VERSION}" >> "$GITHUB_OUTPUT"
+
+      - name: Wait for OneSignal Android SDK on Maven Central
+        uses: OneSignal/sdk-shared/.github/actions/wait-for-maven-artifact@main
+        with:
+          version: ${{ steps.android-sdk-version.outputs.version }}
+
       - name: Build release APK
         working-directory: examples/demo/android
         run: ./gradlew assembleRelease --quiet --console=plain --warning-mode=summary

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -59,13 +59,16 @@ jobs:
 
       - name: Build release APK
         working-directory: examples/demo/android
-        run: ./gradlew assembleRelease --quiet --console=plain --warning-mode=summary
+        # -PciSingleAbi → arm64-v8a-only APK (~10 MB) instead of the
+        # ~30 MB universal APK. BrowserStack devices we test against
+        # are all arm64-v8a.
+        run: ./gradlew assembleRelease -PciSingleAbi --quiet --console=plain --warning-mode=summary
 
       - name: Upload APK
         uses: actions/upload-artifact@v7
         with:
           name: demo-apk
-          path: examples/demo/android/app/build/outputs/apk/release/app-release.apk
+          path: examples/demo/android/app/build/outputs/apk/release/app-arm64-v8a-release.apk
           retention-days: 1
           compression-level: 0
 
@@ -150,7 +153,7 @@ jobs:
     with:
       platform: android
       app-artifact: demo-apk
-      app-filename: app-release.apk
+      app-filename: app-arm64-v8a-release.apk
       sdk-type: react-native
       build-name: react-native-android-${{ github.ref_name }}-${{ github.run_number }}
 

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -39,7 +39,7 @@ dependencies {
     // Exclude OkHttp from OneSignal's transitive deps: the 5.7.x otel module pulls in OkHttp 5.x
     // (via opentelemetry-exporter-sender-okhttp) which is binary-incompatible with React Native's
     // networking stack (okhttp3.internal.Util removed in 5.x). React Native already provides OkHttp 4.x.
-    api('com.onesignal:OneSignal:5.7.7') {
+    api('com.onesignal:OneSignal:5.8.0') {
         exclude group: 'com.squareup.okhttp3', module: 'okhttp'
     }
 

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -36,7 +36,7 @@ dependencies {
     // api is used instead of implementation so the parent :app project can access any of the OneSignal Java
     //   classes if needed. Such as com.onesignal.NotificationExtenderService
     //
-    // Exclude OkHttp from OneSignal's transitive deps: the 5.7.x otel module pulls in OkHttp 5.x
+    // Exclude OkHttp from OneSignal's transitive deps: the otel module pulls in OkHttp 5.x
     // (via opentelemetry-exporter-sender-okhttp) which is binary-incompatible with React Native's
     // networking stack (okhttp3.internal.Util removed in 5.x). React Native already provides OkHttp 4.x.
     api('com.onesignal:OneSignal:5.8.0') {

--- a/android/src/main/java/com/onesignal/rnonesignalandroid/RNOneSignal.java
+++ b/android/src/main/java/com/onesignal/rnonesignalandroid/RNOneSignal.java
@@ -230,7 +230,7 @@ public class RNOneSignal extends NativeOneSignalSpec
     @Override
     public void initialize(String appId) {
         OneSignalWrapper.setSdkType("reactnative");
-        OneSignalWrapper.setSdkVersion("050213");
+        OneSignalWrapper.setSdkVersion("050404");
 
         if (oneSignalInitDone) {
             Logging.debug("Already initialized the OneSignal React-Native SDK", null);

--- a/examples/demo/.env.example
+++ b/examples/demo/.env.example
@@ -2,3 +2,7 @@
 ONESIGNAL_APP_ID=your-onesignal-app-id
 ONESIGNAL_API_KEY=your-onesignal-api-key
 E2E_MODE=false
+
+# Optional: Android Notification Channel ID for the WITH SOUND test notification.
+# Create one in your OneSignal dashboard under Settings > Android Notification Categories.
+ONESIGNAL_ANDROID_CHANNEL_ID=

--- a/examples/demo/android/app/build.gradle
+++ b/examples/demo/android/app/build.gradle
@@ -56,8 +56,9 @@ react {
 
 /**
  * Set this to true to Run Proguard on Release builds to minify the Java bytecode.
+ * Enabled for the demo to keep the BrowserStack/e2e APK small (~28 MB → ~13 MB).
  */
-def enableProguardInReleaseBuilds = false
+def enableProguardInReleaseBuilds = true
 
 /**
  * The preferred build flavor of JavaScriptCore (JSC)

--- a/examples/demo/android/app/build.gradle
+++ b/examples/demo/android/app/build.gradle
@@ -105,6 +105,20 @@ android {
             proguardFiles getDefaultProguardFile("proguard-android.txt"), "proguard-rules.pro"
         }
     }
+
+    // CI-only: build a single arm64-v8a APK (~10 MB) instead of the
+    // universal ~30 MB fat APK. Enable with `-PciSingleAbi`. BrowserStack
+    // devices we run e2e against are all arm64-v8a.
+    if (project.hasProperty('ciSingleAbi')) {
+        splits {
+            abi {
+                enable true
+                reset()
+                include 'arm64-v8a'
+                universalApk false
+            }
+        }
+    }
 }
 
 apply from: "../../node_modules/react-native-vector-icons/fonts.gradle"

--- a/examples/demo/bun.lock
+++ b/examples/demo/bun.lock
@@ -8,9 +8,9 @@
         "@react-native-async-storage/async-storage": "^2.1.0",
         "@react-navigation/native": "^7.0.0",
         "@react-navigation/native-stack": "^7.0.0",
+        "react-native-onesignal": "file:../../react-native-onesignal.tgz",
         "react": "19.2.3",
         "react-native": "0.84.0",
-        "react-native-onesignal": "file:../../react-native-onesignal.tgz",
         "react-native-safe-area-context": "^5.5.2",
         "react-native-screens": "^4.0.0",
         "react-native-svg": "^15.8.0",
@@ -1006,7 +1006,7 @@
 
     "react-native-dotenv": ["react-native-dotenv@3.4.11", "", { "dependencies": { "dotenv": "^16.4.5" }, "peerDependencies": { "@babel/runtime": "^7.20.6" } }, "sha512-6vnIE+WHABSeHCaYP6l3O1BOEhWxKH6nHAdV7n/wKn/sciZ64zPPp2NUdEUf1m7g4uuzlLbjgr+6uDt89q2DOg=="],
 
-    "react-native-onesignal": ["react-native-onesignal@../../react-native-onesignal.tgz", { "dependencies": { "invariant": "^2.2.4" }, "peerDependencies": { "react-native": ">=0.76.0" } }, "sha512-waBo86i8QAv33r75UG6X1k9z6GA2sTxjt0hgf2V25z7IVcqhUUbp5sbH+pzYPBAA/yUQGgb6Im5GUvbNH3zRBg=="],
+    "react-native-onesignal": ["react-native-onesignal@../../react-native-onesignal.tgz", { "dependencies": { "invariant": "^2.2.4" }, "peerDependencies": { "react-native": ">=0.79.0" } }, "sha512-kqBF7g+l2w4q4H/RB7AaX4lYiIe73qv9OcbBZ/5y7FYcf5ngyBESgnd0215+mATnrfxVRJd51IO9dEivMRYptQ=="],
 
     "react-native-safe-area-context": ["react-native-safe-area-context@5.7.0", "", { "peerDependencies": { "react": "*", "react-native": "*" } }, "sha512-/9/MtQz8ODphjsLdZ+GZAIcC/RtoqW9EeShf7Uvnfgm/pzYrJ75y3PV/J1wuAV1T5Dye5ygq4EAW20RoBq0ABQ=="],
 

--- a/examples/demo/bun.lock
+++ b/examples/demo/bun.lock
@@ -1006,7 +1006,7 @@
 
     "react-native-dotenv": ["react-native-dotenv@3.4.11", "", { "dependencies": { "dotenv": "^16.4.5" }, "peerDependencies": { "@babel/runtime": "^7.20.6" } }, "sha512-6vnIE+WHABSeHCaYP6l3O1BOEhWxKH6nHAdV7n/wKn/sciZ64zPPp2NUdEUf1m7g4uuzlLbjgr+6uDt89q2DOg=="],
 
-    "react-native-onesignal": ["react-native-onesignal@../../react-native-onesignal.tgz", { "dependencies": { "invariant": "^2.2.4" }, "peerDependencies": { "react-native": ">=0.79.0" } }, "sha512-kqBF7g+l2w4q4H/RB7AaX4lYiIe73qv9OcbBZ/5y7FYcf5ngyBESgnd0215+mATnrfxVRJd51IO9dEivMRYptQ=="],
+    "react-native-onesignal": ["react-native-onesignal@../../react-native-onesignal.tgz", { "dependencies": { "invariant": "^2.2.4" }, "peerDependencies": { "react-native": ">=0.79.0" } }, "sha512-/WxWrib5VMiOxe5OAcGSxZI2ABafJISiQSVZBhYJToA19nSIZj/b1IwBs6PUoZWpUJDdFvYJ4DtD0Vc47OIM/g=="],
 
     "react-native-safe-area-context": ["react-native-safe-area-context@5.7.0", "", { "peerDependencies": { "react": "*", "react-native": "*" } }, "sha512-/9/MtQz8ODphjsLdZ+GZAIcC/RtoqW9EeShf7Uvnfgm/pzYrJ75y3PV/J1wuAV1T5Dye5ygq4EAW20RoBq0ABQ=="],
 

--- a/examples/demo/ios/ExportOptions.plist
+++ b/examples/demo/ios/ExportOptions.plist
@@ -3,7 +3,7 @@
 <plist version="1.0">
 <dict>
   <key>method</key>
-  <string>development</string>
+  <string>debugging</string>
   <key>teamID</key>
   <string>99SW8E36CT</string>
   <key>signingStyle</key>

--- a/examples/demo/ios/Podfile.lock
+++ b/examples/demo/ios/Podfile.lock
@@ -3,9 +3,9 @@ PODS:
   - hermes-engine (250829098.0.7):
     - hermes-engine/Pre-built (= 250829098.0.7)
   - hermes-engine/Pre-built (250829098.0.7)
-  - OneSignalXCFramework (5.5.0):
-    - OneSignalXCFramework/OneSignalComplete (= 5.5.0)
-  - OneSignalXCFramework/OneSignal (5.5.0):
+  - OneSignalXCFramework (5.5.1):
+    - OneSignalXCFramework/OneSignalComplete (= 5.5.1)
+  - OneSignalXCFramework/OneSignal (5.5.1):
     - OneSignalXCFramework/OneSignalCore
     - OneSignalXCFramework/OneSignalExtension
     - OneSignalXCFramework/OneSignalLiveActivities
@@ -13,38 +13,38 @@ PODS:
     - OneSignalXCFramework/OneSignalOSCore
     - OneSignalXCFramework/OneSignalOutcomes
     - OneSignalXCFramework/OneSignalUser
-  - OneSignalXCFramework/OneSignalComplete (5.5.0):
+  - OneSignalXCFramework/OneSignalComplete (5.5.1):
     - OneSignalXCFramework/OneSignal
     - OneSignalXCFramework/OneSignalInAppMessages
     - OneSignalXCFramework/OneSignalLocation
-  - OneSignalXCFramework/OneSignalCore (5.5.0)
-  - OneSignalXCFramework/OneSignalExtension (5.5.0):
+  - OneSignalXCFramework/OneSignalCore (5.5.1)
+  - OneSignalXCFramework/OneSignalExtension (5.5.1):
     - OneSignalXCFramework/OneSignalCore
     - OneSignalXCFramework/OneSignalOutcomes
-  - OneSignalXCFramework/OneSignalInAppMessages (5.5.0):
+  - OneSignalXCFramework/OneSignalInAppMessages (5.5.1):
     - OneSignalXCFramework/OneSignalCore
     - OneSignalXCFramework/OneSignalNotifications
     - OneSignalXCFramework/OneSignalOSCore
     - OneSignalXCFramework/OneSignalOutcomes
     - OneSignalXCFramework/OneSignalUser
-  - OneSignalXCFramework/OneSignalLiveActivities (5.5.0):
+  - OneSignalXCFramework/OneSignalLiveActivities (5.5.1):
     - OneSignalXCFramework/OneSignalCore
     - OneSignalXCFramework/OneSignalOSCore
     - OneSignalXCFramework/OneSignalUser
-  - OneSignalXCFramework/OneSignalLocation (5.5.0):
+  - OneSignalXCFramework/OneSignalLocation (5.5.1):
     - OneSignalXCFramework/OneSignalCore
     - OneSignalXCFramework/OneSignalNotifications
     - OneSignalXCFramework/OneSignalOSCore
     - OneSignalXCFramework/OneSignalUser
-  - OneSignalXCFramework/OneSignalNotifications (5.5.0):
+  - OneSignalXCFramework/OneSignalNotifications (5.5.1):
     - OneSignalXCFramework/OneSignalCore
     - OneSignalXCFramework/OneSignalExtension
     - OneSignalXCFramework/OneSignalOutcomes
-  - OneSignalXCFramework/OneSignalOSCore (5.5.0):
+  - OneSignalXCFramework/OneSignalOSCore (5.5.1):
     - OneSignalXCFramework/OneSignalCore
-  - OneSignalXCFramework/OneSignalOutcomes (5.5.0):
+  - OneSignalXCFramework/OneSignalOutcomes (5.5.1):
     - OneSignalXCFramework/OneSignalCore
-  - OneSignalXCFramework/OneSignalUser (5.5.0):
+  - OneSignalXCFramework/OneSignalUser (5.5.1):
     - OneSignalXCFramework/OneSignalCore
     - OneSignalXCFramework/OneSignalNotifications
     - OneSignalXCFramework/OneSignalOSCore
@@ -1446,9 +1446,9 @@ PODS:
     - React-RCTFBReactNativeSpec
     - ReactCommon/turbomodule/core
     - ReactNativeDependencies
-  - react-native-onesignal (5.4.3):
+  - react-native-onesignal (5.4.4):
     - hermes-engine
-    - OneSignalXCFramework (= 5.5.0)
+    - OneSignalXCFramework (= 5.5.1)
     - RCTRequired
     - RCTTypeSafety
     - React-Core
@@ -2311,84 +2311,84 @@ EXTERNAL SOURCES:
 
 SPEC CHECKSUMS:
   FBLazyVector: c12d2108050e27952983d565a232f6f7b1ad5e69
-  hermes-engine: 177322198264d50dc281084c48e1ed80ea14884c
-  OneSignalXCFramework: 943852e7d70d719f73e9669d48620aeec1b93022
+  hermes-engine: 4767e0635aa935e639e65671853dc9bcf83191ff
+  OneSignalXCFramework: 2b46c36b38528b65dce33ed9d83375f8c98bf40c
   RCTDeprecation: 3280799c14232a56e5a44f92981a8ee33bc69fd9
   RCTRequired: 9854a51b0f65ccf43ea0b744df4d70fce339db32
   RCTSwiftUI: 96986e49a4fdc2c2103929dee2641e1b57edf33d
-  RCTSwiftUIWrapper: 55e482219b78c2c652123fea845a6b1716fa97e7
+  RCTSwiftUIWrapper: e3eed9f50cad9f171e4487e2ff18a9caa4d46bfb
   RCTTypeSafety: e9ba155357c236764934054ee2d393fd76e7b36b
   React: 7ef36630d07638043a134a7dd2ec17e0be10fc3c
   React-callinvoker: af4e8fe1d60ab63dd8d74c2a68988064c2848954
-  React-Core: c609976c034ba9556bef9850a571a71bd458d73f
-  React-Core-prebuilt: f4df078355bf9605a0d0278aa5c63fcd4b764a1d
-  React-CoreModules: 0ea85f3b3f4b8cbfb3afacd2ed85458fb878517a
-  React-cxxreact: 6752bab77c0599d6136e2b8b9b64b4a7d316d401
+  React-Core: c0fb1df65eb0ed7a8633841831f05f93c3eb3aff
+  React-Core-prebuilt: 3fc0c0607fe45b79cafbfe2913e7d9d6ff2744a9
+  React-CoreModules: 7dfe7962360355f1547c85ab52e1fc4b57f17127
+  React-cxxreact: 9e9c7f1710bc58abebf924813b5e825b99adb8e5
   React-debug: 38389b86e3570558ec73dd4cbc0cd2f2eec47a51
-  React-defaultsnativemodule: c1c25636322de460083d9291bc813067aa706552
-  React-domnativemodule: d1734e540ea9344ec1a024de5704d39063935049
-  React-Fabric: 48a292ed21257b0d9639e3c4cc49047a2c8a7f8f
-  React-FabricComponents: 932d81e7e2de71c25a63c1832f76f123e1a091f3
-  React-FabricImage: adbb7b606e96add2785646a1c81e285367f0d249
-  React-featureflags: 2a6f0a8f885559e1192e8bb0c173de638529df20
-  React-featureflagsnativemodule: 255521af601b622048ec50b5dbf104cc886762a8
-  React-graphics: ddca902e78ca64a824c31d206b083a3f207d6d06
-  React-hermes: b5df3aebd45da232c6e8c9d925260e9d64122d03
-  React-idlecallbacksnativemodule: fb05344181eeb52c5fd54597599b6e71b05dcf21
-  React-ImageManager: 4861de430733ee8cf9fd06acb9fdf65d8d551f9d
-  React-intersectionobservernativemodule: 6699faee489b3439a4961270e880d814690f4eea
-  React-jserrorhandler: a3a9796a152ddd2712403d7cd7903624003db4b6
-  React-jsi: 2c0a2219dacbdf776c5c911fae6f8923813d1ff2
-  React-jsiexecutor: 0c4082df04719e747ae6d728e4e238ef1de16457
-  React-jsinspector: f4d6e379303d120888cd1e15e3e7e1b2b4d41b37
-  React-jsinspectorcdp: 0147c000c3a9e05082d974fdb05f8fc0c470787d
-  React-jsinspectornetwork: d5e1b2d72d1a205aee8141906735bd85c4cb9a7c
-  React-jsinspectortracing: 8d52e3fcb00cf6c4fcdeac0ec7b10bfe819693e1
-  React-jsitooling: 455d72275baff87bd39a8a1b315e0bd8b13fa8e9
-  React-jsitracing: 5a15b0ecc476e47533236dbbf2b6e670d6d8aa41
-  React-logger: 9e51e01455f15cb3ef87a09a1ec773cdb22d56c1
-  React-Mapbuffer: 92b99e450e8ff598b27d6e4db3a75e04fd45e9a9
-  React-microtasksnativemodule: 2fe0f2bd2840dedbd66c0ac249c64f977f39cc18
-  react-native-onesignal: dc0212667c92798d90a72316aec304f9df6dddc4
-  react-native-safe-area-context: ae7587b95fb580d1800c5b0b2a7bd48c2868e67a
-  React-NativeModulesApple: 44a9474594566cd03659f92e38f42599c6b9dee4
-  React-networking: db73d91466cb134fcbdaaa579fb2de14e2c2ea01
+  React-defaultsnativemodule: a326ccbb71369762888a6be09a23fa5bce2bdb6a
+  React-domnativemodule: 8394c7b535d1b484b1eab677e00b086507cd906a
+  React-Fabric: 682dafd75455062590cd1f63c79199cf72ff27d9
+  React-FabricComponents: 11b13a53213cd1aaca3bf7f4c61c669617b26b5f
+  React-FabricImage: 706c27e82f77b77db96ab3a19009ddb5e777967f
+  React-featureflags: c2898fb2f93ab92cfd9f294b4531d2884e7cfc7e
+  React-featureflagsnativemodule: 1edf93adfa12ba4f15d07079c1675b55ff579477
+  React-graphics: 57d042385bfef5104aafeab189f43b8d6145013b
+  React-hermes: 96d2d439f0477a93fe8e801664088eccc07a16ff
+  React-idlecallbacksnativemodule: ab4dc6c3657f434f82c568ca83c963791e783f6a
+  React-ImageManager: f39057f375cf3f98255fb751df3865a91f2755c1
+  React-intersectionobservernativemodule: 54ce679b183149fd9566a79211f2f54dc0a6fd1f
+  React-jserrorhandler: 2e92acff04ac815c6066c7cc08ea302610045db1
+  React-jsi: dc97891e1ee7fa17cad01cd150c50f21e04bd51b
+  React-jsiexecutor: e1543ba5a8be761331c8158d91211079cc5b73a2
+  React-jsinspector: 7a1d86673986db6666cacc8b95e92125397ab6ea
+  React-jsinspectorcdp: 38a0c116fd4965abf29261721db9b903923cb723
+  React-jsinspectornetwork: cfeace6b40f13ba82980ba7cb730847a35675c7f
+  React-jsinspectortracing: 5507411117e51751dba0543cdee7916eb0388693
+  React-jsitooling: e3a2df9043ab7b9ad11bbbfe4b33eb6762514f05
+  React-jsitracing: ad179fab1c1e08a57fcdb840b7021b453f7a2b6d
+  React-logger: e40cc24a61d3a54c09bf4e83d5556b3b9d4c90aa
+  React-Mapbuffer: 53f28c81b84767a0b2fb4c0109dd7e4571226f76
+  React-microtasksnativemodule: ddaf25a8d69f694bc880fb6055e34d79f1d50138
+  react-native-onesignal: 43e49657f86ef5c0ce44379d8f1b0806e2c43602
+  react-native-safe-area-context: 29044d05d61f2c60d0828c373bd0ebe17eed58d0
+  React-NativeModulesApple: 14a8919451154ede904f2bca84b27703a09028ba
+  React-networking: 46c0037f9202c1919493b78662a47cbe13022fdd
   React-oscompat: b924b8609d06899f00ab1aa813b0cde9c5e12771
-  React-perflogger: 8afbf1c6c0e6d8f869cb2917492db19dc212312d
-  React-performancecdpmetrics: 9034e89102afda66d6c6fcb43233c24f3927fa78
-  React-performancetimeline: 7860aafe1782694fa6b5ce7bae0dfd199fe049f7
+  React-perflogger: c3bb13800f795287e73a8c1991a2b8e5008ea3d0
+  React-performancecdpmetrics: 851d2b18ba3d3d8cfb309bf468e5e93e46601122
+  React-performancetimeline: 0a960aee139987151d2976813c47bef17dea3d3a
   React-RCTActionSheet: 21fbcd85f552d5d6575453d2e8c149535d9c6f46
-  React-RCTAnimation: e8840d9f68bbbcf766909d738b021d2c0df1be36
-  React-RCTAppDelegate: 0a491adac54f255d549656cc016c61102aaddfb7
-  React-RCTBlob: f3eceaf519cf0f7f159bb653b3431b26c956400f
-  React-RCTFabric: 6278c2bc45c4b5685f7d7027d86343048b3d906b
-  React-RCTFBReactNativeSpec: ba5c77a9658d3acb7cbc5653162661df1d63ed25
-  React-RCTImage: 928e5125c8e5407f3c6c62d51593eb8000fb2a36
-  React-RCTLinking: 80c236e6e837d297750aac8da269fab24d4e0fc1
-  React-RCTNetwork: 9554720800c31ec6608ed8047a314252e40008ac
-  React-RCTRuntime: d37d53534c207677f86df9b9cb30b7dde8857327
-  React-RCTSettings: 52a066ceedda0253d75755909ee14a11972b16dc
-  React-RCTText: dd2964c3f003549ef3ce9ac5b7966d1c79dc5875
-  React-RCTVibration: dc9e7490a0e270b1ec905c13714434c809a276fa
+  React-RCTAnimation: 2c8cb9508864bb15e9f8fe86242d8918f05278e9
+  React-RCTAppDelegate: 1d52e34d25f5f1bed5c07e0717c40dc572a80010
+  React-RCTBlob: bc487ebb909c23920af75c842b1405edba61b8ea
+  React-RCTFabric: 7de87d2635b95171a06d9fffd907c4ac17823ef2
+  React-RCTFBReactNativeSpec: b3936c48bf5262dc57ba28f8c8208cd1b570964c
+  React-RCTImage: a591fc9f08dc6c7b63b9fb34f51a7c1f32bd9595
+  React-RCTLinking: cb9553b27de77a63beb4e3ce95f82aa8f3bed602
+  React-RCTNetwork: 576ba853aef49628238b4840e969217b826af156
+  React-RCTRuntime: e0aa5ea63ba4e06c9028da5ae8b05cf72bc8a1ea
+  React-RCTSettings: 8caa15edae452a5c4cd064569d5357a2bee8de15
+  React-RCTText: af9a1c8d7c135c4d3ffa2de253ca95544234a521
+  React-RCTVibration: c1dd36479ca1c1a59d16db81e5a994e9be06a68b
   React-rendererconsistency: 32e7b98c05a3f237ecb524add21190036962e868
-  React-renderercss: b5f27fdea2162033c44af42bd9da7eefb08603a6
-  React-rendererdebug: 09e9a23444c9319c965d7f981f8f2d57d2f88428
-  React-RuntimeApple: 7c2c6aff02da8f1d89c211baa0a98bb76b01dfed
-  React-RuntimeCore: 4b3688f2ddcaf644f8e645ec45b4d77ec9cf58f9
-  React-runtimeexecutor: 8540253f799008af0485a9ec417b001e73a9dede
-  React-RuntimeHermes: abc8b8b62dec3d3f5d685d586dd4b2381fc36ea8
-  React-runtimescheduler: a64d5a112f8f8bc58af6f3e3382452f6f91002c6
-  React-timing: 1f40175beb4b55fa3f6de9f947cd7ed9275deb25
-  React-utils: e157d1837edbb842b9c0201a6a144a4d3d395246
-  React-webperformancenativemodule: 295dde5803df595cd9a266f44e4371bbf12a600e
-  ReactAppDependencyProvider: 6b7e8d8d974ed13fb66698d82c30c5e70c1f7d3a
-  ReactCodegen: c5e5343f6691b0cd76913b9be5e89e5a83ff3315
-  ReactCommon: 92b53b0bd7f7d86154dc9f512c1ea5dee717cc72
-  ReactNativeDependencies: eaebe8c9533ec2c41b08a02844af461bfff10540
-  RNCAsyncStorage: 3a4f5e2777dae1688b781a487923a08569e27fe4
-  RNScreens: 6cb648bdad8fe9bee9259fe144df95b6d1d5b707
-  RNSVG: c69f7709226108f5eb89b5aa8833c17a36345468
-  RNVectorIcons: 4351544f100d4f12cac156a7c13399e60bab3e26
+  React-renderercss: d65e9232e5033cd9c07b13fa429ce925b8143bd7
+  React-rendererdebug: 25c6151116b7ea1f78af72afc64f2066ad29a61d
+  React-RuntimeApple: e036929884cc0d8088fe8a5a2d210e068d35e608
+  React-RuntimeCore: 0c8a252051fe6b627f5147ac5b6a5298951472a8
+  React-runtimeexecutor: 0765dddf1842e23e87ad13b2cb1bb72bb9005aeb
+  React-RuntimeHermes: 44cd4fdc4afa44fa782ddce8600e3cc90215fbc5
+  React-runtimescheduler: 1966ff307933cdbafd480cb3aa1fdc90d9a6d539
+  React-timing: 94c4a44dd2d10e4fc51fd42654fd5f67d68247ad
+  React-utils: 172d467a9c037d5ed51ee6eeaa6ad30ca1ebe1b1
+  React-webperformancenativemodule: 9e3c5032dd30bf6418b741ab54ad26187b1c94c3
+  ReactAppDependencyProvider: 625d2f6d9d5ef01acc9dfe2b5385504bbffd2ad0
+  ReactCodegen: 27937747ddc743fcb66a8dc19e8edf60188d94cc
+  ReactCommon: cc0e38600f82487c5fe5d29150abb6fa9d981986
+  ReactNativeDependencies: 1f3a71f078c7654486c7151cce53d5a868a22bd5
+  RNCAsyncStorage: e85a99325df9eb0191a6ee2b2a842644c7eb29f4
+  RNScreens: 088d923c4327c63c9f8c942cae17a9d038f47d97
+  RNSVG: 2ead7004a54d1cded41af4e6ee29104e94ba48c6
+  RNVectorIcons: af977c18ed27deba54ed038b439fca2911a08cfc
   Yoga: 772166513f9cd2d61a6251d0dacbbfaa5b537479
 
 PODFILE CHECKSUM: f62fbda480f1d76e1eac7d980b0960570d6cfe89

--- a/examples/demo/ios/Podfile.lock
+++ b/examples/demo/ios/Podfile.lock
@@ -2311,84 +2311,84 @@ EXTERNAL SOURCES:
 
 SPEC CHECKSUMS:
   FBLazyVector: c12d2108050e27952983d565a232f6f7b1ad5e69
-  hermes-engine: 4767e0635aa935e639e65671853dc9bcf83191ff
+  hermes-engine: 177322198264d50dc281084c48e1ed80ea14884c
   OneSignalXCFramework: 2b46c36b38528b65dce33ed9d83375f8c98bf40c
   RCTDeprecation: 3280799c14232a56e5a44f92981a8ee33bc69fd9
   RCTRequired: 9854a51b0f65ccf43ea0b744df4d70fce339db32
   RCTSwiftUI: 96986e49a4fdc2c2103929dee2641e1b57edf33d
-  RCTSwiftUIWrapper: e3eed9f50cad9f171e4487e2ff18a9caa4d46bfb
+  RCTSwiftUIWrapper: 55e482219b78c2c652123fea845a6b1716fa97e7
   RCTTypeSafety: e9ba155357c236764934054ee2d393fd76e7b36b
   React: 7ef36630d07638043a134a7dd2ec17e0be10fc3c
   React-callinvoker: af4e8fe1d60ab63dd8d74c2a68988064c2848954
-  React-Core: c0fb1df65eb0ed7a8633841831f05f93c3eb3aff
-  React-Core-prebuilt: 3fc0c0607fe45b79cafbfe2913e7d9d6ff2744a9
-  React-CoreModules: 7dfe7962360355f1547c85ab52e1fc4b57f17127
-  React-cxxreact: 9e9c7f1710bc58abebf924813b5e825b99adb8e5
+  React-Core: c609976c034ba9556bef9850a571a71bd458d73f
+  React-Core-prebuilt: f4df078355bf9605a0d0278aa5c63fcd4b764a1d
+  React-CoreModules: 0ea85f3b3f4b8cbfb3afacd2ed85458fb878517a
+  React-cxxreact: 6752bab77c0599d6136e2b8b9b64b4a7d316d401
   React-debug: 38389b86e3570558ec73dd4cbc0cd2f2eec47a51
-  React-defaultsnativemodule: a326ccbb71369762888a6be09a23fa5bce2bdb6a
-  React-domnativemodule: 8394c7b535d1b484b1eab677e00b086507cd906a
-  React-Fabric: 682dafd75455062590cd1f63c79199cf72ff27d9
-  React-FabricComponents: 11b13a53213cd1aaca3bf7f4c61c669617b26b5f
-  React-FabricImage: 706c27e82f77b77db96ab3a19009ddb5e777967f
-  React-featureflags: c2898fb2f93ab92cfd9f294b4531d2884e7cfc7e
-  React-featureflagsnativemodule: 1edf93adfa12ba4f15d07079c1675b55ff579477
-  React-graphics: 57d042385bfef5104aafeab189f43b8d6145013b
-  React-hermes: 96d2d439f0477a93fe8e801664088eccc07a16ff
-  React-idlecallbacksnativemodule: ab4dc6c3657f434f82c568ca83c963791e783f6a
-  React-ImageManager: f39057f375cf3f98255fb751df3865a91f2755c1
-  React-intersectionobservernativemodule: 54ce679b183149fd9566a79211f2f54dc0a6fd1f
-  React-jserrorhandler: 2e92acff04ac815c6066c7cc08ea302610045db1
-  React-jsi: dc97891e1ee7fa17cad01cd150c50f21e04bd51b
-  React-jsiexecutor: e1543ba5a8be761331c8158d91211079cc5b73a2
-  React-jsinspector: 7a1d86673986db6666cacc8b95e92125397ab6ea
-  React-jsinspectorcdp: 38a0c116fd4965abf29261721db9b903923cb723
-  React-jsinspectornetwork: cfeace6b40f13ba82980ba7cb730847a35675c7f
-  React-jsinspectortracing: 5507411117e51751dba0543cdee7916eb0388693
-  React-jsitooling: e3a2df9043ab7b9ad11bbbfe4b33eb6762514f05
-  React-jsitracing: ad179fab1c1e08a57fcdb840b7021b453f7a2b6d
-  React-logger: e40cc24a61d3a54c09bf4e83d5556b3b9d4c90aa
-  React-Mapbuffer: 53f28c81b84767a0b2fb4c0109dd7e4571226f76
-  React-microtasksnativemodule: ddaf25a8d69f694bc880fb6055e34d79f1d50138
-  react-native-onesignal: 43e49657f86ef5c0ce44379d8f1b0806e2c43602
-  react-native-safe-area-context: 29044d05d61f2c60d0828c373bd0ebe17eed58d0
-  React-NativeModulesApple: 14a8919451154ede904f2bca84b27703a09028ba
-  React-networking: 46c0037f9202c1919493b78662a47cbe13022fdd
+  React-defaultsnativemodule: c1c25636322de460083d9291bc813067aa706552
+  React-domnativemodule: d1734e540ea9344ec1a024de5704d39063935049
+  React-Fabric: 48a292ed21257b0d9639e3c4cc49047a2c8a7f8f
+  React-FabricComponents: 932d81e7e2de71c25a63c1832f76f123e1a091f3
+  React-FabricImage: adbb7b606e96add2785646a1c81e285367f0d249
+  React-featureflags: 2a6f0a8f885559e1192e8bb0c173de638529df20
+  React-featureflagsnativemodule: 255521af601b622048ec50b5dbf104cc886762a8
+  React-graphics: ddca902e78ca64a824c31d206b083a3f207d6d06
+  React-hermes: b5df3aebd45da232c6e8c9d925260e9d64122d03
+  React-idlecallbacksnativemodule: fb05344181eeb52c5fd54597599b6e71b05dcf21
+  React-ImageManager: 4861de430733ee8cf9fd06acb9fdf65d8d551f9d
+  React-intersectionobservernativemodule: 6699faee489b3439a4961270e880d814690f4eea
+  React-jserrorhandler: a3a9796a152ddd2712403d7cd7903624003db4b6
+  React-jsi: 2c0a2219dacbdf776c5c911fae6f8923813d1ff2
+  React-jsiexecutor: 0c4082df04719e747ae6d728e4e238ef1de16457
+  React-jsinspector: f4d6e379303d120888cd1e15e3e7e1b2b4d41b37
+  React-jsinspectorcdp: 0147c000c3a9e05082d974fdb05f8fc0c470787d
+  React-jsinspectornetwork: d5e1b2d72d1a205aee8141906735bd85c4cb9a7c
+  React-jsinspectortracing: 8d52e3fcb00cf6c4fcdeac0ec7b10bfe819693e1
+  React-jsitooling: 455d72275baff87bd39a8a1b315e0bd8b13fa8e9
+  React-jsitracing: 5a15b0ecc476e47533236dbbf2b6e670d6d8aa41
+  React-logger: 9e51e01455f15cb3ef87a09a1ec773cdb22d56c1
+  React-Mapbuffer: 92b99e450e8ff598b27d6e4db3a75e04fd45e9a9
+  React-microtasksnativemodule: 2fe0f2bd2840dedbd66c0ac249c64f977f39cc18
+  react-native-onesignal: bc00d2a1100522842e5215026178212c560004eb
+  react-native-safe-area-context: ae7587b95fb580d1800c5b0b2a7bd48c2868e67a
+  React-NativeModulesApple: 44a9474594566cd03659f92e38f42599c6b9dee4
+  React-networking: db73d91466cb134fcbdaaa579fb2de14e2c2ea01
   React-oscompat: b924b8609d06899f00ab1aa813b0cde9c5e12771
-  React-perflogger: c3bb13800f795287e73a8c1991a2b8e5008ea3d0
-  React-performancecdpmetrics: 851d2b18ba3d3d8cfb309bf468e5e93e46601122
-  React-performancetimeline: 0a960aee139987151d2976813c47bef17dea3d3a
+  React-perflogger: 8afbf1c6c0e6d8f869cb2917492db19dc212312d
+  React-performancecdpmetrics: 9034e89102afda66d6c6fcb43233c24f3927fa78
+  React-performancetimeline: 7860aafe1782694fa6b5ce7bae0dfd199fe049f7
   React-RCTActionSheet: 21fbcd85f552d5d6575453d2e8c149535d9c6f46
-  React-RCTAnimation: 2c8cb9508864bb15e9f8fe86242d8918f05278e9
-  React-RCTAppDelegate: 1d52e34d25f5f1bed5c07e0717c40dc572a80010
-  React-RCTBlob: bc487ebb909c23920af75c842b1405edba61b8ea
-  React-RCTFabric: 7de87d2635b95171a06d9fffd907c4ac17823ef2
-  React-RCTFBReactNativeSpec: b3936c48bf5262dc57ba28f8c8208cd1b570964c
-  React-RCTImage: a591fc9f08dc6c7b63b9fb34f51a7c1f32bd9595
-  React-RCTLinking: cb9553b27de77a63beb4e3ce95f82aa8f3bed602
-  React-RCTNetwork: 576ba853aef49628238b4840e969217b826af156
-  React-RCTRuntime: e0aa5ea63ba4e06c9028da5ae8b05cf72bc8a1ea
-  React-RCTSettings: 8caa15edae452a5c4cd064569d5357a2bee8de15
-  React-RCTText: af9a1c8d7c135c4d3ffa2de253ca95544234a521
-  React-RCTVibration: c1dd36479ca1c1a59d16db81e5a994e9be06a68b
+  React-RCTAnimation: e8840d9f68bbbcf766909d738b021d2c0df1be36
+  React-RCTAppDelegate: 0a491adac54f255d549656cc016c61102aaddfb7
+  React-RCTBlob: f3eceaf519cf0f7f159bb653b3431b26c956400f
+  React-RCTFabric: 6278c2bc45c4b5685f7d7027d86343048b3d906b
+  React-RCTFBReactNativeSpec: ba5c77a9658d3acb7cbc5653162661df1d63ed25
+  React-RCTImage: 928e5125c8e5407f3c6c62d51593eb8000fb2a36
+  React-RCTLinking: 80c236e6e837d297750aac8da269fab24d4e0fc1
+  React-RCTNetwork: 9554720800c31ec6608ed8047a314252e40008ac
+  React-RCTRuntime: d37d53534c207677f86df9b9cb30b7dde8857327
+  React-RCTSettings: 52a066ceedda0253d75755909ee14a11972b16dc
+  React-RCTText: dd2964c3f003549ef3ce9ac5b7966d1c79dc5875
+  React-RCTVibration: dc9e7490a0e270b1ec905c13714434c809a276fa
   React-rendererconsistency: 32e7b98c05a3f237ecb524add21190036962e868
-  React-renderercss: d65e9232e5033cd9c07b13fa429ce925b8143bd7
-  React-rendererdebug: 25c6151116b7ea1f78af72afc64f2066ad29a61d
-  React-RuntimeApple: e036929884cc0d8088fe8a5a2d210e068d35e608
-  React-RuntimeCore: 0c8a252051fe6b627f5147ac5b6a5298951472a8
-  React-runtimeexecutor: 0765dddf1842e23e87ad13b2cb1bb72bb9005aeb
-  React-RuntimeHermes: 44cd4fdc4afa44fa782ddce8600e3cc90215fbc5
-  React-runtimescheduler: 1966ff307933cdbafd480cb3aa1fdc90d9a6d539
-  React-timing: 94c4a44dd2d10e4fc51fd42654fd5f67d68247ad
-  React-utils: 172d467a9c037d5ed51ee6eeaa6ad30ca1ebe1b1
-  React-webperformancenativemodule: 9e3c5032dd30bf6418b741ab54ad26187b1c94c3
-  ReactAppDependencyProvider: 625d2f6d9d5ef01acc9dfe2b5385504bbffd2ad0
-  ReactCodegen: 27937747ddc743fcb66a8dc19e8edf60188d94cc
-  ReactCommon: cc0e38600f82487c5fe5d29150abb6fa9d981986
-  ReactNativeDependencies: 1f3a71f078c7654486c7151cce53d5a868a22bd5
-  RNCAsyncStorage: e85a99325df9eb0191a6ee2b2a842644c7eb29f4
-  RNScreens: 088d923c4327c63c9f8c942cae17a9d038f47d97
-  RNSVG: 2ead7004a54d1cded41af4e6ee29104e94ba48c6
-  RNVectorIcons: af977c18ed27deba54ed038b439fca2911a08cfc
+  React-renderercss: b5f27fdea2162033c44af42bd9da7eefb08603a6
+  React-rendererdebug: 09e9a23444c9319c965d7f981f8f2d57d2f88428
+  React-RuntimeApple: 7c2c6aff02da8f1d89c211baa0a98bb76b01dfed
+  React-RuntimeCore: 4b3688f2ddcaf644f8e645ec45b4d77ec9cf58f9
+  React-runtimeexecutor: 8540253f799008af0485a9ec417b001e73a9dede
+  React-RuntimeHermes: abc8b8b62dec3d3f5d685d586dd4b2381fc36ea8
+  React-runtimescheduler: a64d5a112f8f8bc58af6f3e3382452f6f91002c6
+  React-timing: 1f40175beb4b55fa3f6de9f947cd7ed9275deb25
+  React-utils: e157d1837edbb842b9c0201a6a144a4d3d395246
+  React-webperformancenativemodule: 295dde5803df595cd9a266f44e4371bbf12a600e
+  ReactAppDependencyProvider: 6b7e8d8d974ed13fb66698d82c30c5e70c1f7d3a
+  ReactCodegen: c5e5343f6691b0cd76913b9be5e89e5a83ff3315
+  ReactCommon: 92b53b0bd7f7d86154dc9f512c1ea5dee717cc72
+  ReactNativeDependencies: eaebe8c9533ec2c41b08a02844af461bfff10540
+  RNCAsyncStorage: 3a4f5e2777dae1688b781a487923a08569e27fe4
+  RNScreens: 6cb648bdad8fe9bee9259fe144df95b6d1d5b707
+  RNSVG: c69f7709226108f5eb89b5aa8833c17a36345468
+  RNVectorIcons: 4351544f100d4f12cac156a7c13399e60bab3e26
   Yoga: 772166513f9cd2d61a6251d0dacbbfaa5b537479
 
 PODFILE CHECKSUM: f62fbda480f1d76e1eac7d980b0960570d6cfe89

--- a/examples/demo/ios/demo.xcodeproj/project.pbxproj
+++ b/examples/demo/ios/demo.xcodeproj/project.pbxproj
@@ -572,7 +572,7 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				ALWAYS_SEARCH_USER_PATHS = NO;
-				CC = "$(REACT_NATIVE_PATH)/scripts/xcode/ccache-clang.sh";
+				CC = "";
 				CCACHE_BINARY = ccache;
 				CLANG_ANALYZER_LOCALIZABILITY_NONLOCALIZED = YES;
 				CLANG_CXX_LANGUAGE_STANDARD = "c++20";
@@ -601,7 +601,7 @@
 				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
 				COPY_PHASE_STRIP = NO;
-				CXX = "$(REACT_NATIVE_PATH)/scripts/xcode/ccache-clang++.sh";
+				CXX = "";
 				ENABLE_STRICT_OBJC_MSGSEND = YES;
 				ENABLE_TESTABILITY = YES;
 				"EXCLUDED_ARCHS[sdk=iphonesimulator*]" = "";
@@ -621,8 +621,8 @@
 				GCC_WARN_UNUSED_FUNCTION = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
 				IPHONEOS_DEPLOYMENT_TARGET = 15.1;
-				LD = "$(REACT_NATIVE_PATH)/scripts/xcode/ccache-clang.sh";
-				LDPLUSPLUS = "$(REACT_NATIVE_PATH)/scripts/xcode/ccache-clang++.sh";
+				LD = "";
+				LDPLUSPLUS = "";
 				LD_RUNPATH_SEARCH_PATHS = (
 					/usr/lib/swift,
 					"$(inherited)",
@@ -659,7 +659,7 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				ALWAYS_SEARCH_USER_PATHS = NO;
-				CC = "$(REACT_NATIVE_PATH)/scripts/xcode/ccache-clang.sh";
+				CC = "";
 				CCACHE_BINARY = ccache;
 				CLANG_ANALYZER_LOCALIZABILITY_NONLOCALIZED = YES;
 				CLANG_CXX_LANGUAGE_STANDARD = "c++20";
@@ -688,7 +688,7 @@
 				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
 				COPY_PHASE_STRIP = YES;
-				CXX = "$(REACT_NATIVE_PATH)/scripts/xcode/ccache-clang++.sh";
+				CXX = "";
 				ENABLE_NS_ASSERTIONS = NO;
 				ENABLE_STRICT_OBJC_MSGSEND = YES;
 				"EXCLUDED_ARCHS[sdk=iphonesimulator*]" = "";
@@ -701,8 +701,8 @@
 				GCC_WARN_UNUSED_FUNCTION = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
 				IPHONEOS_DEPLOYMENT_TARGET = 15.1;
-				LD = "$(REACT_NATIVE_PATH)/scripts/xcode/ccache-clang.sh";
-				LDPLUSPLUS = "$(REACT_NATIVE_PATH)/scripts/xcode/ccache-clang++.sh";
+				LD = "";
+				LDPLUSPLUS = "";
 				LD_RUNPATH_SEARCH_PATHS = (
 					/usr/lib/swift,
 					"$(inherited)",

--- a/examples/demo/ios/demo.xcodeproj/project.pbxproj
+++ b/examples/demo/ios/demo.xcodeproj/project.pbxproj
@@ -366,13 +366,9 @@
 			inputFileListPaths = (
 				"${PODS_ROOT}/Target Support Files/Pods-demo/Pods-demo-frameworks-${CONFIGURATION}-input-files.xcfilelist",
 			);
-			inputPaths = (
-			);
 			name = "[CP] Embed Pods Frameworks";
 			outputFileListPaths = (
 				"${PODS_ROOT}/Target Support Files/Pods-demo/Pods-demo-frameworks-${CONFIGURATION}-output-files.xcfilelist",
-			);
-			outputPaths = (
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
@@ -431,13 +427,9 @@
 			inputFileListPaths = (
 				"${PODS_ROOT}/Target Support Files/Pods-demo/Pods-demo-resources-${CONFIGURATION}-input-files.xcfilelist",
 			);
-			inputPaths = (
-			);
 			name = "[CP] Copy Pods Resources";
 			outputFileListPaths = (
 				"${PODS_ROOT}/Target Support Files/Pods-demo/Pods-demo-resources-${CONFIGURATION}-output-files.xcfilelist",
-			);
-			outputPaths = (
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
@@ -750,7 +742,7 @@
 				CURRENT_PROJECT_VERSION = 1;
 				DEVELOPMENT_TEAM = 99SW8E36CT;
 				INFOPLIST_FILE = OneSignalNotificationServiceExtension/Info.plist;
-				IPHONEOS_DEPLOYMENT_TARGET = 13.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 15.1;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
@@ -776,7 +768,7 @@
 				DEVELOPMENT_TEAM = "";
 				"DEVELOPMENT_TEAM[sdk=iphoneos*]" = 99SW8E36CT;
 				INFOPLIST_FILE = OneSignalNotificationServiceExtension/Info.plist;
-				IPHONEOS_DEPLOYMENT_TARGET = 13.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 15.1;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",

--- a/examples/demo/package.json
+++ b/examples/demo/package.json
@@ -8,7 +8,7 @@
     "preios": "bun run setup",
     "android": "bash ../run-android.sh",
     "ios": "bash ../run-ios.sh",
-    "update:pods": "cd ios && pod update OneSignalXCFramework --no-repo-update && cd ..",
+    "update:pods": "cd ios && pod update OneSignalXCFramework && cd ..",
     "clean:android": "rm -rf android/app/build android/app/.cxx android/build && adb uninstall com.onesignal.example >/dev/null 2>&1 || true",
     "clean:ios": "rm -rf ios/build ios/Pods",
     "start": "react-native start"
@@ -44,5 +44,6 @@
   },
   "engines": {
     "node": ">= 22.11.0"
-  }
+  },
+  "packageManager": "bun@1.3.13"
 }

--- a/examples/demo/package.json
+++ b/examples/demo/package.json
@@ -4,8 +4,8 @@
   "private": true,
   "scripts": {
     "setup": "../setup.sh",
-    "preandroid": "bun run setup",
-    "preios": "bun run setup",
+    "preandroid": "vp run setup",
+    "preios": "vp run setup",
     "android": "bash ../run-android.sh",
     "ios": "bash ../run-ios.sh",
     "update:pods": "(cd ios && pod update OneSignalXCFramework --no-repo-update)",

--- a/examples/demo/package.json
+++ b/examples/demo/package.json
@@ -8,7 +8,7 @@
     "preios": "bun run setup",
     "android": "bash ../run-android.sh",
     "ios": "bash ../run-ios.sh",
-    "update:pods": "cd ios && pod update OneSignalXCFramework && cd ..",
+    "update:pods": "(cd ios && pod update OneSignalXCFramework --no-repo-update)",
     "clean:android": "rm -rf android/app/build android/app/.cxx android/build && adb uninstall com.onesignal.example >/dev/null 2>&1 || true",
     "clean:ios": "rm -rf ios/build ios/Pods",
     "start": "react-native start"

--- a/examples/demo/src/services/OneSignalApiService.ts
+++ b/examples/demo/src/services/OneSignalApiService.ts
@@ -50,7 +50,7 @@ class OneSignalApiService {
         contents = { en: 'This notification plays a custom sound' };
         extra.ios_sound = 'vine_boom.wav';
         extra.android_channel_id =
-          ONESIGNAL_ANDROID_CHANNEL_ID ?? 'b3b015d9-c050-4042-8548-dcc34aa44aa4';
+          ONESIGNAL_ANDROID_CHANNEL_ID?.trim() || 'b3b015d9-c050-4042-8548-dcc34aa44aa4';
         break;
       default:
         return false;

--- a/examples/demo/src/services/OneSignalApiService.ts
+++ b/examples/demo/src/services/OneSignalApiService.ts
@@ -1,4 +1,4 @@
-import { ONESIGNAL_API_KEY } from '@env';
+import { ONESIGNAL_API_KEY, ONESIGNAL_ANDROID_CHANNEL_ID } from '@env';
 
 import { NotificationType } from '../models/NotificationType';
 import { UserData, userDataFromJson } from '../models/UserData';
@@ -49,7 +49,8 @@ class OneSignalApiService {
         headings = { en: 'Sound Notification' };
         contents = { en: 'This notification plays a custom sound' };
         extra.ios_sound = 'vine_boom.wav';
-        extra.android_channel_id = 'b3b015d9-c050-4042-8548-dcc34aa44aa4';
+        extra.android_channel_id =
+          ONESIGNAL_ANDROID_CHANNEL_ID ?? 'b3b015d9-c050-4042-8548-dcc34aa44aa4';
         break;
       default:
         return false;

--- a/examples/demo/tsconfig.json
+++ b/examples/demo/tsconfig.json
@@ -1,7 +1,9 @@
 {
   "extends": "@react-native/typescript-config",
   "compilerOptions": {
-    "types": ["jest"]
+    // Override the base config's `"types": ["jest"]` since this demo
+    // doesn't ship jest tests and @types/jest isn't installed.
+    "types": []
   },
   "include": ["**/*.ts", "**/*.tsx", "**/*.d.ts"],
   "exclude": ["**/node_modules", "**/Pods"]

--- a/examples/demo/types/env.d.ts
+++ b/examples/demo/types/env.d.ts
@@ -1,5 +1,6 @@
 declare module '@env' {
   export const ONESIGNAL_APP_ID: string;
   export const ONESIGNAL_API_KEY: string;
+  export const ONESIGNAL_ANDROID_CHANNEL_ID: string;
   export const E2E_MODE: string;
 }

--- a/examples/setup.sh
+++ b/examples/setup.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-# Invoked from a demo dir (e.g. examples/demo/) via `bun run setup`.
+# Invoked from a demo dir (e.g. examples/demo/) via `vp run setup`.
 # ORIGINAL_DIR captures that dir so we can return to it after building
 # the SDK; SDK_ROOT is two levels up (the SDK package itself).
 ORIGINAL_DIR=$(pwd)

--- a/examples/setup.sh
+++ b/examples/setup.sh
@@ -41,29 +41,31 @@ fi
 cd "$SDK_ROOT"
 vp run build
 
-# `bun pm pack` honors package.json's "files" field (so the tarball matches
-# what would actually be published). The version suffix in the filename
-# is unstable, so we normalize to react-native-onesignal.tgz for a
-# deterministic path that package.json + the extract step can reference.
+# `vp pm pack` (wraps bun pm pack) honors package.json's "files" field
+# (so the tarball matches what would actually be published). The version
+# suffix in the filename is unstable, so we normalize to
+# react-native-onesignal.tgz for a deterministic path that package.json +
+# the extract step can reference.
 rm -f react-native-onesignal*.tgz
 vp pm pack
 mv react-native-onesignal-*.tgz react-native-onesignal.tgz
 
 cd "$ORIGINAL_DIR"
 
-# Always go through bun add so bun.lock's integrity hash for the tarball
-# stays in sync with the freshly-built tarball on disk. A previous version
-# of this script had a "hot path" that just untarred over node_modules
-# directly, which was faster but left a stale sha512 in bun.lock — any
-# subsequent `bun install` that re-resolved this entry (e.g. when the
-# lockfile was touched by another dep) would fail with IntegrityCheckFailed.
+# Always go through `vp add` (wraps bun) so bun.lock's integrity hash for
+# the tarball stays in sync with the freshly-built tarball on disk. A
+# previous version of this script had a "hot path" that just untarred
+# over node_modules directly, which was faster but left a stale sha512
+# in bun.lock — any subsequent `vp install` that re-resolved this entry
+# (e.g. when the lockfile was touched by another dep) would fail with
+# IntegrityCheckFailed.
 #
-# `bun remove` first because bun verifies the existing integrity hash
+# `vp remove` first because bun verifies the existing integrity hash
 # before replacing the entry; without removing, a stale hash from a prior
-# build causes `bun add` itself to fail. The relative `file:../../...`
+# build causes `vp add` itself to fail. The relative `file:../../...`
 # path is intentional — an absolute path would leak this machine's
 # layout into the lockfile.
-echo "Registering tarball with bun (refreshes bun.lock integrity hash)..."
+echo "Registering tarball with vp (refreshes bun.lock integrity hash)..."
 vp remove react-native-onesignal 2>/dev/null || true
 vp add file:../../react-native-onesignal.tgz
 

--- a/examples/setup.sh
+++ b/examples/setup.sh
@@ -1,3 +1,4 @@
+#!/usr/bin/env bash
 set -euo pipefail
 
 # Invoked from a demo dir (e.g. examples/demo/) via `bun run setup`.

--- a/examples/setup.sh
+++ b/examples/setup.sh
@@ -38,14 +38,14 @@ if [ "${FORCE_SETUP:-0}" != "1" ] \
 fi
 
 cd "$SDK_ROOT"
-bun run build
+vp run build
 
 # `bun pm pack` honors package.json's "files" field (so the tarball matches
 # what would actually be published). The version suffix in the filename
 # is unstable, so we normalize to react-native-onesignal.tgz for a
 # deterministic path that package.json + the extract step can reference.
 rm -f react-native-onesignal*.tgz
-bun pm pack
+vp pm pack
 mv react-native-onesignal-*.tgz react-native-onesignal.tgz
 
 cd "$ORIGINAL_DIR"
@@ -63,8 +63,8 @@ cd "$ORIGINAL_DIR"
 # path is intentional — an absolute path would leak this machine's
 # layout into the lockfile.
 echo "Registering tarball with bun (refreshes bun.lock integrity hash)..."
-bun remove react-native-onesignal 2>/dev/null || true
-bun add file:../../react-native-onesignal.tgz
+vp remove react-native-onesignal 2>/dev/null || true
+vp add file:../../react-native-onesignal.tgz
 
 # Record the hash only after a successful build/install so that an
 # interrupted run forces a full retry next time.

--- a/ios/RCTOneSignal/RCTOneSignal.mm
+++ b/ios/RCTOneSignal/RCTOneSignal.mm
@@ -23,7 +23,7 @@
     return;
 
   OneSignalWrapper.sdkType = @"reactnative";
-  OneSignalWrapper.sdkVersion = @"050213";
+  OneSignalWrapper.sdkVersion = @"050404";
   // initialize the SDK with a nil app ID so cold start click listeners can be
   // triggered
   [OneSignal initialize:nil withLaunchOptions:launchOptions];

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-native-onesignal",
-  "version": "5.4.3",
+  "version": "5.4.4",
   "description": "React Native OneSignal SDK",
   "keywords": [
     "android",

--- a/react-native-onesignal.podspec
+++ b/react-native-onesignal.podspec
@@ -15,5 +15,5 @@ Pod::Spec.new do |s|
 
   install_modules_dependencies(s)
 
-  s.dependency 'OneSignalXCFramework', '5.5.0'
+  s.dependency 'OneSignalXCFramework', '5.5.1'
 end


### PR DESCRIPTION
Channels: Current

### 🐛 Bug Fixes

- fix: [SDK-4390] bump react-native peer dep to >=0.79.0 for TurboModule support (#1944)

### 🛠️ Native Dependency Updates

- Update Android SDK from 5.7.7 to 5.8.0
  - feat: hash PII (email/SMS) in SharedPreferences at rest ([#2620](https://github.com/OneSignal/OneSignal-Android-SDK/pull/2620))
  - feat: SDK-4176: gate background threading behind remote feature flag ([#2595](https://github.com/OneSignal/OneSignal-Android-SDK/pull/2595))
  - feat: SDK-4210: Standardize BACKGROUND_THREADING feature flag key naming ([#2598](https://github.com/OneSignal/OneSignal-Android-SDK/pull/2598))
  - feat: SDK-4363: Turbine remote SDK feature flags and foreground refresh ([#2612](https://github.com/OneSignal/OneSignal-Android-SDK/pull/2612))
  - bug: catch exception if opening a notification fails ([#2508](https://github.com/OneSignal/OneSignal-Android-SDK/pull/2508))
  - Fix: a rare NPE from PermissionViewModel ([#2504](https://github.com/OneSignal/OneSignal-Android-SDK/pull/2504))
  - fix: add retry for notification opened confirmation ([#2606](https://github.com/OneSignal/OneSignal-Android-SDK/pull/2606))
  - fix: end initialization early if device storage is locked ([#2520](https://github.com/OneSignal/OneSignal-Android-SDK/pull/2520))
- Update iOS SDK from 5.5.0 to 5.5.1
  - fix: update unattributed outcomes to match attributed outcomes and Android SDK ([OneSignal-iOS-SDK#1655](https://github.com/OneSignal/OneSignal-iOS-SDK/pull/1655))
