### PR TITLE
chore: [SDK-4728] support Gradle property override

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,12 @@ ONESIGNAL_DISABLE_LOCATION=true pod install        # iOS, from the ios directory
 ONESIGNAL_DISABLE_LOCATION=true ./gradlew assembleDebug   # Android, from the android directory
 ```
 
+For Android, you can also persist the Gradle property in `android/gradle.properties`:
+
+```properties
+onesignal.disableLocation=true
+```
+
 In GitHub Actions, you can also set it once at the job or step level so
 `pod install`, `pod update`, and Gradle builds inherit it:
 
@@ -63,7 +69,7 @@ rm -rf Pods Podfile.lock
 ONESIGNAL_DISABLE_LOCATION=true pod install
 ```
 
-Gradle re-reads the variable on each configuration, so a clean build with the variable set is enough on Android.
+Gradle re-reads the environment variable or `onesignal.disableLocation` property on each configuration, so a clean build after changing the flag is enough on Android.
 
 > [!IMPORTANT]
 > When using Xcode or Android Studio, launch the IDE from a terminal that has `ONESIGNAL_DISABLE_LOCATION` exported. An IDE launched from the Dock/Finder does not inherit variables set only in your shell profile. On CI, key any CocoaPods / Gradle caches on the value of `ONESIGNAL_DISABLE_LOCATION` so a restored cache does not resurrect the location module.

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -5,14 +5,20 @@ def safeExtGet(prop, fallback) {
     rootProject.ext.has(prop) ? rootProject.ext.get(prop) : fallback
 }
 
-def safeEnvFlagGet(prop) {
-    def value = System.getenv(prop)
+def safeFlagGet(envProp, gradleProp) {
+    def value = System.getenv(envProp)
+    if (value == null && project.hasProperty(gradleProp)) {
+        value = project.property(gradleProp)
+    }
+    if (value == null && rootProject.hasProperty(gradleProp)) {
+        value = rootProject.property(gradleProp)
+    }
     def normalizedValue = value?.toString()?.trim()
     return normalizedValue != null && (normalizedValue.equalsIgnoreCase('true') || normalizedValue == '1')
 }
 
 def oneSignalVersion = '5.9.3'
-def oneSignalDisableLocation = safeEnvFlagGet('ONESIGNAL_DISABLE_LOCATION')
+def oneSignalDisableLocation = safeFlagGet('ONESIGNAL_DISABLE_LOCATION', 'onesignal.disableLocation')
 
 android {
     namespace "com.onesignal.rnonesignalandroid"

--- a/examples/demo-no-location/bun.lock
+++ b/examples/demo-no-location/bun.lock
@@ -898,7 +898,7 @@
 
     "react-native-dotenv": ["react-native-dotenv@3.4.11", "", { "dependencies": { "dotenv": "^16.4.5" }, "peerDependencies": { "@babel/runtime": "^7.20.6" } }, "sha512-6vnIE+WHABSeHCaYP6l3O1BOEhWxKH6nHAdV7n/wKn/sciZ64zPPp2NUdEUf1m7g4uuzlLbjgr+6uDt89q2DOg=="],
 
-    "react-native-onesignal": ["react-native-onesignal@../../react-native-onesignal.tgz", { "dependencies": { "invariant": "^2.2.4" }, "peerDependencies": { "react-native": ">=0.79.0" } }, "sha512-W8nKFCwiiTq7yRopB/0MFeZDj+VFJCpkACU0An35asi0yAjJznlTuB+/eGXHA+X1CibcesgZr/+AIYGkhvvDAA=="],
+    "react-native-onesignal": ["react-native-onesignal@../../react-native-onesignal.tgz", { "dependencies": { "invariant": "^2.2.4" }, "peerDependencies": { "react-native": ">=0.79.0" } }, "sha512-Jm9JzhQ/yb9DBGhyJSpKmgOp8gOAhqqdeaXy4gmc88fRrR0YpHhzknA32sCVwMSqtK4FvqcVhxUP6ZnKxX9bxg=="],
 
     "react-refresh": ["react-refresh@0.14.2", "", {}, "sha512-jCvmsr+1IUSMUyzOkRcvnVbX3ZYC6g9TDrDbFuFmRDq7PD4yaGbLKNQL6k2jnArV8hjYxh7hVhAZB6s9HDGpZA=="],
 


### PR DESCRIPTION
# Description

## One Line Summary

Allow Android builds to disable the OneSignal location module through the persistent `onesignal.disableLocation` Gradle property.

## Details

### Motivation

`ONESIGNAL_DISABLE_LOCATION` works well for shell and CI builds, but Android projects and Expo prebuild output need a file-backed option that Gradle can read on later invocations. This adds an idiomatic Gradle property fallback while keeping the existing environment variable behavior.

### Scope

This affects Android dependency selection only. The existing `ONESIGNAL_DISABLE_LOCATION` environment variable remains supported and takes precedence over the Gradle property. iOS behavior is unchanged.

# Testing

## Unit testing

No new unit tests were added because this change is in Gradle dependency selection logic.

## Manual testing

- Ran `vp check && vp test`
- Rebuilt and reinstalled the local SDK tarball into `examples/demo-no-location`
- Verified `env -u ONESIGNAL_DISABLE_LOCATION ./android/gradlew -p android -Ponesignal.disableLocation=true :app:dependencies --configuration debugRuntimeClasspath` excludes `com.onesignal:location`
- Verified the same dependency graph with neither env nor Gradle property includes `com.onesignal:OneSignal` and `com.onesignal:location`


```
2026-06-10 10:04:42.276 19989-20049 OneSignal               com.onesignal.example                E  [mqt_v_native] OneSignal location module is not available. Add the location dependency to use OneSignal.Location.
                                                                                                    java.lang.Exception: Must include gradle module com.onesignal:Location in order to use this functionality!
                                                                                                    	at com.onesignal.location.internal.MisconfiguredLocationManager$Companion.getEXCEPTION(MisconfiguredLocationManager.kt:19)
                                                                                                    	at com.onesignal.location.internal.MisconfiguredLocationManager$Companion.access$getEXCEPTION(MisconfiguredLocationManager.kt:18)
                                                                                                    	at com.onesignal.location.internal.MisconfiguredLocationManager.requestPermission(MisconfiguredLocationManager.kt:16)
                                                                                                    	at com.onesignal.rnonesignalandroid.RNOneSignal.requestLocationPermission(RNOneSignal.java:332)
                                                                                                    	at com.facebook.jni.NativeRunnable.run(Native Method)
                                                                                                    	at android.os.Handler.handleCallback(Handler.java:995)
                                                                                                    	at android.os.Handler.dispatchMessage(Handler.java:103)
                                                                                                    	at com.facebook.react.bridge.queue.MessageQueueThreadHandler.dispatchMessage(MessageQueueThreadHandler.kt:21)
                                                                                                    	at android.os.Looper.loopOnce(Looper.java:248)
                                                                                                    	at android.os.Looper.loop(Looper.java:338)
                                                                                                    	at com.facebook.react.bridge.queue.MessageQueueThreadImpl$Companion.startNewBackgroundThread$lambda$0(MessageQueueThreadImpl.kt:152)
                                                                                                    	at com.facebook.react.bridge.queue.MessageQueueThreadImpl$Companion.$r8$lambda$YYXYCFexeoKtAeDpeNYkxZZlpbA(Unknown Source:0)
                                                                                                    	at com.facebook.react.bridge.queue.MessageQueueThreadImpl$Companion$$ExternalSyntheticLambda0.run(D8$$SyntheticClass:0)
                                                                                                    	at java.lang.Thread.run(Thread.java:1119)

```
# Affected code checklist

- [ ] Notifications
- [ ] Outcomes
- [ ] Sessions
- [ ] In-App Messaging
- [ ] REST API requests
- [x] Public API changes

# Checklist

## Overview

- [x] I have filled out all **REQUIRED** sections above
- [x] PR does one thing
- [x] Any Public API changes are explained in the PR details and conform to existing APIs

## Testing

- [x] I have included test coverage for these changes, or explained why they are not needed
- [x] All automated tests pass, or I explained why that is not possible
- [x] I have personally tested this on my device, or explained why that is not possible

## Final pass

- [x] Code is as readable as possible.
- [x] I have reviewed this PR myself, ensuring it meets each checklist item

Made with [Cursor](https://cursor.com)