### PR TITLE
chore: Release 5.4.5

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -39,7 +39,7 @@ dependencies {
     // Exclude OkHttp from OneSignal's transitive deps: the otel module pulls in OkHttp 5.x
     // (via opentelemetry-exporter-sender-okhttp) which is binary-incompatible with React Native's
     // networking stack (okhttp3.internal.Util removed in 5.x). React Native already provides OkHttp 4.x.
-    api('com.onesignal:OneSignal:5.8.0') {
+    api('com.onesignal:OneSignal:5.8.1') {
         exclude group: 'com.squareup.okhttp3', module: 'okhttp'
     }
 

--- a/android/src/main/java/com/onesignal/rnonesignalandroid/RNOneSignal.java
+++ b/android/src/main/java/com/onesignal/rnonesignalandroid/RNOneSignal.java
@@ -230,7 +230,7 @@ public class RNOneSignal extends NativeOneSignalSpec
     @Override
     public void initialize(String appId) {
         OneSignalWrapper.setSdkType("reactnative");
-        OneSignalWrapper.setSdkVersion("050404");
+        OneSignalWrapper.setSdkVersion("050405");
 
         if (oneSignalInitDone) {
             Logging.debug("Already initialized the OneSignal React-Native SDK", null);

--- a/ios/RCTOneSignal/RCTOneSignal.mm
+++ b/ios/RCTOneSignal/RCTOneSignal.mm
@@ -23,7 +23,7 @@
     return;
 
   OneSignalWrapper.sdkType = @"reactnative";
-  OneSignalWrapper.sdkVersion = @"050404";
+  OneSignalWrapper.sdkVersion = @"050405";
   // initialize the SDK with a nil app ID so cold start click listeners can be
   // triggered
   [OneSignal initialize:nil withLaunchOptions:launchOptions];

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-native-onesignal",
-  "version": "5.4.4",
+  "version": "5.4.5",
   "description": "React Native OneSignal SDK",
   "keywords": [
     "android",


### PR DESCRIPTION
Channels: Current

### 🐛 Bug Fixes

- fix: [SDK-4386] preserve null property values in trackEvent on iOS (#1946)

### 🛠️ Native Dependency Updates

- Update Android SDK from 5.8.0 to 5.8.1
  - feat: SDK-4417: emit ossdk.features_enabled in Otel per-event payload ([#2631](https://github.com/OneSignal/OneSignal-Android-SDK/pull/2631))
  - push token on startup when notification permission already granted ([#2622](https://github.com/OneSignal/OneSignal-Android-SDK/pull/2622))
  - fix: clear unprocessedOpenedNotifs queue after replaying to new listener ([#2632](https://github.com/OneSignal/OneSignal-Android-SDK/pull/2632))
  - fix: login/logout race causes subsequent calls to target previous user ([#2618](https://github.com/OneSignal/OneSignal-Android-SDK/pull/2618))
