### PR TITLE
chore: Release 5.5.3

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -17,7 +17,7 @@ def safeFlagGet(envProp, gradleProp) {
     return normalizedValue != null && (normalizedValue.equalsIgnoreCase('true') || normalizedValue == '1')
 }
 
-def oneSignalVersion = '5.9.4'
+def oneSignalVersion = '5.9.5'
 def oneSignalDisableLocation = safeFlagGet('ONESIGNAL_DISABLE_LOCATION', 'onesignal.disableLocation')
 
 android {

--- a/android/src/main/java/com/onesignal/rnonesignalandroid/RNOneSignal.java
+++ b/android/src/main/java/com/onesignal/rnonesignalandroid/RNOneSignal.java
@@ -236,7 +236,7 @@ public class RNOneSignal extends NativeOneSignalSpec
     @Override
     public void initialize(String appId) {
         OneSignalWrapper.setSdkType("reactnative");
-        OneSignalWrapper.setSdkVersion("050502");
+        OneSignalWrapper.setSdkVersion("050503");
 
         if (oneSignalInitDone) {
             Logging.debug("Already initialized the OneSignal React-Native SDK", null);

--- a/ios/RCTOneSignal/RCTOneSignal.mm
+++ b/ios/RCTOneSignal/RCTOneSignal.mm
@@ -23,7 +23,7 @@
     return;
 
   OneSignalWrapper.sdkType = @"reactnative";
-  OneSignalWrapper.sdkVersion = @"050502";
+  OneSignalWrapper.sdkVersion = @"050503";
   // initialize the SDK with a nil app ID so cold start click listeners can be
   // triggered
   [OneSignal initialize:nil withLaunchOptions:launchOptions];

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-native-onesignal",
-  "version": "5.5.2",
+  "version": "5.5.3",
   "description": "React Native OneSignal SDK",
   "keywords": [
     "android",


### PR DESCRIPTION
Channels: Current


### 🛠️ Native Dependency Updates

- Update Android SDK from 5.9.4 to 5.9.5
  - fix(notifications): guard against null PendingResult from goAsync() [SDK-4803] ([#2667](https://github.com/OneSignal/OneSignal-Android-SDK/pull/2667))
  - fix: prevent location permission crashes from FusedLocation API calls ([#2653](https://github.com/OneSignal/OneSignal-Android-SDK/pull/2653))
  - fix: [SDK-4672] start location updates when permission is granted ([#2663](https://github.com/OneSignal/OneSignal-Android-SDK/pull/2663))
  - fix: [SDK-4793] prevent main-thread ANR in blocking SDK APIs during/after init ([#2666](https://github.com/OneSignal/OneSignal-Android-SDK/pull/2666))
  - fix: [SDK-4794] prewarm dispatchers at cold-start entry points ([#2664](https://github.com/OneSignal/OneSignal-Android-SDK/pull/2664))


