### PR TITLE
fix(android): [SDK-5061] use proguard-android-optimize.txt for AGP 9

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -29,7 +29,8 @@ android {
     }
     buildTypes {
         release {
-            proguardFiles getDefaultProguardFile('proguard-android.txt'), 'proguard-rules.pro'
+            // AGP 9 rejects proguard-android.txt because it includes -dontoptimize.
+            proguardFiles getDefaultProguardFile('proguard-android-optimize.txt'), 'proguard-rules.pro'
         }
     }
 

--- a/examples/demo-no-location/android/app/build.gradle
+++ b/examples/demo-no-location/android/app/build.gradle
@@ -103,7 +103,7 @@ android {
             // see https://reactnative.dev/docs/signed-apk-android.
             signingConfig signingConfigs.debug
             minifyEnabled enableProguardInReleaseBuilds
-            proguardFiles getDefaultProguardFile("proguard-android.txt"), "proguard-rules.pro"
+            proguardFiles getDefaultProguardFile("proguard-android-optimize.txt"), "proguard-rules.pro"
         }
     }
 

--- a/examples/demo/android/app/build.gradle
+++ b/examples/demo/android/app/build.gradle
@@ -103,7 +103,7 @@ android {
             // see https://reactnative.dev/docs/signed-apk-android.
             signingConfig signingConfigs.debug
             minifyEnabled enableProguardInReleaseBuilds
-            proguardFiles getDefaultProguardFile("proguard-android.txt"), "proguard-rules.pro"
+            proguardFiles getDefaultProguardFile("proguard-android-optimize.txt"), "proguard-rules.pro"
         }
     }
 


### PR DESCRIPTION
# Description

## One Line Summary

Switch `getDefaultProguardFile` from `proguard-android.txt` to `proguard-android-optimize.txt` so the Android module evaluates under AGP 9 / React Native 0.87.

## Details

### Motivation

Fixes https://github.com/OneSignal/react-native-onesignal/issues/1970 ([SDK-5061](https://linear.app/onesignal/issue/SDK-5061)).

React Native 0.87 is the first RN release that requires Android Gradle Plugin 9. AGP 9 rejects `getDefaultProguardFile('proguard-android.txt')` during **project evaluation** because that default includes `-dontoptimize`, which disables most R8 optimizations. The consumer error is:

```
A problem occurred evaluating project ':react-native-onesignal'.
> `getDefaultProguardFile('proguard-android.txt')` is no longer supported since it includes `-dontoptimize`...
```

This fails before Java/Kotlin compile or minify. The published module (`android/build.gradle`) is what apps evaluate via autolinking; the demo apps are updated so they stay AGP 9-safe as well. The `optimize` default is valid on AGP 8, so RN 0.84 consumers are unchanged.

### Scope

- `android/build.gradle` (published with the npm package)
- example app Gradle files (`examples/demo`, `examples/demo-no-location`)
- No native/JS API changes, no keep-rule changes (`android/proguard-rules.pro` is still empty; the native Android SDK ships its own consumer rules)

# Testing

## Unit testing

No automated test is added, and current CI cannot catch this class of regression.

The failure is AGP 9 **configuration-time**, not minify-time. Our PR CI (`wrapper-js-ci`) runs JS lint/tests plus `examples/demo/android/gradlew spotlessCheck`. That does evaluate `:react-native-onesignal`, but the demo is still React Native **0.84**, which pins AGP **8.12**. AGP 8 still accepts `proguard-android.txt`, so both `spotlessCheck` and e2e `assembleRelease` would stay green on the broken 5.5.7 line.

A true reproduction needs a Gradle evaluation under AGP 9. That means a React Native 0.87 host: `android/build.gradle` applies `com.facebook.react`, so a standalone AGP 9 fixture cannot evaluate the published module without the RN Gradle plugin. Bumping the demo to 0.87 is the real future gate (`gradlew help` / `spotlessCheck` / `assembleRelease` would then fail on the old default). That bump is out of scope here.

A static grep for `getDefaultProguardFile('proguard-android.txt')` would fail closed on this exact string without AGP 9, but it would not prove the rest of the module still evaluates under AGP 9, and it would not have caught a dynamically constructed filename. Until the demo is on RN 0.87, there is no CI job that exercises the actual consumer failure.

## Manual testing

Not run on a RN 0.87 app in this PR. The change is the replacement AGP itself recommends, and it is the same one-line fix used by other AGP 9 library plugins.

# Affected code checklist

- [ ] Notifications
  - [ ] Display
  - [ ] Open
  - [ ] Push Processing
  - [ ] Confirm Deliveries
- [ ] Outcomes
- [ ] Sessions
- [ ] In-App Messaging
- [ ] REST API requests
- [ ] Public API changes

# Checklist

## Overview

- [x] I have filled out all **REQUIRED** sections above
- [x] PR does one thing
- [x] Any Public API changes are explained in the PR details and conform to existing APIs

## Testing

- [x] I have included test coverage for these changes, or explained why they are not needed
- [x] All automated tests pass, or I explained why that is not possible
- [x] I have personally tested this on my device, or explained why that is not possible

## Final pass

- [x] Code is as readable as possible.
- [x] I have reviewed this PR myself, ensuring it meets each checklist item

Made with [Cursor](https://cursor.com)