### PR TITLE
feat: [SDK-4728] support disabling location module

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,24 @@ If you run into any challenges or have concerns, please contact our support team
 
 See the [Setup Guide](https://documentation.onesignal.com/docs/react-native-sdk-setup) for setup instructions.
 
+#### Disable Location Module
+
+By default, `react-native-onesignal` includes OneSignal's native location module so `OneSignal.Location` works without extra setup. If your app does not use location features, you can exclude the native location module from iOS and Android builds.
+
+In your iOS `Podfile`, set this before React Native installs native modules:
+
+```ruby
+$OneSignalDisableLocation = true
+```
+
+In your Android `gradle.properties`, set:
+
+```properties
+OneSignal_disableLocation=true
+```
+
+When disabled, `OneSignal.Location.requestPermission()` and `OneSignal.Location.setShared()` no-op on native builds without the location module, and `OneSignal.Location.isShared()` resolves `false`.
+
 #### Change Log
 
 See this repository's [release tags](https://github.com/OneSignal/react-native-onesignal/releases) for a complete change log of every released version.

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -5,6 +5,18 @@ def safeExtGet(prop, fallback) {
     rootProject.ext.has(prop) ? rootProject.ext.get(prop) : fallback
 }
 
+def safePropGet(prop, fallback) {
+    if (rootProject.ext.has(prop)) {
+        return rootProject.ext.get(prop)
+    }
+
+    def value = rootProject.findProperty(prop)
+    return value != null ? value : fallback
+}
+
+def oneSignalVersion = '5.9.3'
+def oneSignalDisableLocation = safePropGet('OneSignal_disableLocation', false).toString().toBoolean()
+
 android {
     namespace "com.onesignal.rnonesignalandroid"
     compileSdkVersion safeExtGet('compileSdkVersion', 34)
@@ -33,8 +45,20 @@ dependencies {
     // Exclude OkHttp from OneSignal's transitive deps: the otel module pulls in OkHttp 5.x
     // (via opentelemetry-exporter-sender-okhttp) which is binary-incompatible with React Native's
     // networking stack (okhttp3.internal.Util removed in 5.x). React Native already provides OkHttp 4.x.
-    api('com.onesignal:OneSignal:5.9.3') {
-        exclude group: 'com.squareup.okhttp3', module: 'okhttp'
+    if (oneSignalDisableLocation) {
+        api("com.onesignal:core:${oneSignalVersion}") {
+            exclude group: 'com.squareup.okhttp3', module: 'okhttp'
+        }
+        api("com.onesignal:notifications:${oneSignalVersion}") {
+            exclude group: 'com.squareup.okhttp3', module: 'okhttp'
+        }
+        api("com.onesignal:in-app-messages:${oneSignalVersion}") {
+            exclude group: 'com.squareup.okhttp3', module: 'okhttp'
+        }
+    } else {
+        api("com.onesignal:OneSignal:${oneSignalVersion}") {
+            exclude group: 'com.squareup.okhttp3', module: 'okhttp'
+        }
     }
 
     testImplementation 'junit:junit:4.12'

--- a/android/src/main/java/com/onesignal/rnonesignalandroid/RNOneSignal.java
+++ b/android/src/main/java/com/onesignal/rnonesignalandroid/RNOneSignal.java
@@ -168,8 +168,8 @@ public class RNOneSignal extends NativeOneSignalSpec
         Logging.error("Failed to serialize payload for " + eventName, exception);
     }
 
-    private void logLocationModuleNotAvailable(Exception exception) {
-        Logging.error(LOCATION_MODULE_NOT_AVAILABLE, exception);
+    private void logLocationModuleNotAvailable(Throwable throwable) {
+        Logging.error(LOCATION_MODULE_NOT_AVAILABLE, throwable);
     }
 
     private void removeObservers() {
@@ -330,8 +330,8 @@ public class RNOneSignal extends NativeOneSignalSpec
     public void requestLocationPermission() {
         try {
             OneSignal.getLocation().requestPermission(Continue.none());
-        } catch (Exception e) {
-            logLocationModuleNotAvailable(e);
+        } catch (Throwable t) {
+            logLocationModuleNotAvailable(t);
         }
     }
 
@@ -339,8 +339,8 @@ public class RNOneSignal extends NativeOneSignalSpec
     public void isLocationShared(Promise promise) {
         try {
             promise.resolve(OneSignal.getLocation().isShared());
-        } catch (Exception e) {
-            logLocationModuleNotAvailable(e);
+        } catch (Throwable t) {
+            logLocationModuleNotAvailable(t);
             promise.resolve(false);
         }
     }
@@ -349,8 +349,8 @@ public class RNOneSignal extends NativeOneSignalSpec
     public void setLocationShared(boolean shared) {
         try {
             OneSignal.getLocation().setShared(shared);
-        } catch (Exception e) {
-            logLocationModuleNotAvailable(e);
+        } catch (Throwable t) {
+            logLocationModuleNotAvailable(t);
         }
     }
 

--- a/android/src/main/java/com/onesignal/rnonesignalandroid/RNOneSignal.java
+++ b/android/src/main/java/com/onesignal/rnonesignalandroid/RNOneSignal.java
@@ -79,6 +79,8 @@ public class RNOneSignal extends NativeOneSignalSpec
                 LifecycleEventListener,
                 INotificationLifecycleListener {
     public static final String NAME = "OneSignal";
+    private static final String LOCATION_MODULE_NOT_AVAILABLE =
+            "OneSignal location module is not available. Add the location dependency to use OneSignal.Location.";
 
     private boolean oneSignalInitDone;
     private boolean hasSetPermissionObserver = false;
@@ -164,6 +166,10 @@ public class RNOneSignal extends NativeOneSignalSpec
 
     private void logJSONException(String eventName, JSONException exception) {
         Logging.error("Failed to serialize payload for " + eventName, exception);
+    }
+
+    private void logLocationModuleNotAvailable(Exception exception) {
+        Logging.error(LOCATION_MODULE_NOT_AVAILABLE, exception);
     }
 
     private void removeObservers() {
@@ -322,17 +328,30 @@ public class RNOneSignal extends NativeOneSignalSpec
 
     @Override
     public void requestLocationPermission() {
-        OneSignal.getLocation().requestPermission(Continue.none());
+        try {
+            OneSignal.getLocation().requestPermission(Continue.none());
+        } catch (Exception e) {
+            logLocationModuleNotAvailable(e);
+        }
     }
 
     @Override
     public void isLocationShared(Promise promise) {
-        promise.resolve(OneSignal.getLocation().isShared());
+        try {
+            promise.resolve(OneSignal.getLocation().isShared());
+        } catch (Exception e) {
+            logLocationModuleNotAvailable(e);
+            promise.resolve(false);
+        }
     }
 
     @Override
     public void setLocationShared(boolean shared) {
-        OneSignal.getLocation().setShared(shared);
+        try {
+            OneSignal.getLocation().setShared(shared);
+        } catch (Exception e) {
+            logLocationModuleNotAvailable(e);
+        }
     }
 
     @Override

--- a/react-native-onesignal.podspec
+++ b/react-native-onesignal.podspec
@@ -1,5 +1,7 @@
 require 'json'
 package_json = JSON.parse(File.read('package.json'))
+onesignal_xcframework_version = '5.5.2'
+onesignal_disable_location = defined?($OneSignalDisableLocation) && $OneSignalDisableLocation == true
 
 Pod::Spec.new do |s|
   s.name           = "react-native-onesignal"
@@ -15,5 +17,10 @@ Pod::Spec.new do |s|
 
   install_modules_dependencies(s)
 
-  s.dependency 'OneSignalXCFramework', '5.5.2'
+  if onesignal_disable_location
+    s.dependency 'OneSignalXCFramework/OneSignal', onesignal_xcframework_version
+    s.dependency 'OneSignalXCFramework/OneSignalInAppMessages', onesignal_xcframework_version
+  else
+    s.dependency 'OneSignalXCFramework', onesignal_xcframework_version
+  end
 end


### PR DESCRIPTION
# Description

## One Line Summary

Adds build-time flags to exclude the native OneSignal location module from React Native apps.

## Details

### Motivation

Apps that do not use `OneSignal.Location` should be able to avoid linking native location dependencies so iOS and Android builds do not include location-specific modules or permissions.

### Scope

This PR adds the core SDK support only:

- iOS: `$OneSignalDisableLocation = true` switches CocoaPods from the aggregate `OneSignalXCFramework` pod to non-location subspecs.
- Android: `OneSignal_disableLocation=true` switches Gradle from the aggregate `com.onesignal:OneSignal` module to non-location modules.
- Android location bridge calls catch the missing-module path and degrade without crashing.
- README documents the native flags for consumers.

The runnable no-location demo is intentionally split into the follow-up stacked PR.

# Testing

## Unit testing

No unit tests were added. This change adjusts native dependency selection and bridge handling, which is covered by manual app build/runtime checks in the stacked demo PR.

## Manual testing

- Verified the stacked no-location demo builds and launches on iOS and Android with these flags enabled.
- Verified iOS Pod resolution excludes `OneSignalLocation` in the stacked demo.
- Verified Android logs report the expected missing location module message when invoking `OneSignal.Location` without the location dependency.

# Affected code checklist

- [x] Notifications
  - [ ] Display
  - [ ] Open
  - [x] Push Processing
  - [ ] Confirm Deliveries
- [ ] Outcomes
- [ ] Sessions
- [x] In-App Messaging
- [ ] REST API requests
- [x] Public API changes

# Checklist

## Overview

- [x] I have filled out all **REQUIRED** sections above
- [x] PR does one thing
- [x] Any Public API changes are explained in the PR details and conform to existing APIs

## Testing

- [x] I have included test coverage for these changes, or explained why they are not needed
- [x] All automated tests pass, or I explained why that is not possible
- [x] I have personally tested this on my device, or explained why that is not possible

## Final pass

- [x] Code is as readable as possible.
- [x] I have reviewed this PR myself, ensuring it meets each checklist item

Made with [Cursor](https://cursor.com)