### PR TITLE
fix(example): prevent stale initialization and user state updates

### DIFF
--- a/examples/demo/src/hooks/useOneSignal.ts
+++ b/examples/demo/src/hooks/useOneSignal.ts
@@ -164,10 +164,10 @@ function useOneSignalState(): UseOneSignalReturn {
   }, []);
 
   useEffect(() => {
-    let active = true;
-    let pushVersion = 0;
-    let permissionVersion = 0;
-    let userVersion = 0;
+    let cancelled = false;
+    let pushChanged = false;
+    let permissionChanged = false;
+    let userChanged = false;
 
     const handleIamWillDisplay = (e: InAppMessageWillDisplayEvent) => {
       console.log(`IAM willDisplay: ${e.message.messageId}`);
@@ -199,18 +199,18 @@ function useOneSignalState(): UseOneSignalReturn {
     };
 
     const pushSubHandler = (event: PushSubscriptionChangedState) => {
-      pushVersion++;
+      pushChanged = true;
       setPushSubscriptionId(event.current.id ?? undefined);
       setIsPushEnabled(event.current.optedIn);
     };
 
     const permissionHandler = (granted: boolean) => {
-      permissionVersion++;
+      permissionChanged = true;
       setHasNotificationPermission(granted);
     };
 
     const userChangeHandler = (event: UserChangedState) => {
-      userVersion++;
+      userChanged = true;
       requestSequenceRef.current++;
       const nextOnesignalId = event.current.onesignalId ?? null;
       console.log(
@@ -238,7 +238,7 @@ function useOneSignalState(): UseOneSignalReturn {
           preferences.getLocationShared(),
         ]);
       const storedExternalUserId = (await preferences.getExternalUserId()) ?? undefined;
-      if (!active) return;
+      if (cancelled) return;
 
       apiService.setAppId(nextAppId);
 
@@ -276,9 +276,6 @@ function useOneSignalState(): UseOneSignalReturn {
 
       console.log(`OneSignal initialized with app ID: ${nextAppId}`);
 
-      const initialPushVersion = pushVersion;
-      const initialPermissionVersion = permissionVersion;
-      const initialUserVersion = userVersion;
       const [externalId, initialOnesignalId, pushId, pushOptedIn, hasPerm] = await Promise.all([
         OneSignal.User.getExternalId(),
         OneSignal.User.getOnesignalId(),
@@ -286,21 +283,21 @@ function useOneSignalState(): UseOneSignalReturn {
         OneSignal.User.pushSubscription.getOptedInAsync(),
         OneSignal.Notifications.getPermissionAsync(),
       ]);
-      if (!active) return;
+      if (cancelled) return;
 
       setAppId(nextAppId);
       setConsentRequiredState(nextConsentRequired);
       setPrivacyConsentGivenState(nextPrivacyConsentGiven);
       setInAppMessagesPaused(nextIamPaused);
       setLocationSharedState(nextLocationShared);
-      if (initialPushVersion === pushVersion) {
+      if (!pushChanged) {
         setPushSubscriptionId(pushId ?? undefined);
         setIsPushEnabled(pushOptedIn);
       }
-      if (initialPermissionVersion === permissionVersion) setHasNotificationPermission(hasPerm);
+      if (!permissionChanged) setHasNotificationPermission(hasPerm);
       setIsReady(true);
 
-      if (initialUserVersion === userVersion) {
+      if (!userChanged) {
         setExternalUserId(externalId ?? storedExternalUserId);
         setOneSignalId(initialOnesignalId ?? undefined);
         if (initialOnesignalId) await fetchUserDataFromApi();
@@ -308,13 +305,13 @@ function useOneSignalState(): UseOneSignalReturn {
     };
 
     void load().catch((err) => {
-      if (!active) return;
+      if (cancelled) return;
       console.error(`Initial load error: ${String(err)}`);
       setIsLoading(false);
     });
 
     return () => {
-      active = false;
+      cancelled = true;
       requestSequenceRef.current++;
       OneSignal.InAppMessages.removeEventListener('willDisplay', handleIamWillDisplay);
       OneSignal.InAppMessages.removeEventListener('didDisplay', handleIamDidDisplay);

--- a/examples/demo/src/hooks/useOneSignal.ts
+++ b/examples/demo/src/hooks/useOneSignal.ts
@@ -19,6 +19,7 @@ import {
   type InAppMessageWillDisplayEvent,
   type NotificationClickEvent,
   type NotificationWillDisplayEvent,
+  type PushSubscriptionChangedState,
   type UserChangedState,
 } from 'react-native-onesignal';
 
@@ -139,10 +140,10 @@ function useOneSignalState(): UseOneSignalReturn {
 
     try {
       const onesignalId = await OneSignal.User.getOnesignalId();
-      if (!onesignalId) return;
+      if (!onesignalId || requestSequenceRef.current !== requestId) return;
 
       const userData = await apiService.fetchUser(onesignalId);
-      if (!userData) return;
+      if (!userData || requestSequenceRef.current !== requestId) return;
 
       const externalId = await OneSignal.User.getExternalId();
 
@@ -153,6 +154,8 @@ function useOneSignalState(): UseOneSignalReturn {
       setEmailsList((prev) => mergeUnique(prev, userData.emails));
       setSmsNumbersList((prev) => mergeUnique(prev, userData.smsNumbers));
       setExternalUserId(externalId ?? userData.externalId);
+    } catch (err) {
+      console.error(`Fetch user error: ${String(err)}`);
     } finally {
       if (requestSequenceRef.current === requestId) {
         setIsLoading(false);
@@ -161,6 +164,11 @@ function useOneSignalState(): UseOneSignalReturn {
   }, []);
 
   useEffect(() => {
+    let active = true;
+    let pushVersion = 0;
+    let permissionVersion = 0;
+    let userVersion = 0;
+
     const handleIamWillDisplay = (e: InAppMessageWillDisplayEvent) => {
       console.log(`IAM willDisplay: ${e.message.messageId}`);
     };
@@ -190,28 +198,30 @@ function useOneSignalState(): UseOneSignalReturn {
       e.getNotification().display();
     };
 
-    const pushSubHandler = async () => {
-      const [id, optedIn] = await Promise.all([
-        OneSignal.User.pushSubscription.getIdAsync(),
-        OneSignal.User.pushSubscription.getOptedInAsync(),
-      ]);
-      setPushSubscriptionId(id ?? undefined);
-      setIsPushEnabled(optedIn);
+    const pushSubHandler = (event: PushSubscriptionChangedState) => {
+      pushVersion++;
+      setPushSubscriptionId(event.current.id ?? undefined);
+      setIsPushEnabled(event.current.optedIn);
     };
 
     const permissionHandler = (granted: boolean) => {
+      permissionVersion++;
       setHasNotificationPermission(granted);
     };
 
     const userChangeHandler = (event: UserChangedState) => {
+      userVersion++;
+      requestSequenceRef.current++;
       const nextOnesignalId = event.current.onesignalId ?? null;
       console.log(
         `User changed: onesignalId=${nextOnesignalId ?? 'null'}, externalId=${event.current.externalId ?? 'null'}`,
       );
 
       setOneSignalId(nextOnesignalId ?? undefined);
+      setExternalUserId(event.current.externalId ?? undefined);
 
       if (nextOnesignalId === null) {
+        setIsLoading(false);
         return;
       }
 
@@ -228,6 +238,7 @@ function useOneSignalState(): UseOneSignalReturn {
           preferences.getLocationShared(),
         ]);
       const storedExternalUserId = (await preferences.getExternalUserId()) ?? undefined;
+      if (!active) return;
 
       apiService.setAppId(nextAppId);
 
@@ -265,37 +276,46 @@ function useOneSignalState(): UseOneSignalReturn {
 
       console.log(`OneSignal initialized with app ID: ${nextAppId}`);
 
-      const externalId = await OneSignal.User.getExternalId();
-      const [pushId, pushOptedIn, hasPerm] = await Promise.all([
+      const initialPushVersion = pushVersion;
+      const initialPermissionVersion = permissionVersion;
+      const initialUserVersion = userVersion;
+      const [externalId, initialOnesignalId, pushId, pushOptedIn, hasPerm] = await Promise.all([
+        OneSignal.User.getExternalId(),
+        OneSignal.User.getOnesignalId(),
         OneSignal.User.pushSubscription.getIdAsync(),
         OneSignal.User.pushSubscription.getOptedInAsync(),
         OneSignal.Notifications.getPermissionAsync(),
       ]);
+      if (!active) return;
 
       setAppId(nextAppId);
       setConsentRequiredState(nextConsentRequired);
       setPrivacyConsentGivenState(nextPrivacyConsentGiven);
       setInAppMessagesPaused(nextIamPaused);
       setLocationSharedState(nextLocationShared);
-      setExternalUserId(externalId ?? storedExternalUserId);
-      setPushSubscriptionId(pushId ?? undefined);
-      setIsPushEnabled(pushOptedIn);
-      setHasNotificationPermission(hasPerm);
+      if (initialPushVersion === pushVersion) {
+        setPushSubscriptionId(pushId ?? undefined);
+        setIsPushEnabled(pushOptedIn);
+      }
+      if (initialPermissionVersion === permissionVersion) setHasNotificationPermission(hasPerm);
       setIsReady(true);
 
-      const initialOnesignalId = await OneSignal.User.getOnesignalId();
-      setOneSignalId(initialOnesignalId ?? undefined);
-      if (initialOnesignalId) {
-        await fetchUserDataFromApi();
+      if (initialUserVersion === userVersion) {
+        setExternalUserId(externalId ?? storedExternalUserId);
+        setOneSignalId(initialOnesignalId ?? undefined);
+        if (initialOnesignalId) await fetchUserDataFromApi();
       }
     };
 
     void load().catch((err) => {
+      if (!active) return;
       console.error(`Initial load error: ${String(err)}`);
       setIsLoading(false);
     });
 
     return () => {
+      active = false;
+      requestSequenceRef.current++;
       OneSignal.InAppMessages.removeEventListener('willDisplay', handleIamWillDisplay);
       OneSignal.InAppMessages.removeEventListener('didDisplay', handleIamDidDisplay);
       OneSignal.InAppMessages.removeEventListener('willDismiss', handleIamWillDismiss);
@@ -313,6 +333,7 @@ function useOneSignalState(): UseOneSignalReturn {
   }, [fetchUserDataFromApi]);
 
   const loginUser = async (nextExternalUserId: string) => {
+    requestSequenceRef.current++;
     setAliasesList([]);
     setEmailsList([]);
     setSmsNumbersList([]);
@@ -334,6 +355,8 @@ function useOneSignalState(): UseOneSignalReturn {
   };
 
   const logoutUser = async () => {
+    requestSequenceRef.current++;
+    setIsLoading(false);
     OneSignal.logout();
     await preferences.setExternalUserId(null);
     setExternalUserId(undefined);


### PR DESCRIPTION
# Description

## One Line Summary

Cancel late initialization after effect cleanup, invalidate pending user fetches on logout/login/user changes, handle fetch errors, use push event snapshots directly, and protect startup values from newer events.

## Compatibility and observable changes

Example only. Removed providers no longer attach listeners, old users do not repopulate lists after logout, and live permission/subscription events win over stale startup reads. SDK public APIs are unchanged.

## Details

### Motivation

The source audit reproduced the failure paths described below. This PR contains only the associated fix; unrelated audit changes are in separate PRs.

### Scope

- `examples/demo/src/hooks/useOneSignal.ts`

# Testing

Actual example hook rendered with React test renderer and deferred preference/native/API doubles. Reproductions cover unmount-before-load, logout/null-user races, push event values and stale startup snapshots. No network requests are sent.

Each code/tooling fix was also applied independently to upstream commit `a70312207cf094ac361eaa9196c317acb175c2cd` and passed its targeted external actual-source diagnostics. Documentation snippets were checked separately. Native diagnostic harnesses use bridge/SDK doubles and are not an end-to-end push test.

On the combined audit branch:

- Existing SDK suite: 5 files, 262 tests pass; unchanged 95% coverage thresholds pass.
- `vp check`: formatting, lint and type checks pass; native Spotless check passes.
- Both example apps: Android Debug and unsigned iOS Simulator builds pass.
- Both example apps: iOS and Android production Metro bundles pass.

No checked-in test files were added or modified; regression evidence comes from external diagnostic harnesses and the existing suite. No physical-device, live notification delivery, Appium/BrowserStack, or release-workflow execution is claimed. The no-location example's stale native lock was updated locally to resolve the current SDK for verification; generated locks are not part of this PR.

# Checklist

- [x] Required description sections completed.
- [x] Scope and observable/API behavior explained.
- [x] Diff reviewed and targeted regression checks run.
- [x] Automated checks and device-testing limitations documented.
