### PR TITLE
chore: Release 5.5.7

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -17,7 +17,7 @@ def safeFlagGet(envProp, gradleProp) {
     return normalizedValue != null && (normalizedValue.equalsIgnoreCase('true') || normalizedValue == '1')
 }
 
-def oneSignalVersion = '5.9.8'
+def oneSignalVersion = '5.9.9'
 def oneSignalDisableLocation = safeFlagGet('ONESIGNAL_DISABLE_LOCATION', 'onesignal.disableLocation')
 
 android {

--- a/android/src/main/java/com/onesignal/rnonesignalandroid/RNOneSignal.java
+++ b/android/src/main/java/com/onesignal/rnonesignalandroid/RNOneSignal.java
@@ -236,7 +236,7 @@ public class RNOneSignal extends NativeOneSignalSpec
     @Override
     public void initialize(String appId) {
         OneSignalWrapper.setSdkType("reactnative");
-        OneSignalWrapper.setSdkVersion("050506");
+        OneSignalWrapper.setSdkVersion("050507");
 
         if (oneSignalInitDone) {
             Logging.debug("Already initialized the OneSignal React-Native SDK", null);

--- a/examples/demo/bun.lock
+++ b/examples/demo/bun.lock
@@ -1006,7 +1006,7 @@
 
     "react-native-dotenv": ["react-native-dotenv@3.4.11", "", { "dependencies": { "dotenv": "^16.4.5" }, "peerDependencies": { "@babel/runtime": "^7.20.6" } }, "sha512-6vnIE+WHABSeHCaYP6l3O1BOEhWxKH6nHAdV7n/wKn/sciZ64zPPp2NUdEUf1m7g4uuzlLbjgr+6uDt89q2DOg=="],
 
-    "react-native-onesignal": ["react-native-onesignal@../../react-native-onesignal.tgz", { "dependencies": { "invariant": "^2.2.4" }, "peerDependencies": { "react-native": ">=0.79.0" } }, "sha512-eteqP3QsKjnV9IGAaPINFFBLEVfpYwiYah5cM0uVvro47z67gsm6Hm5x8L/CkzZePojnkbwmpHx5mHU2/CRd7g=="],
+    "react-native-onesignal": ["react-native-onesignal@../../react-native-onesignal.tgz", { "dependencies": { "invariant": "^2.2.4" }, "peerDependencies": { "react-native": ">=0.79.0" } }, "sha512-5pN/I1dsp6CnLpazNGt4Qjkhh+zw0sU2uHp3UyxM8gIzfJKLvi2Avzwzfdh7Ao+0tA4xB9jQ1UBLzZdpg/yRLw=="],
 
     "react-native-safe-area-context": ["react-native-safe-area-context@5.7.0", "", { "peerDependencies": { "react": "*", "react-native": "*" } }, "sha512-/9/MtQz8ODphjsLdZ+GZAIcC/RtoqW9EeShf7Uvnfgm/pzYrJ75y3PV/J1wuAV1T5Dye5ygq4EAW20RoBq0ABQ=="],
 

--- a/examples/demo/ios/Podfile.lock
+++ b/examples/demo/ios/Podfile.lock
@@ -3,9 +3,9 @@ PODS:
   - hermes-engine (250829098.0.7):
     - hermes-engine/Pre-built (= 250829098.0.7)
   - hermes-engine/Pre-built (250829098.0.7)
-  - OneSignalXCFramework (5.5.5):
-    - OneSignalXCFramework/OneSignalComplete (= 5.5.5)
-  - OneSignalXCFramework/OneSignal (5.5.5):
+  - OneSignalXCFramework (5.5.6):
+    - OneSignalXCFramework/OneSignalComplete (= 5.5.6)
+  - OneSignalXCFramework/OneSignal (5.5.6):
     - OneSignalXCFramework/OneSignalCore
     - OneSignalXCFramework/OneSignalExtension
     - OneSignalXCFramework/OneSignalLiveActivities
@@ -13,41 +13,41 @@ PODS:
     - OneSignalXCFramework/OneSignalOSCore
     - OneSignalXCFramework/OneSignalOutcomes
     - OneSignalXCFramework/OneSignalUser
-  - OneSignalXCFramework/OneSignalComplete (5.5.5):
+  - OneSignalXCFramework/OneSignalComplete (5.5.6):
     - OneSignalXCFramework/OneSignal
     - OneSignalXCFramework/OneSignalInAppMessages
     - OneSignalXCFramework/OneSignalLocation
-  - OneSignalXCFramework/OneSignalCore (5.5.5)
-  - OneSignalXCFramework/OneSignalExtension (5.5.5):
+  - OneSignalXCFramework/OneSignalCore (5.5.6)
+  - OneSignalXCFramework/OneSignalExtension (5.5.6):
     - OneSignalXCFramework/OneSignalCore
     - OneSignalXCFramework/OneSignalOSCore
     - OneSignalXCFramework/OneSignalOutcomes
-  - OneSignalXCFramework/OneSignalInAppMessages (5.5.5):
+  - OneSignalXCFramework/OneSignalInAppMessages (5.5.6):
     - OneSignalXCFramework/OneSignalCore
     - OneSignalXCFramework/OneSignalNotifications
     - OneSignalXCFramework/OneSignalOSCore
     - OneSignalXCFramework/OneSignalOutcomes
     - OneSignalXCFramework/OneSignalUser
-  - OneSignalXCFramework/OneSignalLiveActivities (5.5.5):
+  - OneSignalXCFramework/OneSignalLiveActivities (5.5.6):
     - OneSignalXCFramework/OneSignalCore
     - OneSignalXCFramework/OneSignalOSCore
     - OneSignalXCFramework/OneSignalUser
-  - OneSignalXCFramework/OneSignalLocation (5.5.5):
+  - OneSignalXCFramework/OneSignalLocation (5.5.6):
     - OneSignalXCFramework/OneSignalCore
     - OneSignalXCFramework/OneSignalNotifications
     - OneSignalXCFramework/OneSignalOSCore
     - OneSignalXCFramework/OneSignalUser
-  - OneSignalXCFramework/OneSignalNotifications (5.5.5):
+  - OneSignalXCFramework/OneSignalNotifications (5.5.6):
     - OneSignalXCFramework/OneSignalCore
     - OneSignalXCFramework/OneSignalExtension
     - OneSignalXCFramework/OneSignalOSCore
     - OneSignalXCFramework/OneSignalOutcomes
-  - OneSignalXCFramework/OneSignalOSCore (5.5.5):
+  - OneSignalXCFramework/OneSignalOSCore (5.5.6):
     - OneSignalXCFramework/OneSignalCore
-  - OneSignalXCFramework/OneSignalOutcomes (5.5.5):
+  - OneSignalXCFramework/OneSignalOutcomes (5.5.6):
     - OneSignalXCFramework/OneSignalCore
     - OneSignalXCFramework/OneSignalOSCore
-  - OneSignalXCFramework/OneSignalUser (5.5.5):
+  - OneSignalXCFramework/OneSignalUser (5.5.6):
     - OneSignalXCFramework/OneSignalCore
     - OneSignalXCFramework/OneSignalNotifications
     - OneSignalXCFramework/OneSignalOSCore
@@ -1449,9 +1449,9 @@ PODS:
     - React-RCTFBReactNativeSpec
     - ReactCommon/turbomodule/core
     - ReactNativeDependencies
-  - react-native-onesignal (5.5.6):
+  - react-native-onesignal (5.5.7):
     - hermes-engine
-    - OneSignalXCFramework (= 5.5.5)
+    - OneSignalXCFramework (= 5.5.6)
     - RCTRequired
     - RCTTypeSafety
     - React-Core
@@ -2314,8 +2314,8 @@ EXTERNAL SOURCES:
 
 SPEC CHECKSUMS:
   FBLazyVector: c12d2108050e27952983d565a232f6f7b1ad5e69
-  hermes-engine: 177322198264d50dc281084c48e1ed80ea14884c
-  OneSignalXCFramework: 48e5b7c5b51d4e67bab3405229f963efde1a3894
+  hermes-engine: 431876dbea22ba6821b0e999131ecbf5d706c8d2
+  OneSignalXCFramework: 9a0f33eaef7544788a2b04f067e90fe18759fdf9
   RCTDeprecation: 3280799c14232a56e5a44f92981a8ee33bc69fd9
   RCTRequired: 9854a51b0f65ccf43ea0b744df4d70fce339db32
   RCTSwiftUI: 96986e49a4fdc2c2103929dee2641e1b57edf33d
@@ -2324,7 +2324,7 @@ SPEC CHECKSUMS:
   React: 7ef36630d07638043a134a7dd2ec17e0be10fc3c
   React-callinvoker: af4e8fe1d60ab63dd8d74c2a68988064c2848954
   React-Core: c609976c034ba9556bef9850a571a71bd458d73f
-  React-Core-prebuilt: f4df078355bf9605a0d0278aa5c63fcd4b764a1d
+  React-Core-prebuilt: 5e3e0e5fe0a22af7fb36c5b593882da759f395c9
   React-CoreModules: 0ea85f3b3f4b8cbfb3afacd2ed85458fb878517a
   React-cxxreact: 6752bab77c0599d6136e2b8b9b64b4a7d316d401
   React-debug: 38389b86e3570558ec73dd4cbc0cd2f2eec47a51
@@ -2352,7 +2352,7 @@ SPEC CHECKSUMS:
   React-logger: 9e51e01455f15cb3ef87a09a1ec773cdb22d56c1
   React-Mapbuffer: 92b99e450e8ff598b27d6e4db3a75e04fd45e9a9
   React-microtasksnativemodule: 2fe0f2bd2840dedbd66c0ac249c64f977f39cc18
-  react-native-onesignal: 58844456efe0816ef0184d1ef4212c9ed8f3a11e
+  react-native-onesignal: aa3a644f781e6dd21a1127afd33c1c66cb2fcc10
   react-native-safe-area-context: ae7587b95fb580d1800c5b0b2a7bd48c2868e67a
   React-NativeModulesApple: 44a9474594566cd03659f92e38f42599c6b9dee4
   React-networking: db73d91466cb134fcbdaaa579fb2de14e2c2ea01
@@ -2387,7 +2387,7 @@ SPEC CHECKSUMS:
   ReactAppDependencyProvider: 6b7e8d8d974ed13fb66698d82c30c5e70c1f7d3a
   ReactCodegen: c5e5343f6691b0cd76913b9be5e89e5a83ff3315
   ReactCommon: 92b53b0bd7f7d86154dc9f512c1ea5dee717cc72
-  ReactNativeDependencies: eaebe8c9533ec2c41b08a02844af461bfff10540
+  ReactNativeDependencies: f822e1f0812f671d9bfe99225d09dc144fa6f02b
   RNCAsyncStorage: 3a4f5e2777dae1688b781a487923a08569e27fe4
   RNScreens: 6cb648bdad8fe9bee9259fe144df95b6d1d5b707
   RNSVG: c69f7709226108f5eb89b5aa8833c17a36345468
@@ -2396,4 +2396,4 @@ SPEC CHECKSUMS:
 
 PODFILE CHECKSUM: f62fbda480f1d76e1eac7d980b0960570d6cfe89
 
-COCOAPODS: 1.16.2
+COCOAPODS: 1.17.0

--- a/ios/RCTOneSignal/RCTOneSignal.mm
+++ b/ios/RCTOneSignal/RCTOneSignal.mm
@@ -23,7 +23,7 @@
     return;
 
   OneSignalWrapper.sdkType = @"reactnative";
-  OneSignalWrapper.sdkVersion = @"050506";
+  OneSignalWrapper.sdkVersion = @"050507";
   // initialize the SDK with a nil app ID so cold start click listeners can be
   // triggered
   [OneSignal initialize:nil withLaunchOptions:launchOptions];

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-native-onesignal",
-  "version": "5.5.6",
+  "version": "5.5.7",
   "description": "React Native OneSignal SDK",
   "keywords": [
     "android",

--- a/react-native-onesignal.podspec
+++ b/react-native-onesignal.podspec
@@ -1,6 +1,6 @@
 require 'json'
 package_json = JSON.parse(File.read('package.json'))
-onesignal_xcframework_version = '5.5.5'
+onesignal_xcframework_version = '5.5.6'
 onesignal_disable_location_env = ENV['ONESIGNAL_DISABLE_LOCATION'].to_s.strip.downcase
 onesignal_disable_location = ['true', '1'].include?(onesignal_disable_location_env)
 


### PR DESCRIPTION
Channels: Current

### 🛠️ Native Dependency Updates

- Update Android SDK from 5.9.8 to 5.9.9
  - chore(logger): adopt shared KMP logger module via OneSignal-KMP-SDK submodule ([#2687](https://github.com/OneSignal/OneSignal-Android-SDK/pull/2687))
  - chore(logger): gate otel-vs-logger switch on SDK_CUSTOM_LOGGING flag ([#2688](https://github.com/OneSignal/OneSignal-Android-SDK/pull/2688))
  - chore(logger): wire Android FileLogStore for shared KMP legacy purge ([#2691](https://github.com/OneSignal/OneSignal-Android-SDK/pull/2691))
  - chore(logger): log release-diagnostic info at SDK startup ([#2692](https://github.com/OneSignal/OneSignal-Android-SDK/pull/2692))
  - chore: emit Kotlin version on remote log resource attrs ([#2713](https://github.com/OneSignal/OneSignal-Android-SDK/pull/2713))
  - chore: adopt shared KMP feature-flags client and catalog ([#2716](https://github.com/OneSignal/OneSignal-Android-SDK/pull/2716))
  - fix: restrict notification component exports ([#2659](https://github.com/OneSignal/OneSignal-Android-SDK/pull/2659))
  - fix: forward PermissionsActivity theme fix ([#2701](https://github.com/OneSignal/OneSignal-Android-SDK/pull/2701))
  - fix: skip ShortcutBadger on API 26+ to prevent SIGSEGV on Xiaomi devices ([#2570](https://github.com/OneSignal/OneSignal-Android-SDK/pull/2570))
  - fix: destroy IAM WebView on dismiss to stop Activity leaks ([#2706](https://github.com/OneSignal/OneSignal-Android-SDK/pull/2706))
- Update iOS SDK from 5.5.5 to 5.5.6
  - fix: resolve TOCTOU race on the current user ([OneSignal-iOS-SDK#1695](https://github.com/OneSignal/OneSignal-iOS-SDK/pull/1695))
  - fix: lock OSSubscriptionModel state to stop encode crashes ([OneSignal-iOS-SDK#1694](https://github.com/OneSignal/OneSignal-iOS-SDK/pull/1694))
  - refactor: rebuild OperationRepo unmatched delta queue on flush ([OneSignal-iOS-SDK#1693](https://github.com/OneSignal/OneSignal-iOS-SDK/pull/1693))
