### PR TITLE
fix(ci): prepare releases from the requested target branch

### DIFF
--- a/.github/workflows/create-release-pr.yml
+++ b/.github/workflows/create-release-pr.yml
@@ -75,6 +75,7 @@ jobs:
     with:
       target_repo: OneSignal/react-native-onesignal
       version: ${{ needs.determine_version.outputs.rn_version }}
+      target_branch: ${{ inputs.target_branch }}
 
   # React Native specific steps
   update_version:


### PR DESCRIPTION
# Description

## One Line Summary

Forward target_branch into the shared release preparation workflow instead of silently using its main default.

## Compatibility and observable changes

Release tooling only. Releases requested against a maintenance branch now start from that branch, matching the target used by later version reads and PR creation. Default main behavior is unchanged.

## Details

### Motivation

The source audit reproduced the failure paths described below. This PR contains only the associated fix; unrelated audit changes are in separate PRs.

### Scope

- `.github/workflows/create-release-pr.yml`

# Testing

Parsed the caller workflow and checked the current shared prep-release.yml contract. Baseline omits the field; fixed configuration forwards the requested input. No release workflow was dispatched.

Each code/tooling fix was also applied independently to upstream commit `a70312207cf094ac361eaa9196c317acb175c2cd` and passed its targeted external actual-source diagnostics. Documentation snippets were checked separately. Native diagnostic harnesses use bridge/SDK doubles and are not an end-to-end push test.

On the combined audit branch:

- Existing SDK suite: 5 files, 262 tests pass; unchanged 95% coverage thresholds pass.
- `vp check`: formatting, lint and type checks pass; native Spotless check passes.
- Both example apps: Android Debug and unsigned iOS Simulator builds pass.
- Both example apps: iOS and Android production Metro bundles pass.

No checked-in test files were added or modified; regression evidence comes from external diagnostic harnesses and the existing suite. No physical-device, live notification delivery, Appium/BrowserStack, or release-workflow execution is claimed. The no-location example's stale native lock was updated locally to resolve the current SDK for verification; generated locks are not part of this PR.

# Checklist

- [x] Required description sections completed.
- [x] Scope and observable/API behavior explained.
- [x] Diff reviewed and targeted regression checks run.
- [x] Automated checks and device-testing limitations documented.
