### PR TITLE
fix(android): avoid blocking foreground delivery and consume display events

### DIFF
--- a/android/src/main/java/com/onesignal/rnonesignalandroid/RNOneSignal.java
+++ b/android/src/main/java/com/onesignal/rnonesignalandroid/RNOneSignal.java
@@ -215,7 +215,6 @@ public class RNOneSignal extends NativeOneSignalSpec
     public void invalidate() {
         removeObservers();
         notificationWillDisplayCache.clear();
-        preventDefaultCache.clear();
         if (currentInstance == this) {
             currentInstance = null;
         }

--- a/android/src/main/java/com/onesignal/rnonesignalandroid/RNOneSignal.java
+++ b/android/src/main/java/com/onesignal/rnonesignalandroid/RNOneSignal.java
@@ -67,6 +67,7 @@ import com.onesignal.user.state.UserChangedState;
 import com.onesignal.user.subscriptions.IPushSubscription;
 import com.onesignal.user.subscriptions.IPushSubscriptionObserver;
 import com.onesignal.user.subscriptions.PushSubscriptionChangedState;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
 import org.json.JSONException;
@@ -82,8 +83,8 @@ public class RNOneSignal extends NativeOneSignalSpec
     private boolean hasSetPushSubscriptionObserver = false;
     private boolean hasSetUserStateObserver = false;
 
-    private final HashMap<String, INotificationWillDisplayEvent> notificationWillDisplayCache = new HashMap<>();
-    private final HashMap<String, INotificationWillDisplayEvent> preventDefaultCache = new HashMap<>();
+    private final Map<String, INotificationWillDisplayEvent> notificationWillDisplayCache =
+            Collections.synchronizedMap(new HashMap<>());
 
     private boolean hasAddedNotificationForegroundListener = false;
     private boolean hasAddedInAppMessageLifecycleListener = false;
@@ -366,6 +367,7 @@ public class RNOneSignal extends NativeOneSignalSpec
     public void onWillDisplay(INotificationWillDisplayEvent event) {
         if (!this.hasAddedNotificationForegroundListener) {
             event.getNotification().display();
+            return;
         }
 
         INotification notification = event.getNotification();
@@ -376,16 +378,6 @@ public class RNOneSignal extends NativeOneSignalSpec
         try {
             emitOnNotificationWillDisplay(
                     RNUtils.convertHashMapToWritableMap(RNUtils.convertNotificationToMap(notification)));
-
-            try {
-                synchronized (event) {
-                    while (preventDefaultCache.containsKey(notificationId)) {
-                        event.wait();
-                    }
-                }
-            } catch (InterruptedException e) {
-                Logging.error("InterruptedException: " + e.toString(), null);
-            }
         } catch (JSONException e) {
             logJSONException("onNotificationWillDisplay", e);
         }
@@ -393,7 +385,7 @@ public class RNOneSignal extends NativeOneSignalSpec
 
     @Override
     public void displayNotification(String notificationId) {
-        INotificationWillDisplayEvent event = notificationWillDisplayCache.get(notificationId);
+        INotificationWillDisplayEvent event = notificationWillDisplayCache.remove(notificationId);
         if (event == null) {
             Logging.error(
                     "Could not find onWillDisplayNotification event for notification with id: " + notificationId, null);
@@ -411,7 +403,6 @@ public class RNOneSignal extends NativeOneSignalSpec
             return;
         }
         event.preventDefault();
-        this.preventDefaultCache.put(notificationId, event);
     }
 
     @Override


### PR DESCRIPTION
# Description

## One Line Summary

Remove the wrapper wait loop and redundant prevention map. The native SDK already supports preventing display and returning before a later explicit display call. Use a synchronized map and atomically consume displayed events. Return immediately after the no-listener default display.

## Compatibility and observable changes

No automatic display timer is added. Explicit suppression stays suppressed, and deferred display remains under application control. Repeated display commands for a consumed event are ignored. Nullable native IDs remain supported. This differs from closed #1887, which proposed timeout-driven automatic display.

## Details

### Motivation

The source audit reproduced the failure paths described below. This PR contains only the associated fix; unrelated audit changes are in separate PRs.

### Scope

- `android/src/main/java/com/onesignal/rnonesignalandroid/RNOneSignal.java`

# Testing

Compiled real Java method bodies with native/bridge doubles exercise the blocked callback, duplicate display, cache release, no-listener path, deferred display, and nullable-ID controls. Checked against the 5.9.9 native SDK interfaces. No live push service or physical device delivery claim.

Each code/tooling fix was also applied independently to upstream commit `a70312207cf094ac361eaa9196c317acb175c2cd` and passed its targeted external actual-source diagnostics. Documentation snippets were checked separately. Native diagnostic harnesses use bridge/SDK doubles and are not an end-to-end push test.

On the combined audit branch:

- Existing SDK suite: 5 files, 262 tests pass; unchanged 95% coverage thresholds pass.
- `vp check`: formatting, lint and type checks pass; native Spotless check passes.
- Both example apps: Android Debug and unsigned iOS Simulator builds pass.
- Both example apps: iOS and Android production Metro bundles pass.

No checked-in test files were added or modified; regression evidence comes from external diagnostic harnesses and the existing suite. No physical-device, live notification delivery, Appium/BrowserStack, or release-workflow execution is claimed. The no-location example's stale native lock was updated locally to resolve the current SDK for verification; generated locks are not part of this PR.

# Checklist

- [x] Required description sections completed.
- [x] Scope and observable/API behavior explained.
- [x] Diff reviewed and targeted regression checks run.
- [x] Automated checks and device-testing limitations documented.
