### PR TITLE
fix(android): tie observer cleanup to the React module lifetime

### DIFF
--- a/android/src/main/java/com/onesignal/rnonesignalandroid/RNOneSignal.java
+++ b/android/src/main/java/com/onesignal/rnonesignalandroid/RNOneSignal.java
@@ -68,7 +68,9 @@ import com.onesignal.user.subscriptions.IPushSubscription;
 import com.onesignal.user.subscriptions.IPushSubscriptionObserver;
 import com.onesignal.user.subscriptions.PushSubscriptionChangedState;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.Map;
+import java.util.Set;
 import org.json.JSONException;
 
 public class RNOneSignal extends NativeOneSignalSpec
@@ -82,8 +84,10 @@ public class RNOneSignal extends NativeOneSignalSpec
     private boolean hasSetPushSubscriptionObserver = false;
     private boolean hasSetUserStateObserver = false;
 
+    private final Object notificationCacheLock = new Object();
     private final HashMap<String, INotificationWillDisplayEvent> notificationWillDisplayCache = new HashMap<>();
     private final HashMap<String, INotificationWillDisplayEvent> preventDefaultCache = new HashMap<>();
+    private boolean invalidated = false;
 
     private boolean hasAddedNotificationForegroundListener = false;
     private boolean hasAddedInAppMessageLifecycleListener = false;
@@ -91,6 +95,7 @@ public class RNOneSignal extends NativeOneSignalSpec
     private boolean hasAddedInAppMessageClickListener = false;
 
     // Static reference to track current instance for cleanup on reload
+    private static final Object currentInstanceLock = new Object();
     private static RNOneSignal currentInstance = null;
 
     private final IInAppMessageClickListener rnInAppClickListener = new IInAppMessageClickListener() {
@@ -199,10 +204,14 @@ public class RNOneSignal extends NativeOneSignalSpec
         super(reactContext);
 
         // Clean up previous instance if it exists (handles reload scenario)
-        if (currentInstance != null && currentInstance != this) {
-            currentInstance.removeObservers();
+        RNOneSignal previousInstance;
+        synchronized (currentInstanceLock) {
+            previousInstance = currentInstance;
+            currentInstance = this;
         }
-        currentInstance = this;
+        if (previousInstance != null && previousInstance != this) {
+            previousInstance.removeObservers();
+        }
     }
 
     @Override
@@ -213,9 +222,25 @@ public class RNOneSignal extends NativeOneSignalSpec
     @Override
     public void invalidate() {
         removeObservers();
-        notificationWillDisplayCache.clear();
-        if (currentInstance == this) {
-            currentInstance = null;
+
+        Set<INotificationWillDisplayEvent> pendingEvents;
+        synchronized (notificationCacheLock) {
+            invalidated = true;
+            pendingEvents = new HashSet<>(notificationWillDisplayCache.values());
+            pendingEvents.addAll(preventDefaultCache.values());
+            notificationWillDisplayCache.clear();
+            preventDefaultCache.clear();
+        }
+        for (INotificationWillDisplayEvent event : pendingEvents) {
+            synchronized (event) {
+                event.notifyAll();
+            }
+        }
+
+        synchronized (currentInstanceLock) {
+            if (currentInstance == this) {
+                currentInstance = null;
+            }
         }
         super.invalidate();
     }
@@ -369,7 +394,17 @@ public class RNOneSignal extends NativeOneSignalSpec
 
         INotification notification = event.getNotification();
         String notificationId = notification.getNotificationId();
-        notificationWillDisplayCache.put(notificationId, event);
+        boolean shouldDisplayImmediately;
+        synchronized (notificationCacheLock) {
+            shouldDisplayImmediately = invalidated;
+            if (!shouldDisplayImmediately) {
+                notificationWillDisplayCache.put(notificationId, event);
+            }
+        }
+        if (shouldDisplayImmediately) {
+            event.getNotification().display();
+            return;
+        }
         event.preventDefault();
 
         try {
@@ -378,7 +413,7 @@ public class RNOneSignal extends NativeOneSignalSpec
 
             try {
                 synchronized (event) {
-                    while (preventDefaultCache.containsKey(notificationId)) {
+                    while (shouldWaitForNotification(notificationId)) {
                         event.wait();
                     }
                 }
@@ -392,25 +427,45 @@ public class RNOneSignal extends NativeOneSignalSpec
 
     @Override
     public void displayNotification(String notificationId) {
-        INotificationWillDisplayEvent event = notificationWillDisplayCache.get(notificationId);
+        INotificationWillDisplayEvent event;
+        synchronized (notificationCacheLock) {
+            event = notificationWillDisplayCache.remove(notificationId);
+            preventDefaultCache.remove(notificationId);
+        }
         if (event == null) {
             Logging.error(
                     "Could not find onWillDisplayNotification event for notification with id: " + notificationId, null);
             return;
         }
         event.getNotification().display();
+        synchronized (event) {
+            event.notifyAll();
+        }
     }
 
     @Override
     public void preventDefault(String notificationId) {
-        INotificationWillDisplayEvent event = notificationWillDisplayCache.get(notificationId);
+        INotificationWillDisplayEvent event;
+        synchronized (notificationCacheLock) {
+            event = notificationWillDisplayCache.get(notificationId);
+        }
         if (event == null) {
             Logging.error(
                     "Could not find onWillDisplayNotification event for notification with id: " + notificationId, null);
             return;
         }
         event.preventDefault();
-        this.preventDefaultCache.put(notificationId, event);
+        synchronized (notificationCacheLock) {
+            if (!invalidated && notificationWillDisplayCache.get(notificationId) == event) {
+                preventDefaultCache.put(notificationId, event);
+            }
+        }
+    }
+
+    private boolean shouldWaitForNotification(String notificationId) {
+        synchronized (notificationCacheLock) {
+            return !invalidated && preventDefaultCache.containsKey(notificationId);
+        }
     }
 
     @Override

--- a/android/src/main/java/com/onesignal/rnonesignalandroid/RNOneSignal.java
+++ b/android/src/main/java/com/onesignal/rnonesignalandroid/RNOneSignal.java
@@ -39,7 +39,6 @@ import android.content.Context;
 import androidx.annotation.Nullable;
 import com.facebook.react.bridge.Arguments;
 import com.facebook.react.bridge.Callback;
-import com.facebook.react.bridge.LifecycleEventListener;
 import com.facebook.react.bridge.Promise;
 import com.facebook.react.bridge.ReactApplicationContext;
 import com.facebook.react.bridge.ReadableArray;
@@ -73,11 +72,7 @@ import java.util.Map;
 import org.json.JSONException;
 
 public class RNOneSignal extends NativeOneSignalSpec
-        implements IPushSubscriptionObserver,
-                IPermissionObserver,
-                IUserStateObserver,
-                LifecycleEventListener,
-                INotificationLifecycleListener {
+        implements IPushSubscriptionObserver, IPermissionObserver, IUserStateObserver, INotificationLifecycleListener {
     public static final String NAME = "OneSignal";
     private static final String LOCATION_MODULE_NOT_AVAILABLE =
             "OneSignal location module is not available. Add the location dependency to use OneSignal.Location.";
@@ -202,7 +197,6 @@ public class RNOneSignal extends NativeOneSignalSpec
 
     public RNOneSignal(ReactApplicationContext reactContext) {
         super(reactContext);
-        reactContext.addLifecycleEventListener(this);
 
         // Clean up previous instance if it exists (handles reload scenario)
         if (currentInstance != null && currentInstance != this) {
@@ -217,19 +211,12 @@ public class RNOneSignal extends NativeOneSignalSpec
     }
 
     @Override
-    public void onHostDestroy() {
-        removeObservers();
-    }
-
-    @Override
-    public void onHostPause() {}
-
-    @Override
-    public void onHostResume() {}
-
-    @Override
     public void invalidate() {
         removeObservers();
+        notificationWillDisplayCache.clear();
+        if (currentInstance == this) {
+            currentInstance = null;
+        }
         super.invalidate();
     }
 

--- a/android/src/main/java/com/onesignal/rnonesignalandroid/RNOneSignal.java
+++ b/android/src/main/java/com/onesignal/rnonesignalandroid/RNOneSignal.java
@@ -68,9 +68,7 @@ import com.onesignal.user.subscriptions.IPushSubscription;
 import com.onesignal.user.subscriptions.IPushSubscriptionObserver;
 import com.onesignal.user.subscriptions.PushSubscriptionChangedState;
 import java.util.HashMap;
-import java.util.HashSet;
 import java.util.Map;
-import java.util.Set;
 import org.json.JSONException;
 
 public class RNOneSignal extends NativeOneSignalSpec
@@ -84,10 +82,8 @@ public class RNOneSignal extends NativeOneSignalSpec
     private boolean hasSetPushSubscriptionObserver = false;
     private boolean hasSetUserStateObserver = false;
 
-    private final Object notificationCacheLock = new Object();
     private final HashMap<String, INotificationWillDisplayEvent> notificationWillDisplayCache = new HashMap<>();
     private final HashMap<String, INotificationWillDisplayEvent> preventDefaultCache = new HashMap<>();
-    private boolean invalidated = false;
 
     private boolean hasAddedNotificationForegroundListener = false;
     private boolean hasAddedInAppMessageLifecycleListener = false;
@@ -95,7 +91,6 @@ public class RNOneSignal extends NativeOneSignalSpec
     private boolean hasAddedInAppMessageClickListener = false;
 
     // Static reference to track current instance for cleanup on reload
-    private static final Object currentInstanceLock = new Object();
     private static RNOneSignal currentInstance = null;
 
     private final IInAppMessageClickListener rnInAppClickListener = new IInAppMessageClickListener() {
@@ -204,14 +199,10 @@ public class RNOneSignal extends NativeOneSignalSpec
         super(reactContext);
 
         // Clean up previous instance if it exists (handles reload scenario)
-        RNOneSignal previousInstance;
-        synchronized (currentInstanceLock) {
-            previousInstance = currentInstance;
-            currentInstance = this;
+        if (currentInstance != null && currentInstance != this) {
+            currentInstance.removeObservers();
         }
-        if (previousInstance != null && previousInstance != this) {
-            previousInstance.removeObservers();
-        }
+        currentInstance = this;
     }
 
     @Override
@@ -222,25 +213,10 @@ public class RNOneSignal extends NativeOneSignalSpec
     @Override
     public void invalidate() {
         removeObservers();
-
-        Set<INotificationWillDisplayEvent> pendingEvents;
-        synchronized (notificationCacheLock) {
-            invalidated = true;
-            pendingEvents = new HashSet<>(notificationWillDisplayCache.values());
-            pendingEvents.addAll(preventDefaultCache.values());
-            notificationWillDisplayCache.clear();
-            preventDefaultCache.clear();
-        }
-        for (INotificationWillDisplayEvent event : pendingEvents) {
-            synchronized (event) {
-                event.notifyAll();
-            }
-        }
-
-        synchronized (currentInstanceLock) {
-            if (currentInstance == this) {
-                currentInstance = null;
-            }
+        notificationWillDisplayCache.clear();
+        preventDefaultCache.clear();
+        if (currentInstance == this) {
+            currentInstance = null;
         }
         super.invalidate();
     }
@@ -394,17 +370,7 @@ public class RNOneSignal extends NativeOneSignalSpec
 
         INotification notification = event.getNotification();
         String notificationId = notification.getNotificationId();
-        boolean shouldDisplayImmediately;
-        synchronized (notificationCacheLock) {
-            shouldDisplayImmediately = invalidated;
-            if (!shouldDisplayImmediately) {
-                notificationWillDisplayCache.put(notificationId, event);
-            }
-        }
-        if (shouldDisplayImmediately) {
-            event.getNotification().display();
-            return;
-        }
+        notificationWillDisplayCache.put(notificationId, event);
         event.preventDefault();
 
         try {
@@ -413,7 +379,7 @@ public class RNOneSignal extends NativeOneSignalSpec
 
             try {
                 synchronized (event) {
-                    while (shouldWaitForNotification(notificationId)) {
+                    while (preventDefaultCache.containsKey(notificationId)) {
                         event.wait();
                     }
                 }
@@ -427,45 +393,25 @@ public class RNOneSignal extends NativeOneSignalSpec
 
     @Override
     public void displayNotification(String notificationId) {
-        INotificationWillDisplayEvent event;
-        synchronized (notificationCacheLock) {
-            event = notificationWillDisplayCache.remove(notificationId);
-            preventDefaultCache.remove(notificationId);
-        }
+        INotificationWillDisplayEvent event = notificationWillDisplayCache.get(notificationId);
         if (event == null) {
             Logging.error(
                     "Could not find onWillDisplayNotification event for notification with id: " + notificationId, null);
             return;
         }
         event.getNotification().display();
-        synchronized (event) {
-            event.notifyAll();
-        }
     }
 
     @Override
     public void preventDefault(String notificationId) {
-        INotificationWillDisplayEvent event;
-        synchronized (notificationCacheLock) {
-            event = notificationWillDisplayCache.get(notificationId);
-        }
+        INotificationWillDisplayEvent event = notificationWillDisplayCache.get(notificationId);
         if (event == null) {
             Logging.error(
                     "Could not find onWillDisplayNotification event for notification with id: " + notificationId, null);
             return;
         }
         event.preventDefault();
-        synchronized (notificationCacheLock) {
-            if (!invalidated && notificationWillDisplayCache.get(notificationId) == event) {
-                preventDefaultCache.put(notificationId, event);
-            }
-        }
-    }
-
-    private boolean shouldWaitForNotification(String notificationId) {
-        synchronized (notificationCacheLock) {
-            return !invalidated && preventDefaultCache.containsKey(notificationId);
-        }
+        this.preventDefaultCache.put(notificationId, event);
     }
 
     @Override


### PR DESCRIPTION
# Description

## One Line Summary

Remove the activity lifecycle listener, whose destroy callback removed observers even while the React instance remained usable. Keep cleanup in invalidate and release retained notification events and the current static instance there.

## Compatibility and observable changes

Observers remain available across host activity recreation until module invalidation. Invalidating an old module does not clear a newer current instance. No JS API changes.

## Details

### Motivation

The source audit reproduced the failure paths described below. This PR contains only the associated fix; unrelated audit changes are in separate PRs.

### Scope

- `android/src/main/java/com/onesignal/rnonesignalandroid/RNOneSignal.java`

# Testing

Compiled actual constructor/invalidate methods and activity lifecycle reproduction; checked ReactContext and LifecycleEventListener source to distinguish activity destruction from React instance invalidation.

Each code/tooling fix was also applied independently to upstream commit `a70312207cf094ac361eaa9196c317acb175c2cd` and passed its targeted external actual-source diagnostics. Documentation snippets were checked separately. Native diagnostic harnesses use bridge/SDK doubles and are not an end-to-end push test.

On the combined audit branch:

- Existing SDK suite: 5 files, 262 tests pass; unchanged 95% coverage thresholds pass.
- `vp check`: formatting, lint and type checks pass; native Spotless check passes.
- Both example apps: Android Debug and unsigned iOS Simulator builds pass.
- Both example apps: iOS and Android production Metro bundles pass.

No checked-in test files were added or modified; regression evidence comes from external diagnostic harnesses and the existing suite. No physical-device, live notification delivery, Appium/BrowserStack, or release-workflow execution is claimed. The no-location example's stale native lock was updated locally to resolve the current SDK for verification; generated locks are not part of this PR.

# Checklist

- [x] Required description sections completed.
- [x] Scope and observable/API behavior explained.
- [x] Diff reviewed and targeted regression checks run.
- [x] Automated checks and device-testing limitations documented.
