### PR TITLE
chore(example): clean icon-generation temporary files on failure

### DIFF
--- a/examples/generate-icons.ts
+++ b/examples/generate-icons.ts
@@ -84,8 +84,8 @@ try pngData.write(to: URL(fileURLWithPath: outputPath))
 
   const tempDir = mkdtempSync(join(tmpdir(), 'onesignal-icon-'));
   const swiftFile = join(tempDir, 'flatten.swift');
-  writeFileSync(swiftFile, swift);
   try {
+    writeFileSync(swiftFile, swift);
     execFileSync('swift', [swiftFile, src, dest], { stdio: 'ignore' });
   } finally {
     rmSync(tempDir, { recursive: true, force: true });
@@ -211,9 +211,9 @@ async function generateIos(): Promise<void> {
   console.log('Generating iOS icons...');
   const tempDir = mkdtempSync(join(tmpdir(), 'onesignal-ios-icon-'));
   const iosSource = join(tempDir, 'ios-source-white.png');
-  await flattenToWhiteBackground(source, iosSource);
-  await writeIosContents();
   try {
+    await flattenToWhiteBackground(source, iosSource);
+    await writeIosContents();
     for (const { filename, pixels } of IOS_ICONS) {
       await resize(iosSource, join(IOS_APPICONSET, filename), pixels);
       console.log(`  ${filename}: ${pixels}x${pixels}`);


### PR DESCRIPTION
# Description

## One Line Summary

Place script creation and all iOS conversion/metadata steps inside their existing try/finally cleanup boundaries.

## Compatibility and observable changes

No generated asset, output format or success-path behavior changes. Temporary directories are also removed when earlier preparation steps fail.

## Details

### Motivation

The source audit reproduced the failure paths described below. This PR contains only the associated fix; unrelated audit changes are in separate PRs.

### Scope

- `examples/generate-icons.ts`

# Testing

Three actual-function failure-injection diagnostics reproduce leaked temporary directories before the fix and pass afterwards. No repository image assets were regenerated.

Each code/tooling fix was also applied independently to upstream commit `a70312207cf094ac361eaa9196c317acb175c2cd` and passed its targeted external actual-source diagnostics. Documentation snippets were checked separately. Native diagnostic harnesses use bridge/SDK doubles and are not an end-to-end push test.

On the combined audit branch:

- Existing SDK suite: 5 files, 262 tests pass; unchanged 95% coverage thresholds pass.
- `vp check`: formatting, lint and type checks pass; native Spotless check passes.
- Both example apps: Android Debug and unsigned iOS Simulator builds pass.
- Both example apps: iOS and Android production Metro bundles pass.

No checked-in test files were added or modified; regression evidence comes from external diagnostic harnesses and the existing suite. No physical-device, live notification delivery, Appium/BrowserStack, or release-workflow execution is claimed. The no-location example's stale native lock was updated locally to resolve the current SDK for verification; generated locks are not part of this PR.

# Checklist

- [x] Required description sections completed.
- [x] Scope and observable/API behavior explained.
- [x] Diff reviewed and targeted regression checks run.
- [x] Automated checks and device-testing limitations documented.
