### PR TITLE
fix(ios): synchronize foreground notification cache access

### DIFF
--- a/ios/RCTOneSignal/RCTOneSignalEventEmitter.mm
+++ b/ios/RCTOneSignal/RCTOneSignalEventEmitter.mm
@@ -52,7 +52,6 @@ static id OSDecodeNullSentinels(id value) {
   BOOL _hasAddedNotificationForegroundLifecycleListener;
   BOOL _hasAddedInAppMessageClickListener;
   BOOL _hasAddedInAppMessageLifecycleListener;
-  NSMutableDictionary *_preventDefaultCache;
   NSMutableDictionary *_notificationWillDisplayCache;
 }
 
@@ -66,7 +65,6 @@ RCT_EXPORT_MODULE(OneSignal)
 
 - (instancetype)init {
   if (self = [super init]) {
-    _preventDefaultCache = [NSMutableDictionary new];
     _notificationWillDisplayCache = [NSMutableDictionary new];
 
     // Clean up previous instance if it exists (handles reload scenario)
@@ -83,8 +81,9 @@ RCT_EXPORT_MODULE(OneSignal)
 - (void)invalidate {
   [self removeHandlers];
   [self removeObservers];
-  [_preventDefaultCache removeAllObjects];
-  [_notificationWillDisplayCache removeAllObjects];
+  @synchronized(_notificationWillDisplayCache) {
+    [_notificationWillDisplayCache removeAllObjects];
+  }
   if (_currentInstance == self) {
     _currentInstance = nil;
   }
@@ -396,7 +395,9 @@ RCT_EXPORT_METHOD(addNotificationForegroundLifecycleListener) {
 }
 
 - (void)onWillDisplayNotification:(OSNotificationWillDisplayEvent *)event {
-  _notificationWillDisplayCache[event.notification.notificationId] = event;
+  @synchronized(_notificationWillDisplayCache) {
+    _notificationWillDisplayCache[event.notification.notificationId] = event;
+  }
   [event preventDefault];
   [RCTOneSignalEventEmitter
       sendEventWithName:@"OneSignal-notificationWillDisplayInForeground"
@@ -404,8 +405,10 @@ RCT_EXPORT_METHOD(addNotificationForegroundLifecycleListener) {
 }
 
 RCT_EXPORT_METHOD(preventDefault : (NSString *)notificationId) {
-  OSNotificationWillDisplayEvent *event =
-      _notificationWillDisplayCache[notificationId];
+  OSNotificationWillDisplayEvent *event;
+  @synchronized(_notificationWillDisplayCache) {
+    event = _notificationWillDisplayCache[notificationId];
+  }
   if (!event) {
     [OneSignalLog
         onesignalLog:ONE_S_LL_ERROR
@@ -416,7 +419,6 @@ RCT_EXPORT_METHOD(preventDefault : (NSString *)notificationId) {
                              notificationId]];
     return;
   }
-  _preventDefaultCache[event.notification.notificationId] = event;
   [event preventDefault];
 }
 
@@ -579,8 +581,11 @@ RCT_EXPORT_METHOD(optIn) { [OneSignal.User.pushSubscription optIn]; }
 RCT_EXPORT_METHOD(optOut) { [OneSignal.User.pushSubscription optOut]; }
 
 RCT_EXPORT_METHOD(displayNotification : (NSString *)notificationId) {
-  OSNotificationWillDisplayEvent *event =
-      _notificationWillDisplayCache[notificationId];
+  OSNotificationWillDisplayEvent *event;
+  @synchronized(_notificationWillDisplayCache) {
+    event = _notificationWillDisplayCache[notificationId];
+    [_notificationWillDisplayCache removeObjectForKey:notificationId];
+  }
   if (!event) {
     [OneSignalLog
         onesignalLog:ONE_S_LL_ERROR
@@ -594,9 +599,6 @@ RCT_EXPORT_METHOD(displayNotification : (NSString *)notificationId) {
   dispatch_async(dispatch_get_main_queue(), ^{
     [event.notification display];
   });
-
-  [_preventDefaultCache removeObjectForKey:notificationId];
-  [_notificationWillDisplayCache removeObjectForKey:notificationId];
 }
 
 - (void)removeObservers {


### PR DESCRIPTION
# Description

## One Line Summary

Synchronize dictionary insertion, lookup, consumption and invalidation across native delivery callbacks and React module calls. Consume before scheduling display, keep SDK/display calls outside the lock, and remove the unused prevention dictionary.

## Compatibility and observable changes

No automatic timeout or display policy change. Suppressed notifications remain deferred; explicit display still runs on the main queue. No public signature or native dependency changes.

## Details

### Motivation

The source audit reproduced the failure paths described below. This PR contains only the associated fix; unrelated audit changes are in separate PRs.

### Scope

- `ios/RCTOneSignal/RCTOneSignalEventEmitter.mm`

# Testing

Six compiled Objective-C/Foundation cases using actual method bodies and an instrumented dictionary; three reproduce overlapping baseline accesses. Native SDK 5.5.6 forwards delivery directly from the notification callback, while React uses a separate module method queue. Device end-to-end push delivery is not claimed.

Each code/tooling fix was also applied independently to upstream commit `a70312207cf094ac361eaa9196c317acb175c2cd` and passed its targeted external actual-source diagnostics. Documentation snippets were checked separately. Native diagnostic harnesses use bridge/SDK doubles and are not an end-to-end push test.

On the combined audit branch:

- Existing SDK suite: 5 files, 262 tests pass; unchanged 95% coverage thresholds pass.
- `vp check`: formatting, lint and type checks pass; native Spotless check passes.
- Both example apps: Android Debug and unsigned iOS Simulator builds pass.
- Both example apps: iOS and Android production Metro bundles pass.

No checked-in test files were added or modified; regression evidence comes from external diagnostic harnesses and the existing suite. No physical-device, live notification delivery, Appium/BrowserStack, or release-workflow execution is claimed. The no-location example's stale native lock was updated locally to resolve the current SDK for verification; generated locks are not part of this PR.

# Checklist

- [x] Required description sections completed.
- [x] Scope and observable/API behavior explained.
- [x] Diff reviewed and targeted regression checks run.
- [x] Automated checks and device-testing limitations documented.
