### PR TITLE
chore: Release 5.5.9

### DIFF
--- a/android/src/main/java/com/onesignal/rnonesignalandroid/RNOneSignal.java
+++ b/android/src/main/java/com/onesignal/rnonesignalandroid/RNOneSignal.java
@@ -224,7 +224,7 @@ public class RNOneSignal extends NativeOneSignalSpec
     @Override
     public void initialize(String appId) {
         OneSignalWrapper.setSdkType("reactnative");
-        OneSignalWrapper.setSdkVersion("050508");
+        OneSignalWrapper.setSdkVersion("050509");
 
         if (oneSignalInitDone) {
             Logging.debug("Already initialized the OneSignal React-Native SDK", null);

--- a/ios/RCTOneSignal/RCTOneSignal.mm
+++ b/ios/RCTOneSignal/RCTOneSignal.mm
@@ -23,7 +23,7 @@
     return;
 
   OneSignalWrapper.sdkType = @"reactnative";
-  OneSignalWrapper.sdkVersion = @"050508";
+  OneSignalWrapper.sdkVersion = @"050509";
   // initialize the SDK with a nil app ID so cold start click listeners can be
   // triggered
   [OneSignal initialize:nil withLaunchOptions:launchOptions];

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-native-onesignal",
-  "version": "5.5.8",
+  "version": "5.5.9",
   "description": "React Native OneSignal SDK",
   "keywords": [
     "android",


### PR DESCRIPTION
Channels: Current

### 🐛 Bug Fixes

- fix: [SDK-5139] display foreground notifications by default (#1989)
- fix(example): prevent stale initialization and user state updates (#1981)
- fix(ios): synchronize foreground notification cache access (#1980)
- fix(ios): forward every application delegate assignment (#1979)
- fix(android): preserve structured notification payloads across the bridge (#1978)
- fix(android): tie observer cleanup to the React module lifetime (#1977)
- fix(android): avoid blocking foreground delivery and consume display events (#1976)
- fix(ios): preserve own property keys when encoding null values (#1975)
- fix: stabilize observer lifecycle and asynchronous state snapshots (#1974)


