### PR TITLE
chore(example): share tooltip requests and allow retries after failure

### DIFF
--- a/examples/demo/src/services/TooltipHelper.ts
+++ b/examples/demo/src/services/TooltipHelper.ts
@@ -16,6 +16,7 @@ class TooltipHelper {
   private static _instance: TooltipHelper;
   private tooltips: Record<string, TooltipData> = {};
   private initialized = false;
+  private initialization?: Promise<void>;
 
   static getInstance(): TooltipHelper {
     if (!TooltipHelper._instance) {
@@ -24,20 +25,25 @@ class TooltipHelper {
     return TooltipHelper._instance;
   }
 
-  async init(): Promise<void> {
+  init(): Promise<void> {
     if (this.initialized) {
-      return;
+      return Promise.resolve();
     }
-    try {
-      const response = await fetch(TOOLTIP_URL);
-      if (response.ok) {
-        const json = await response.json();
-        this.tooltips = json as Record<string, TooltipData>;
-      }
-    } catch {
-      // Tooltips are non-critical; silently ignore failures
+    if (!this.initialization) {
+      this.initialization = (async () => {
+        try {
+          const response = await fetch(TOOLTIP_URL);
+          if (!response.ok) return;
+          this.tooltips = (await response.json()) as Record<string, TooltipData>;
+          this.initialized = true;
+        } catch {
+          // Tooltips are non-critical; silently ignore failures and allow a retry.
+        }
+      })().finally(() => {
+        this.initialization = undefined;
+      });
     }
-    this.initialized = true;
+    return this.initialization;
   }
 
   getTooltip(key: string): TooltipData | undefined {


### PR DESCRIPTION
# Description

## One Line Summary

Share one in-flight request, mark initialization complete only after a successful response, and clear the pending promise on every exit.

## Compatibility and observable changes

Example only. A later init call can retry failed loading; successful results remain cached. Failures remain non-fatal and no automatic retry timer is introduced.

## Details

### Motivation

The source audit reproduced the failure paths described below. This PR contains only the associated fix; unrelated audit changes are in separate PRs.

### Scope

- `examples/demo/src/services/TooltipHelper.ts`

# Testing

Deferred/mock fetch diagnostics verify concurrent request deduplication, retry after HTTP failure, and cached success.

Each code/tooling fix was also applied independently to upstream commit `a70312207cf094ac361eaa9196c317acb175c2cd` and passed its targeted external actual-source diagnostics. Documentation snippets were checked separately. Native diagnostic harnesses use bridge/SDK doubles and are not an end-to-end push test.

On the combined audit branch:

- Existing SDK suite: 5 files, 262 tests pass; unchanged 95% coverage thresholds pass.
- `vp check`: formatting, lint and type checks pass; native Spotless check passes.
- Both example apps: Android Debug and unsigned iOS Simulator builds pass.
- Both example apps: iOS and Android production Metro bundles pass.

No checked-in test files were added or modified; regression evidence comes from external diagnostic harnesses and the existing suite. No physical-device, live notification delivery, Appium/BrowserStack, or release-workflow execution is claimed. The no-location example's stale native lock was updated locally to resolve the current SDK for verification; generated locks are not part of this PR.

# Checklist

- [x] Required description sections completed.
- [x] Scope and observable/API behavior explained.
- [x] Diff reviewed and targeted regression checks run.
- [x] Automated checks and device-testing limitations documented.
