### PR TITLE
fix: [SDK-5139] display foreground notifications by default

### DIFF
--- a/MIGRATION_GUIDE.md
+++ b/MIGRATION_GUIDE.md
@@ -329,6 +329,10 @@ OneSignal.Notifications.removeEventListener('permissionChange', permissionObserv
 
 ### Notification Lifecycle Listener
 
+Foreground notifications display automatically unless `preventDefault()` is called synchronously
+inside the listener. To delay display for asynchronous work, call `preventDefault()` first, then call
+`display()` within about 25 seconds.
+
 ```typescript
 OneSignal.Notifications.addEventListener(
   'foregroundWillDisplay',

--- a/examples/build.md
+++ b/examples/build.md
@@ -216,7 +216,7 @@ OneSignal.User.addEventListener('change', handler);
 
 ### Foreground notification handler
 
-- `foregroundWillDisplay` calls `e.getNotification().display()` inside `useOneSignal.ts` so foreground pushes are still shown by the OS UI.
+- `foregroundWillDisplay` logs the notification; foreground pushes display automatically unless the handler calls `preventDefault()`.
 
 ---
 

--- a/examples/demo/bun.lock
+++ b/examples/demo/bun.lock
@@ -1006,7 +1006,7 @@
 
     "react-native-dotenv": ["react-native-dotenv@3.4.11", "", { "dependencies": { "dotenv": "^16.4.5" }, "peerDependencies": { "@babel/runtime": "^7.20.6" } }, "sha512-6vnIE+WHABSeHCaYP6l3O1BOEhWxKH6nHAdV7n/wKn/sciZ64zPPp2NUdEUf1m7g4uuzlLbjgr+6uDt89q2DOg=="],
 
-    "react-native-onesignal": ["react-native-onesignal@../../react-native-onesignal.tgz", { "dependencies": { "invariant": "^2.2.4" }, "peerDependencies": { "react-native": ">=0.79.0" } }, "sha512-n27/13rn/viQCldBWaxetgH7r7MfbxPhPX4HmLVXE2mVcvEjaFfhLEKf5Jn0YbFltNStubuMOceKji1mmGGHWw=="],
+    "react-native-onesignal": ["react-native-onesignal@../../react-native-onesignal.tgz", { "dependencies": { "invariant": "^2.2.4" }, "peerDependencies": { "react-native": ">=0.79.0" } }, "sha512-qA4hsVlrUxAkCc3v96ONehYfE9meBMZl8Ydlc0inV86IX60beTLf1wdXxs21T8s6jnPh7OBwLmtwwU/vUYV68Q=="],
 
     "react-native-safe-area-context": ["react-native-safe-area-context@5.7.0", "", { "peerDependencies": { "react": "*", "react-native": "*" } }, "sha512-/9/MtQz8ODphjsLdZ+GZAIcC/RtoqW9EeShf7Uvnfgm/pzYrJ75y3PV/J1wuAV1T5Dye5ygq4EAW20RoBq0ABQ=="],
 

--- a/examples/demo/bun.lock
+++ b/examples/demo/bun.lock
@@ -1006,7 +1006,7 @@
 
     "react-native-dotenv": ["react-native-dotenv@3.4.11", "", { "dependencies": { "dotenv": "^16.4.5" }, "peerDependencies": { "@babel/runtime": "^7.20.6" } }, "sha512-6vnIE+WHABSeHCaYP6l3O1BOEhWxKH6nHAdV7n/wKn/sciZ64zPPp2NUdEUf1m7g4uuzlLbjgr+6uDt89q2DOg=="],
 
-    "react-native-onesignal": ["react-native-onesignal@../../react-native-onesignal.tgz", { "dependencies": { "invariant": "^2.2.4" }, "peerDependencies": { "react-native": ">=0.79.0" } }, "sha512-qA4hsVlrUxAkCc3v96ONehYfE9meBMZl8Ydlc0inV86IX60beTLf1wdXxs21T8s6jnPh7OBwLmtwwU/vUYV68Q=="],
+    "react-native-onesignal": ["react-native-onesignal@../../react-native-onesignal.tgz", { "dependencies": { "invariant": "^2.2.4" }, "peerDependencies": { "react-native": ">=0.79.0" } }, "sha512-n27/13rn/viQCldBWaxetgH7r7MfbxPhPX4HmLVXE2mVcvEjaFfhLEKf5Jn0YbFltNStubuMOceKji1mmGGHWw=="],
 
     "react-native-safe-area-context": ["react-native-safe-area-context@5.7.0", "", { "peerDependencies": { "react": "*", "react-native": "*" } }, "sha512-/9/MtQz8ODphjsLdZ+GZAIcC/RtoqW9EeShf7Uvnfgm/pzYrJ75y3PV/J1wuAV1T5Dye5ygq4EAW20RoBq0ABQ=="],
 

--- a/examples/demo/src/hooks/useOneSignal.ts
+++ b/examples/demo/src/hooks/useOneSignal.ts
@@ -195,6 +195,11 @@ function useOneSignalState(): UseOneSignalReturn {
 
     const handleForegroundWillDisplay = (e: NotificationWillDisplayEvent) => {
       console.log(`Notification foregroundWillDisplay: ${e.getNotification().title ?? ''}`);
+      // uncomment to test preventing the default display behavior
+      // e.preventDefault();
+
+      // can call this after preventDefault (within ~25 seconds) to force display of notification
+      // e.getNotification().display();
     };
 
     const pushSubHandler = (event: PushSubscriptionChangedState) => {

--- a/examples/demo/src/hooks/useOneSignal.ts
+++ b/examples/demo/src/hooks/useOneSignal.ts
@@ -195,7 +195,6 @@ function useOneSignalState(): UseOneSignalReturn {
 
     const handleForegroundWillDisplay = (e: NotificationWillDisplayEvent) => {
       console.log(`Notification foregroundWillDisplay: ${e.getNotification().title ?? ''}`);
-      e.getNotification().display();
     };
 
     const pushSubHandler = (event: PushSubscriptionChangedState) => {

--- a/src/events/EventManager.test.ts
+++ b/src/events/EventManager.test.ts
@@ -1,5 +1,6 @@
 import { beforeEach, describe, expect, test, vi } from 'vite-plus/test';
 
+import { mockRNOneSignal } from '../../__mocks__/react-native';
 import {
   IN_APP_MESSAGE_CLICKED,
   IN_APP_MESSAGE_DID_DISMISS,
@@ -50,6 +51,7 @@ describe('EventManager', () => {
   let callbacks: Map<string, (payload: unknown) => void>;
 
   beforeEach(() => {
+    vi.clearAllMocks();
     const mock = createMockNativeModule();
     mockModule = mock.module;
     callbacks = mock.callbacks;
@@ -193,6 +195,58 @@ describe('EventManager', () => {
       expect(handler).toHaveBeenCalled();
       const receivedEvent = handler.mock.calls[0][0];
       expect(receivedEvent).toBeInstanceOf(NotificationWillDisplayEvent);
+    });
+
+    test('should display a foreground notification when no handlers are registered', () => {
+      callbacks.get('onNotificationWillDisplay')!(rawWillDisplayPayload);
+
+      expect(mockRNOneSignal.displayNotification).toHaveBeenCalledOnce();
+      expect(mockRNOneSignal.displayNotification).toHaveBeenCalledWith('test-id');
+    });
+
+    test('should display a foreground notification when handlers do not prevent it', () => {
+      const handler1 = vi.fn();
+      const handler2 = vi.fn();
+      eventManager.addEventListener(NOTIFICATION_WILL_DISPLAY, handler1);
+      eventManager.addEventListener(NOTIFICATION_WILL_DISPLAY, handler2);
+
+      callbacks.get('onNotificationWillDisplay')!(rawWillDisplayPayload);
+
+      expect(handler1).toHaveBeenCalledOnce();
+      expect(handler2).toHaveBeenCalledOnce();
+      expect(mockRNOneSignal.displayNotification).toHaveBeenCalledOnce();
+    });
+
+    test('should not display automatically when any handler prevents default', () => {
+      const observingHandler = vi.fn();
+      const preventingHandler = vi.fn((event: NotificationWillDisplayEvent) => {
+        event.preventDefault();
+      });
+      eventManager.addEventListener(NOTIFICATION_WILL_DISPLAY, observingHandler);
+      eventManager.addEventListener(NOTIFICATION_WILL_DISPLAY, preventingHandler);
+
+      callbacks.get('onNotificationWillDisplay')!(rawWillDisplayPayload);
+
+      expect(observingHandler).toHaveBeenCalledOnce();
+      expect(preventingHandler).toHaveBeenCalledOnce();
+      expect(mockRNOneSignal.preventDefault).toHaveBeenCalledWith('test-id');
+      expect(mockRNOneSignal.displayNotification).not.toHaveBeenCalled();
+    });
+
+    test('should allow deferred display after preventing default', () => {
+      let receivedEvent: NotificationWillDisplayEvent | undefined;
+      eventManager.addEventListener(NOTIFICATION_WILL_DISPLAY, (event) => {
+        receivedEvent = event;
+        event.preventDefault();
+      });
+
+      callbacks.get('onNotificationWillDisplay')!(rawWillDisplayPayload);
+      expect(mockRNOneSignal.displayNotification).not.toHaveBeenCalled();
+
+      receivedEvent?.getNotification().display();
+
+      expect(mockRNOneSignal.displayNotification).toHaveBeenCalledOnce();
+      expect(mockRNOneSignal.displayNotification).toHaveBeenCalledWith('test-id');
     });
 
     test('should handle PERMISSION_CHANGED events with boolean payload', () => {

--- a/src/events/EventManager.test.ts
+++ b/src/events/EventManager.test.ts
@@ -463,6 +463,9 @@ describe('EventManager', () => {
       expect(notificationWillDisplayHandler.mock.calls[0][0]).toBeInstanceOf(
         NotificationWillDisplayEvent,
       );
+      expect(notificationWillDisplayHandler.mock.calls[0][0].getNotification().notificationId).toBe(
+        'test-id',
+      );
     });
 
     test('should maintain separate handler arrays for different events', () => {

--- a/src/events/EventManager.test.ts
+++ b/src/events/EventManager.test.ts
@@ -249,6 +249,45 @@ describe('EventManager', () => {
       expect(mockRNOneSignal.displayNotification).toHaveBeenCalledWith('test-id');
     });
 
+    test('should not display twice when a handler displays explicitly', () => {
+      eventManager.addEventListener(NOTIFICATION_WILL_DISPLAY, (event) => {
+        event.getNotification().display();
+      });
+
+      callbacks.get('onNotificationWillDisplay')!(rawWillDisplayPayload);
+
+      expect(mockRNOneSignal.displayNotification).toHaveBeenCalledOnce();
+      expect(mockRNOneSignal.displayNotification).toHaveBeenCalledWith('test-id');
+    });
+
+    test('should display by default when a handler throws', () => {
+      eventManager.addEventListener(NOTIFICATION_WILL_DISPLAY, () => {
+        throw new Error('listener failed');
+      });
+
+      expect(() => {
+        callbacks.get('onNotificationWillDisplay')!(rawWillDisplayPayload);
+      }).toThrow('listener failed');
+      expect(mockRNOneSignal.displayNotification).toHaveBeenCalledOnce();
+      expect(mockRNOneSignal.displayNotification).toHaveBeenCalledWith('test-id');
+    });
+
+    test('should continue dispatching after a handler throws', () => {
+      const preventingHandler = vi.fn((event: NotificationWillDisplayEvent) => {
+        event.preventDefault();
+      });
+      eventManager.addEventListener(NOTIFICATION_WILL_DISPLAY, () => {
+        throw new Error('listener failed');
+      });
+      eventManager.addEventListener(NOTIFICATION_WILL_DISPLAY, preventingHandler);
+
+      expect(() => {
+        callbacks.get('onNotificationWillDisplay')!(rawWillDisplayPayload);
+      }).toThrow('listener failed');
+      expect(preventingHandler).toHaveBeenCalledOnce();
+      expect(mockRNOneSignal.displayNotification).not.toHaveBeenCalled();
+    });
+
     test('should handle PERMISSION_CHANGED events with boolean payload', () => {
       const handler = vi.fn();
       eventManager.addEventListener(PERMISSION_CHANGED, handler);
@@ -420,8 +459,9 @@ describe('EventManager', () => {
 
       expect(permissionHandler).toHaveBeenCalledWith(true);
       expect(subscriptionHandler).toHaveBeenCalledWith(pushChangedPayload);
-      expect(notificationWillDisplayHandler).toHaveBeenCalledWith(
-        new NotificationWillDisplayEvent(rawWillDisplayPayload),
+      expect(notificationWillDisplayHandler).toHaveBeenCalledOnce();
+      expect(notificationWillDisplayHandler.mock.calls[0][0]).toBeInstanceOf(
+        NotificationWillDisplayEvent,
       );
     });
 

--- a/src/events/EventManager.ts
+++ b/src/events/EventManager.ts
@@ -132,6 +132,7 @@ export default class EventManager {
   }
 
   private dispatchNotificationWillDisplayHandlers(event: NotificationWillDisplayEvent) {
+    // Every handler must run because any one of them can prevent automatic display.
     const handlers = [...(this.eventListenerArrayMap.get(NOTIFICATION_WILL_DISPLAY) ?? [])];
     let firstError: unknown;
     let handlerThrew = false;

--- a/src/events/EventManager.ts
+++ b/src/events/EventManager.ts
@@ -73,9 +73,12 @@ export default class EventManager {
       }),
       this.RNOneSignal.onNotificationWillDisplay((payload) => {
         const event = new NotificationWillDisplayEvent(payload as OSNotification);
-        this.dispatchHandlers(NOTIFICATION_WILL_DISPLAY, event);
-        if (!event.isDefaultPrevented()) {
-          event.getNotification().display();
+        try {
+          this.dispatchNotificationWillDisplayHandlers(event);
+        } finally {
+          if (!event.isDefaultPrevented() && !event.isDisplayRequested()) {
+            event.getNotification().display();
+          }
         }
       }),
       this.RNOneSignal.onNotificationClicked((payload) => {
@@ -122,6 +125,27 @@ export default class EventManager {
     }
     if (handlerArray.length === 0) {
       this.eventListenerArrayMap.delete(eventName);
+    }
+  }
+
+  private dispatchNotificationWillDisplayHandlers(event: NotificationWillDisplayEvent) {
+    const handlers = [...(this.eventListenerArrayMap.get(NOTIFICATION_WILL_DISPLAY) ?? [])];
+    let firstError: unknown;
+    let handlerThrew = false;
+
+    handlers.forEach((handler) => {
+      try {
+        handler(event);
+      } catch (error) {
+        if (!handlerThrew) {
+          firstError = error;
+          handlerThrew = true;
+        }
+      }
+    });
+
+    if (handlerThrew) {
+      throw firstError;
     }
   }
 

--- a/src/events/EventManager.ts
+++ b/src/events/EventManager.ts
@@ -24,7 +24,10 @@ import type {
 import type { NotificationClickEvent } from '../types/notificationEvents';
 import type { PushSubscriptionChangedState } from '../types/subscription';
 import type { UserChangedState } from '../types/user';
-import NotificationWillDisplayEvent from './NotificationWillDisplayEvent';
+import NotificationWillDisplayEvent, {
+  isDefaultPrevented,
+  isDisplayRequested,
+} from './NotificationWillDisplayEvent';
 
 export interface EventListenerMap {
   [PERMISSION_CHANGED]: (event: boolean) => void;
@@ -76,7 +79,7 @@ export default class EventManager {
         try {
           this.dispatchNotificationWillDisplayHandlers(event);
         } finally {
-          if (!event.isDefaultPrevented() && !event.isDisplayRequested()) {
+          if (!isDefaultPrevented(event) && !isDisplayRequested(event)) {
             event.getNotification().display();
           }
         }

--- a/src/events/EventManager.ts
+++ b/src/events/EventManager.ts
@@ -72,10 +72,11 @@ export default class EventManager {
         this.dispatchHandlers(USER_STATE_CHANGED, payload);
       }),
       this.RNOneSignal.onNotificationWillDisplay((payload) => {
-        this.dispatchHandlers(
-          NOTIFICATION_WILL_DISPLAY,
-          new NotificationWillDisplayEvent(payload as OSNotification),
-        );
+        const event = new NotificationWillDisplayEvent(payload as OSNotification);
+        this.dispatchHandlers(NOTIFICATION_WILL_DISPLAY, event);
+        if (!event.isDefaultPrevented()) {
+          event.getNotification().display();
+        }
       }),
       this.RNOneSignal.onNotificationClicked((payload) => {
         this.dispatchHandlers(NOTIFICATION_CLICKED, payload);

--- a/src/events/NotificationWillDisplayEvent.test.ts
+++ b/src/events/NotificationWillDisplayEvent.test.ts
@@ -2,7 +2,10 @@ import { describe, expect, test } from 'vite-plus/test';
 
 import { mockRNOneSignal } from '../../__mocks__/react-native';
 import OSNotification, { type BaseNotificationData } from '../OSNotification';
-import NotificationWillDisplayEvent from './NotificationWillDisplayEvent';
+import NotificationWillDisplayEvent, {
+  isDefaultPrevented,
+  isDisplayRequested,
+} from './NotificationWillDisplayEvent';
 
 describe('NotificationWillDisplayEvent', () => {
   const notificationId = 'test-notification-id';
@@ -68,7 +71,7 @@ describe('NotificationWillDisplayEvent', () => {
       const result = event.preventDefault();
 
       expect(mockRNOneSignal.preventDefault).toHaveBeenCalledWith(notificationId);
-      expect(event.isDefaultPrevented()).toBe(true);
+      expect(isDefaultPrevented(event)).toBe(true);
       expect(result).toBeUndefined();
     });
 
@@ -82,7 +85,7 @@ describe('NotificationWillDisplayEvent', () => {
 
       expect(mockRNOneSignal.preventDefault).toHaveBeenCalledTimes(3);
       expect(mockRNOneSignal.preventDefault).toHaveBeenCalledWith('test-notification-id');
-      expect(event.isDefaultPrevented()).toBe(true);
+      expect(isDefaultPrevented(event)).toBe(true);
     });
   });
 
@@ -91,7 +94,7 @@ describe('NotificationWillDisplayEvent', () => {
       const notification = new OSNotification(baseNotificationData);
       const event = new NotificationWillDisplayEvent(notification);
 
-      expect(event.isDefaultPrevented()).toBe(false);
+      expect(isDefaultPrevented(event)).toBe(false);
     });
   });
 
@@ -100,12 +103,12 @@ describe('NotificationWillDisplayEvent', () => {
       const notification = new OSNotification(baseNotificationData);
       const event = new NotificationWillDisplayEvent(notification);
 
-      expect(event.isDisplayRequested()).toBe(false);
+      expect(isDisplayRequested(event)).toBe(false);
 
       event.getNotification().display();
       event.getNotification().display();
 
-      expect(event.isDisplayRequested()).toBe(true);
+      expect(isDisplayRequested(event)).toBe(true);
       expect(mockRNOneSignal.displayNotification).toHaveBeenCalledOnce();
       expect(mockRNOneSignal.displayNotification).toHaveBeenCalledWith(notificationId);
     });

--- a/src/events/NotificationWillDisplayEvent.test.ts
+++ b/src/events/NotificationWillDisplayEvent.test.ts
@@ -68,6 +68,7 @@ describe('NotificationWillDisplayEvent', () => {
       const result = event.preventDefault();
 
       expect(mockRNOneSignal.preventDefault).toHaveBeenCalledWith(notificationId);
+      expect(event.isDefaultPrevented()).toBe(true);
       expect(result).toBeUndefined();
     });
 
@@ -81,6 +82,16 @@ describe('NotificationWillDisplayEvent', () => {
 
       expect(mockRNOneSignal.preventDefault).toHaveBeenCalledTimes(3);
       expect(mockRNOneSignal.preventDefault).toHaveBeenCalledWith('test-notification-id');
+      expect(event.isDefaultPrevented()).toBe(true);
+    });
+  });
+
+  describe('isDefaultPrevented', () => {
+    test('should be false before preventDefault is called', () => {
+      const notification = new OSNotification(baseNotificationData);
+      const event = new NotificationWillDisplayEvent(notification);
+
+      expect(event.isDefaultPrevented()).toBe(false);
     });
   });
 

--- a/src/events/NotificationWillDisplayEvent.test.ts
+++ b/src/events/NotificationWillDisplayEvent.test.ts
@@ -95,6 +95,22 @@ describe('NotificationWillDisplayEvent', () => {
     });
   });
 
+  describe('isDisplayRequested', () => {
+    test('should track notification display calls', () => {
+      const notification = new OSNotification(baseNotificationData);
+      const event = new NotificationWillDisplayEvent(notification);
+
+      expect(event.isDisplayRequested()).toBe(false);
+
+      event.getNotification().display();
+      event.getNotification().display();
+
+      expect(event.isDisplayRequested()).toBe(true);
+      expect(mockRNOneSignal.displayNotification).toHaveBeenCalledOnce();
+      expect(mockRNOneSignal.displayNotification).toHaveBeenCalledWith(notificationId);
+    });
+  });
+
   describe('getNotification', () => {
     test('should return the notification instance', () => {
       const notification = new OSNotification(baseNotificationData);

--- a/src/events/NotificationWillDisplayEvent.ts
+++ b/src/events/NotificationWillDisplayEvent.ts
@@ -4,16 +4,22 @@ const RNOneSignal = NativeOneSignal;
 
 export default class NotificationWillDisplayEvent {
   public notification: OSNotification;
+  private defaultPrevented = false;
 
   constructor(displayEvent: OSNotification) {
     this.notification = new OSNotification(displayEvent);
   }
 
   preventDefault(): void {
+    this.defaultPrevented = true;
     RNOneSignal.preventDefault(this.notification.notificationId);
   }
 
   getNotification(): OSNotification {
     return this.notification;
+  }
+
+  isDefaultPrevented(): boolean {
+    return this.defaultPrevented;
   }
 }

--- a/src/events/NotificationWillDisplayEvent.ts
+++ b/src/events/NotificationWillDisplayEvent.ts
@@ -3,6 +3,7 @@ import OSNotification from '../OSNotification';
 const RNOneSignal = NativeOneSignal;
 
 const displayedNotifications = new WeakSet<OSNotification>();
+const preventedEvents = new WeakSet<NotificationWillDisplayEvent>();
 
 class ForegroundNotification extends OSNotification {
   display(): void {
@@ -16,7 +17,6 @@ class ForegroundNotification extends OSNotification {
 
 export default class NotificationWillDisplayEvent {
   public notification: OSNotification;
-  private defaultPrevented = false;
 
   constructor(displayEvent: OSNotification) {
     this.notification = new ForegroundNotification(displayEvent);
@@ -24,19 +24,19 @@ export default class NotificationWillDisplayEvent {
 
   /** This must be called synchronously while the foreground listener is running. */
   preventDefault(): void {
-    this.defaultPrevented = true;
+    preventedEvents.add(this);
     RNOneSignal.preventDefault(this.notification.notificationId);
   }
 
   getNotification(): OSNotification {
     return this.notification;
   }
+}
 
-  isDefaultPrevented(): boolean {
-    return this.defaultPrevented;
-  }
+export function isDefaultPrevented(event: NotificationWillDisplayEvent): boolean {
+  return preventedEvents.has(event);
+}
 
-  isDisplayRequested(): boolean {
-    return displayedNotifications.has(this.notification);
-  }
+export function isDisplayRequested(event: NotificationWillDisplayEvent): boolean {
+  return displayedNotifications.has(event.notification);
 }

--- a/src/events/NotificationWillDisplayEvent.ts
+++ b/src/events/NotificationWillDisplayEvent.ts
@@ -22,7 +22,10 @@ export default class NotificationWillDisplayEvent {
     this.notification = new ForegroundNotification(displayEvent);
   }
 
-  /** This must be called synchronously while the foreground listener is running. */
+  /**
+   * This must be called synchronously while the foreground listener is running.
+   * Calling it later cannot stop the automatic display.
+   */
   preventDefault(): void {
     preventedEvents.add(this);
     RNOneSignal.preventDefault(this.notification.notificationId);

--- a/src/events/NotificationWillDisplayEvent.ts
+++ b/src/events/NotificationWillDisplayEvent.ts
@@ -2,14 +2,27 @@ import NativeOneSignal from '../NativeOneSignal';
 import OSNotification from '../OSNotification';
 const RNOneSignal = NativeOneSignal;
 
+const displayedNotifications = new WeakSet<OSNotification>();
+
+class ForegroundNotification extends OSNotification {
+  display(): void {
+    if (displayedNotifications.has(this)) {
+      return;
+    }
+    displayedNotifications.add(this);
+    super.display();
+  }
+}
+
 export default class NotificationWillDisplayEvent {
   public notification: OSNotification;
   private defaultPrevented = false;
 
   constructor(displayEvent: OSNotification) {
-    this.notification = new OSNotification(displayEvent);
+    this.notification = new ForegroundNotification(displayEvent);
   }
 
+  /** This must be called synchronously while the foreground listener is running. */
   preventDefault(): void {
     this.defaultPrevented = true;
     RNOneSignal.preventDefault(this.notification.notificationId);
@@ -21,5 +34,9 @@ export default class NotificationWillDisplayEvent {
 
   isDefaultPrevented(): boolean {
     return this.defaultPrevented;
+  }
+
+  isDisplayRequested(): boolean {
+    return displayedNotifications.has(this.notification);
   }
 }


### PR DESCRIPTION
# Description

## One Line Summary

Display foreground notifications automatically unless a listener calls `preventDefault()`.

## Details

### Motivation

The native bridges prevent foreground display before dispatching to JavaScript to avoid an asynchronous bridge race. Previously, that meant adding a log-only listener suppressed the notification unless the app explicitly called `display()`.

### Scope

- Track the synchronous JavaScript listener decision and display automatically when no listener prevents it.
- Support multiple listeners, with any `preventDefault()` call suppressing automatic display.
- Preserve explicit and deferred display without duplicate native display calls.
- Keep notifications displaying if a listener throws while allowing remaining listeners to run.
- No public API changes.

# Testing

## Unit testing

- Added coverage for automatic display, no listeners, multiple listeners, prevention, deferred display, explicit display, duplicate display calls, and thrown listeners.
- `vp check`
- `vp test`: 272 tests passed
- `vp run build`
- Multi-model review completed with Claude Opus 5, GPT 5.6 Sol, and Cursor Grok 4.6.

## Manual testing

Tested on Android and iOS with:

- `handleForegroundWillDisplay` containing only a log.
- `preventDefault()` uncommented.
- `preventDefault()` followed by `display()`.
- `preventDefault()` followed by `display()` after approximately 25 seconds.

# Affected code checklist

- [x] Notifications
  - [x] Display
  - [ ] Open
  - [ ] Push Processing
  - [ ] Confirm Deliveries
- [ ] Outcomes
- [ ] Sessions
- [ ] In-App Messaging
- [ ] REST API requests
- [ ] Public API changes

# Checklist

## Overview

- [x] I have filled out all **REQUIRED** sections above
- [x] PR does one thing
- [x] Any Public API changes are explained in the PR details and conform to existing APIs

## Testing

- [x] I have included test coverage for these changes, or explained why they are not needed
- [x] All automated tests pass, or I explained why that is not possible
- [x] I have personally tested this on my device, or explained why that is not possible

## Final pass

- [x] Code is as readable as possible
- [x] I have reviewed this PR myself, ensuring it meets each checklist item

Made with [Cursor](https://cursor.com)