### PR TITLE
chore: Release 5.5.10

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -17,7 +17,7 @@ def safeFlagGet(envProp, gradleProp) {
     return normalizedValue != null && (normalizedValue.equalsIgnoreCase('true') || normalizedValue == '1')
 }
 
-def oneSignalVersion = '5.9.9'
+def oneSignalVersion = '5.10.0'
 def oneSignalDisableLocation = safeFlagGet('ONESIGNAL_DISABLE_LOCATION', 'onesignal.disableLocation')
 
 android {

--- a/android/src/main/java/com/onesignal/rnonesignalandroid/RNOneSignal.java
+++ b/android/src/main/java/com/onesignal/rnonesignalandroid/RNOneSignal.java
@@ -224,7 +224,7 @@ public class RNOneSignal extends NativeOneSignalSpec
     @Override
     public void initialize(String appId) {
         OneSignalWrapper.setSdkType("reactnative");
-        OneSignalWrapper.setSdkVersion("050509");
+        OneSignalWrapper.setSdkVersion("050510");
 
         if (oneSignalInitDone) {
             Logging.debug("Already initialized the OneSignal React-Native SDK", null);

--- a/examples/demo/bun.lock
+++ b/examples/demo/bun.lock
@@ -1006,7 +1006,7 @@
 
     "react-native-dotenv": ["react-native-dotenv@3.4.11", "", { "dependencies": { "dotenv": "^16.4.5" }, "peerDependencies": { "@babel/runtime": "^7.20.6" } }, "sha512-6vnIE+WHABSeHCaYP6l3O1BOEhWxKH6nHAdV7n/wKn/sciZ64zPPp2NUdEUf1m7g4uuzlLbjgr+6uDt89q2DOg=="],
 
-    "react-native-onesignal": ["react-native-onesignal@../../react-native-onesignal.tgz", { "dependencies": { "invariant": "^2.2.4" }, "peerDependencies": { "react-native": ">=0.79.0" } }, "sha512-FbLpn0pTEbMP5YLl2GQr79S7ltIYejWJap3Gn3K8bNbM5+vUmU6xpWTYHdX0jquj7NXHT+oKsP8h0sioNjUl0A=="],
+    "react-native-onesignal": ["react-native-onesignal@../../react-native-onesignal.tgz", { "dependencies": { "invariant": "^2.2.4" }, "peerDependencies": { "react-native": ">=0.79.0" } }, "sha512-UiPEj1EY1ghqHM/iUrcAIFr5YRnVqKQsOVLl2G7Y/Dq8BxE8S8jkPeMJpyFCgjZzQgKk9B3yCuWwTqECucaQAg=="],
 
     "react-native-safe-area-context": ["react-native-safe-area-context@5.7.0", "", { "peerDependencies": { "react": "*", "react-native": "*" } }, "sha512-/9/MtQz8ODphjsLdZ+GZAIcC/RtoqW9EeShf7Uvnfgm/pzYrJ75y3PV/J1wuAV1T5Dye5ygq4EAW20RoBq0ABQ=="],
 

--- a/examples/demo/bun.lock
+++ b/examples/demo/bun.lock
@@ -1006,7 +1006,7 @@
 
     "react-native-dotenv": ["react-native-dotenv@3.4.11", "", { "dependencies": { "dotenv": "^16.4.5" }, "peerDependencies": { "@babel/runtime": "^7.20.6" } }, "sha512-6vnIE+WHABSeHCaYP6l3O1BOEhWxKH6nHAdV7n/wKn/sciZ64zPPp2NUdEUf1m7g4uuzlLbjgr+6uDt89q2DOg=="],
 
-    "react-native-onesignal": ["react-native-onesignal@../../react-native-onesignal.tgz", { "dependencies": { "invariant": "^2.2.4" }, "peerDependencies": { "react-native": ">=0.79.0" } }, "sha512-n27/13rn/viQCldBWaxetgH7r7MfbxPhPX4HmLVXE2mVcvEjaFfhLEKf5Jn0YbFltNStubuMOceKji1mmGGHWw=="],
+    "react-native-onesignal": ["react-native-onesignal@../../react-native-onesignal.tgz", { "dependencies": { "invariant": "^2.2.4" }, "peerDependencies": { "react-native": ">=0.79.0" } }, "sha512-FbLpn0pTEbMP5YLl2GQr79S7ltIYejWJap3Gn3K8bNbM5+vUmU6xpWTYHdX0jquj7NXHT+oKsP8h0sioNjUl0A=="],
 
     "react-native-safe-area-context": ["react-native-safe-area-context@5.7.0", "", { "peerDependencies": { "react": "*", "react-native": "*" } }, "sha512-/9/MtQz8ODphjsLdZ+GZAIcC/RtoqW9EeShf7Uvnfgm/pzYrJ75y3PV/J1wuAV1T5Dye5ygq4EAW20RoBq0ABQ=="],
 

--- a/examples/demo/ios/Podfile.lock
+++ b/examples/demo/ios/Podfile.lock
@@ -3,9 +3,9 @@ PODS:
   - hermes-engine (250829098.0.7):
     - hermes-engine/Pre-built (= 250829098.0.7)
   - hermes-engine/Pre-built (250829098.0.7)
-  - OneSignalXCFramework (5.5.6):
-    - OneSignalXCFramework/OneSignalComplete (= 5.5.6)
-  - OneSignalXCFramework/OneSignal (5.5.6):
+  - OneSignalXCFramework (5.6.0):
+    - OneSignalXCFramework/OneSignalComplete (= 5.6.0)
+  - OneSignalXCFramework/OneSignal (5.6.0):
     - OneSignalXCFramework/OneSignalCore
     - OneSignalXCFramework/OneSignalExtension
     - OneSignalXCFramework/OneSignalLiveActivities
@@ -13,41 +13,41 @@ PODS:
     - OneSignalXCFramework/OneSignalOSCore
     - OneSignalXCFramework/OneSignalOutcomes
     - OneSignalXCFramework/OneSignalUser
-  - OneSignalXCFramework/OneSignalComplete (5.5.6):
+  - OneSignalXCFramework/OneSignalComplete (5.6.0):
     - OneSignalXCFramework/OneSignal
     - OneSignalXCFramework/OneSignalInAppMessages
     - OneSignalXCFramework/OneSignalLocation
-  - OneSignalXCFramework/OneSignalCore (5.5.6)
-  - OneSignalXCFramework/OneSignalExtension (5.5.6):
+  - OneSignalXCFramework/OneSignalCore (5.6.0)
+  - OneSignalXCFramework/OneSignalExtension (5.6.0):
     - OneSignalXCFramework/OneSignalCore
     - OneSignalXCFramework/OneSignalOSCore
     - OneSignalXCFramework/OneSignalOutcomes
-  - OneSignalXCFramework/OneSignalInAppMessages (5.5.6):
+  - OneSignalXCFramework/OneSignalInAppMessages (5.6.0):
     - OneSignalXCFramework/OneSignalCore
     - OneSignalXCFramework/OneSignalNotifications
     - OneSignalXCFramework/OneSignalOSCore
     - OneSignalXCFramework/OneSignalOutcomes
     - OneSignalXCFramework/OneSignalUser
-  - OneSignalXCFramework/OneSignalLiveActivities (5.5.6):
+  - OneSignalXCFramework/OneSignalLiveActivities (5.6.0):
     - OneSignalXCFramework/OneSignalCore
     - OneSignalXCFramework/OneSignalOSCore
     - OneSignalXCFramework/OneSignalUser
-  - OneSignalXCFramework/OneSignalLocation (5.5.6):
+  - OneSignalXCFramework/OneSignalLocation (5.6.0):
     - OneSignalXCFramework/OneSignalCore
     - OneSignalXCFramework/OneSignalNotifications
     - OneSignalXCFramework/OneSignalOSCore
     - OneSignalXCFramework/OneSignalUser
-  - OneSignalXCFramework/OneSignalNotifications (5.5.6):
+  - OneSignalXCFramework/OneSignalNotifications (5.6.0):
     - OneSignalXCFramework/OneSignalCore
     - OneSignalXCFramework/OneSignalExtension
     - OneSignalXCFramework/OneSignalOSCore
     - OneSignalXCFramework/OneSignalOutcomes
-  - OneSignalXCFramework/OneSignalOSCore (5.5.6):
+  - OneSignalXCFramework/OneSignalOSCore (5.6.0):
     - OneSignalXCFramework/OneSignalCore
-  - OneSignalXCFramework/OneSignalOutcomes (5.5.6):
+  - OneSignalXCFramework/OneSignalOutcomes (5.6.0):
     - OneSignalXCFramework/OneSignalCore
     - OneSignalXCFramework/OneSignalOSCore
-  - OneSignalXCFramework/OneSignalUser (5.5.6):
+  - OneSignalXCFramework/OneSignalUser (5.6.0):
     - OneSignalXCFramework/OneSignalCore
     - OneSignalXCFramework/OneSignalNotifications
     - OneSignalXCFramework/OneSignalOSCore
@@ -1449,9 +1449,9 @@ PODS:
     - React-RCTFBReactNativeSpec
     - ReactCommon/turbomodule/core
     - ReactNativeDependencies
-  - react-native-onesignal (5.5.8):
+  - react-native-onesignal (5.5.10):
     - hermes-engine
-    - OneSignalXCFramework (= 5.5.6)
+    - OneSignalXCFramework (= 5.6.0)
     - RCTRequired
     - RCTTypeSafety
     - React-Core
@@ -2314,8 +2314,8 @@ EXTERNAL SOURCES:
 
 SPEC CHECKSUMS:
   FBLazyVector: c12d2108050e27952983d565a232f6f7b1ad5e69
-  hermes-engine: 177322198264d50dc281084c48e1ed80ea14884c
-  OneSignalXCFramework: 9a0f33eaef7544788a2b04f067e90fe18759fdf9
+  hermes-engine: 431876dbea22ba6821b0e999131ecbf5d706c8d2
+  OneSignalXCFramework: 15d4cab8ec5e0772fe5f16ba837db6562c975a93
   RCTDeprecation: 3280799c14232a56e5a44f92981a8ee33bc69fd9
   RCTRequired: 9854a51b0f65ccf43ea0b744df4d70fce339db32
   RCTSwiftUI: 96986e49a4fdc2c2103929dee2641e1b57edf33d
@@ -2324,7 +2324,7 @@ SPEC CHECKSUMS:
   React: 7ef36630d07638043a134a7dd2ec17e0be10fc3c
   React-callinvoker: af4e8fe1d60ab63dd8d74c2a68988064c2848954
   React-Core: c609976c034ba9556bef9850a571a71bd458d73f
-  React-Core-prebuilt: f4df078355bf9605a0d0278aa5c63fcd4b764a1d
+  React-Core-prebuilt: 5e3e0e5fe0a22af7fb36c5b593882da759f395c9
   React-CoreModules: 0ea85f3b3f4b8cbfb3afacd2ed85458fb878517a
   React-cxxreact: 6752bab77c0599d6136e2b8b9b64b4a7d316d401
   React-debug: 38389b86e3570558ec73dd4cbc0cd2f2eec47a51
@@ -2352,7 +2352,7 @@ SPEC CHECKSUMS:
   React-logger: 9e51e01455f15cb3ef87a09a1ec773cdb22d56c1
   React-Mapbuffer: 92b99e450e8ff598b27d6e4db3a75e04fd45e9a9
   React-microtasksnativemodule: 2fe0f2bd2840dedbd66c0ac249c64f977f39cc18
-  react-native-onesignal: e2f5c75b26ba500eaad8d249ca8ae101ed615742
+  react-native-onesignal: e40275dad361b95ec78a1cacaefd0aba46b6ee3d
   react-native-safe-area-context: ae7587b95fb580d1800c5b0b2a7bd48c2868e67a
   React-NativeModulesApple: 44a9474594566cd03659f92e38f42599c6b9dee4
   React-networking: db73d91466cb134fcbdaaa579fb2de14e2c2ea01
@@ -2387,7 +2387,7 @@ SPEC CHECKSUMS:
   ReactAppDependencyProvider: 6b7e8d8d974ed13fb66698d82c30c5e70c1f7d3a
   ReactCodegen: c5e5343f6691b0cd76913b9be5e89e5a83ff3315
   ReactCommon: 92b53b0bd7f7d86154dc9f512c1ea5dee717cc72
-  ReactNativeDependencies: eaebe8c9533ec2c41b08a02844af461bfff10540
+  ReactNativeDependencies: f822e1f0812f671d9bfe99225d09dc144fa6f02b
   RNCAsyncStorage: 3a4f5e2777dae1688b781a487923a08569e27fe4
   RNScreens: 6cb648bdad8fe9bee9259fe144df95b6d1d5b707
   RNSVG: c69f7709226108f5eb89b5aa8833c17a36345468

--- a/examples/demo/ios/Podfile.lock
+++ b/examples/demo/ios/Podfile.lock
@@ -2314,7 +2314,7 @@ EXTERNAL SOURCES:
 
 SPEC CHECKSUMS:
   FBLazyVector: c12d2108050e27952983d565a232f6f7b1ad5e69
-  hermes-engine: 431876dbea22ba6821b0e999131ecbf5d706c8d2
+  hermes-engine: 177322198264d50dc281084c48e1ed80ea14884c
   OneSignalXCFramework: 15d4cab8ec5e0772fe5f16ba837db6562c975a93
   RCTDeprecation: 3280799c14232a56e5a44f92981a8ee33bc69fd9
   RCTRequired: 9854a51b0f65ccf43ea0b744df4d70fce339db32
@@ -2324,7 +2324,7 @@ SPEC CHECKSUMS:
   React: 7ef36630d07638043a134a7dd2ec17e0be10fc3c
   React-callinvoker: af4e8fe1d60ab63dd8d74c2a68988064c2848954
   React-Core: c609976c034ba9556bef9850a571a71bd458d73f
-  React-Core-prebuilt: 5e3e0e5fe0a22af7fb36c5b593882da759f395c9
+  React-Core-prebuilt: f4df078355bf9605a0d0278aa5c63fcd4b764a1d
   React-CoreModules: 0ea85f3b3f4b8cbfb3afacd2ed85458fb878517a
   React-cxxreact: 6752bab77c0599d6136e2b8b9b64b4a7d316d401
   React-debug: 38389b86e3570558ec73dd4cbc0cd2f2eec47a51
@@ -2387,7 +2387,7 @@ SPEC CHECKSUMS:
   ReactAppDependencyProvider: 6b7e8d8d974ed13fb66698d82c30c5e70c1f7d3a
   ReactCodegen: c5e5343f6691b0cd76913b9be5e89e5a83ff3315
   ReactCommon: 92b53b0bd7f7d86154dc9f512c1ea5dee717cc72
-  ReactNativeDependencies: f822e1f0812f671d9bfe99225d09dc144fa6f02b
+  ReactNativeDependencies: eaebe8c9533ec2c41b08a02844af461bfff10540
   RNCAsyncStorage: 3a4f5e2777dae1688b781a487923a08569e27fe4
   RNScreens: 6cb648bdad8fe9bee9259fe144df95b6d1d5b707
   RNSVG: c69f7709226108f5eb89b5aa8833c17a36345468

--- a/examples/demo/ios/Podfile.lock
+++ b/examples/demo/ios/Podfile.lock
@@ -3,9 +3,9 @@ PODS:
   - hermes-engine (250829098.0.7):
     - hermes-engine/Pre-built (= 250829098.0.7)
   - hermes-engine/Pre-built (250829098.0.7)
-  - OneSignalXCFramework (5.6.0):
-    - OneSignalXCFramework/OneSignalComplete (= 5.6.0)
-  - OneSignalXCFramework/OneSignal (5.6.0):
+  - OneSignalXCFramework (5.6.1):
+    - OneSignalXCFramework/OneSignalComplete (= 5.6.1)
+  - OneSignalXCFramework/OneSignal (5.6.1):
     - OneSignalXCFramework/OneSignalCore
     - OneSignalXCFramework/OneSignalExtension
     - OneSignalXCFramework/OneSignalLiveActivities
@@ -13,41 +13,41 @@ PODS:
     - OneSignalXCFramework/OneSignalOSCore
     - OneSignalXCFramework/OneSignalOutcomes
     - OneSignalXCFramework/OneSignalUser
-  - OneSignalXCFramework/OneSignalComplete (5.6.0):
+  - OneSignalXCFramework/OneSignalComplete (5.6.1):
     - OneSignalXCFramework/OneSignal
     - OneSignalXCFramework/OneSignalInAppMessages
     - OneSignalXCFramework/OneSignalLocation
-  - OneSignalXCFramework/OneSignalCore (5.6.0)
-  - OneSignalXCFramework/OneSignalExtension (5.6.0):
+  - OneSignalXCFramework/OneSignalCore (5.6.1)
+  - OneSignalXCFramework/OneSignalExtension (5.6.1):
     - OneSignalXCFramework/OneSignalCore
     - OneSignalXCFramework/OneSignalOSCore
     - OneSignalXCFramework/OneSignalOutcomes
-  - OneSignalXCFramework/OneSignalInAppMessages (5.6.0):
+  - OneSignalXCFramework/OneSignalInAppMessages (5.6.1):
     - OneSignalXCFramework/OneSignalCore
     - OneSignalXCFramework/OneSignalNotifications
     - OneSignalXCFramework/OneSignalOSCore
     - OneSignalXCFramework/OneSignalOutcomes
     - OneSignalXCFramework/OneSignalUser
-  - OneSignalXCFramework/OneSignalLiveActivities (5.6.0):
+  - OneSignalXCFramework/OneSignalLiveActivities (5.6.1):
     - OneSignalXCFramework/OneSignalCore
     - OneSignalXCFramework/OneSignalOSCore
     - OneSignalXCFramework/OneSignalUser
-  - OneSignalXCFramework/OneSignalLocation (5.6.0):
+  - OneSignalXCFramework/OneSignalLocation (5.6.1):
     - OneSignalXCFramework/OneSignalCore
     - OneSignalXCFramework/OneSignalNotifications
     - OneSignalXCFramework/OneSignalOSCore
     - OneSignalXCFramework/OneSignalUser
-  - OneSignalXCFramework/OneSignalNotifications (5.6.0):
+  - OneSignalXCFramework/OneSignalNotifications (5.6.1):
     - OneSignalXCFramework/OneSignalCore
     - OneSignalXCFramework/OneSignalExtension
     - OneSignalXCFramework/OneSignalOSCore
     - OneSignalXCFramework/OneSignalOutcomes
-  - OneSignalXCFramework/OneSignalOSCore (5.6.0):
+  - OneSignalXCFramework/OneSignalOSCore (5.6.1):
     - OneSignalXCFramework/OneSignalCore
-  - OneSignalXCFramework/OneSignalOutcomes (5.6.0):
+  - OneSignalXCFramework/OneSignalOutcomes (5.6.1):
     - OneSignalXCFramework/OneSignalCore
     - OneSignalXCFramework/OneSignalOSCore
-  - OneSignalXCFramework/OneSignalUser (5.6.0):
+  - OneSignalXCFramework/OneSignalUser (5.6.1):
     - OneSignalXCFramework/OneSignalCore
     - OneSignalXCFramework/OneSignalNotifications
     - OneSignalXCFramework/OneSignalOSCore
@@ -1451,7 +1451,7 @@ PODS:
     - ReactNativeDependencies
   - react-native-onesignal (5.5.10):
     - hermes-engine
-    - OneSignalXCFramework (= 5.6.0)
+    - OneSignalXCFramework (= 5.6.1)
     - RCTRequired
     - RCTTypeSafety
     - React-Core
@@ -2314,8 +2314,8 @@ EXTERNAL SOURCES:
 
 SPEC CHECKSUMS:
   FBLazyVector: c12d2108050e27952983d565a232f6f7b1ad5e69
-  hermes-engine: 177322198264d50dc281084c48e1ed80ea14884c
-  OneSignalXCFramework: 15d4cab8ec5e0772fe5f16ba837db6562c975a93
+  hermes-engine: 431876dbea22ba6821b0e999131ecbf5d706c8d2
+  OneSignalXCFramework: c38d48069949912d19e7c64d2ff30f5c9edba1ee
   RCTDeprecation: 3280799c14232a56e5a44f92981a8ee33bc69fd9
   RCTRequired: 9854a51b0f65ccf43ea0b744df4d70fce339db32
   RCTSwiftUI: 96986e49a4fdc2c2103929dee2641e1b57edf33d
@@ -2324,7 +2324,7 @@ SPEC CHECKSUMS:
   React: 7ef36630d07638043a134a7dd2ec17e0be10fc3c
   React-callinvoker: af4e8fe1d60ab63dd8d74c2a68988064c2848954
   React-Core: c609976c034ba9556bef9850a571a71bd458d73f
-  React-Core-prebuilt: f4df078355bf9605a0d0278aa5c63fcd4b764a1d
+  React-Core-prebuilt: 5e3e0e5fe0a22af7fb36c5b593882da759f395c9
   React-CoreModules: 0ea85f3b3f4b8cbfb3afacd2ed85458fb878517a
   React-cxxreact: 6752bab77c0599d6136e2b8b9b64b4a7d316d401
   React-debug: 38389b86e3570558ec73dd4cbc0cd2f2eec47a51
@@ -2352,7 +2352,7 @@ SPEC CHECKSUMS:
   React-logger: 9e51e01455f15cb3ef87a09a1ec773cdb22d56c1
   React-Mapbuffer: 92b99e450e8ff598b27d6e4db3a75e04fd45e9a9
   React-microtasksnativemodule: 2fe0f2bd2840dedbd66c0ac249c64f977f39cc18
-  react-native-onesignal: e40275dad361b95ec78a1cacaefd0aba46b6ee3d
+  react-native-onesignal: a81ee7621455d7a4b529039b9d7a9e9e900ed43f
   react-native-safe-area-context: ae7587b95fb580d1800c5b0b2a7bd48c2868e67a
   React-NativeModulesApple: 44a9474594566cd03659f92e38f42599c6b9dee4
   React-networking: db73d91466cb134fcbdaaa579fb2de14e2c2ea01
@@ -2387,7 +2387,7 @@ SPEC CHECKSUMS:
   ReactAppDependencyProvider: 6b7e8d8d974ed13fb66698d82c30c5e70c1f7d3a
   ReactCodegen: c5e5343f6691b0cd76913b9be5e89e5a83ff3315
   ReactCommon: 92b53b0bd7f7d86154dc9f512c1ea5dee717cc72
-  ReactNativeDependencies: eaebe8c9533ec2c41b08a02844af461bfff10540
+  ReactNativeDependencies: f822e1f0812f671d9bfe99225d09dc144fa6f02b
   RNCAsyncStorage: 3a4f5e2777dae1688b781a487923a08569e27fe4
   RNScreens: 6cb648bdad8fe9bee9259fe144df95b6d1d5b707
   RNSVG: c69f7709226108f5eb89b5aa8833c17a36345468

--- a/examples/demo/package.json
+++ b/examples/demo/package.json
@@ -8,7 +8,7 @@
     "preios": "vp run setup",
     "android": "bash ../run-android.sh",
     "ios": "bash ../run-ios.sh",
-    "update:pods": "(cd ios && pod update OneSignalXCFramework --no-repo-update)",
+    "update:pods": "(cd ios && pod update OneSignalXCFramework)",
     "clean:android": "rm -rf android/app/build android/app/.cxx android/build && adb uninstall com.onesignal.example >/dev/null 2>&1 || true",
     "clean:ios": "rm -rf ios/build ios/Pods",
     "start": "react-native start"

--- a/ios/RCTOneSignal/RCTOneSignal.mm
+++ b/ios/RCTOneSignal/RCTOneSignal.mm
@@ -23,7 +23,7 @@
     return;
 
   OneSignalWrapper.sdkType = @"reactnative";
-  OneSignalWrapper.sdkVersion = @"050509";
+  OneSignalWrapper.sdkVersion = @"050510";
   // initialize the SDK with a nil app ID so cold start click listeners can be
   // triggered
   [OneSignal initialize:nil withLaunchOptions:launchOptions];

--- a/ios/RCTOneSignal/RCTOneSignalExtensionService.m
+++ b/ios/RCTOneSignal/RCTOneSignalExtensionService.m
@@ -8,10 +8,8 @@
 + (void)didReceiveNotificationRequest:(UNNotificationRequest *)request
                           withContent:
                               (UNMutableNotificationContent *_Nullable)content {
-  // OneSignal 5.6.0 removed the 2-arg selector; nil handler is the old sync path.
   [OneSignal didReceiveNotificationExtensionRequest:request
-                     withMutableNotificationContent:content
-                                 withContentHandler:nil];
+                     withMutableNotificationContent:content];
 }
 
 + (void)didReceiveNotificationRequest:(UNNotificationRequest *)request

--- a/ios/RCTOneSignal/RCTOneSignalExtensionService.m
+++ b/ios/RCTOneSignal/RCTOneSignalExtensionService.m
@@ -8,8 +8,10 @@
 + (void)didReceiveNotificationRequest:(UNNotificationRequest *)request
                           withContent:
                               (UNMutableNotificationContent *_Nullable)content {
+  // OneSignal 5.6.0 removed the 2-arg selector; nil handler is the old sync path.
   [OneSignal didReceiveNotificationExtensionRequest:request
-                     withMutableNotificationContent:content];
+                     withMutableNotificationContent:content
+                                 withContentHandler:nil];
 }
 
 + (void)didReceiveNotificationRequest:(UNNotificationRequest *)request

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-native-onesignal",
-  "version": "5.5.9",
+  "version": "5.5.10",
   "description": "React Native OneSignal SDK",
   "keywords": [
     "android",

--- a/react-native-onesignal.podspec
+++ b/react-native-onesignal.podspec
@@ -1,6 +1,6 @@
 require 'json'
 package_json = JSON.parse(File.read('package.json'))
-onesignal_xcframework_version = '5.5.6'
+onesignal_xcframework_version = '5.6.0'
 onesignal_disable_location_env = ENV['ONESIGNAL_DISABLE_LOCATION'].to_s.strip.downcase
 onesignal_disable_location = ['true', '1'].include?(onesignal_disable_location_env)
 

--- a/react-native-onesignal.podspec
+++ b/react-native-onesignal.podspec
@@ -1,6 +1,6 @@
 require 'json'
 package_json = JSON.parse(File.read('package.json'))
-onesignal_xcframework_version = '5.6.0'
+onesignal_xcframework_version = '5.6.1'
 onesignal_disable_location_env = ENV['ONESIGNAL_DISABLE_LOCATION'].to_s.strip.downcase
 onesignal_disable_location = ['true', '1'].include?(onesignal_disable_location_env)
 


### PR DESCRIPTION
Channels: Current

### 🛠️ Native Dependency Updates

- Update Android SDK from 5.9.9 to 5.10.0
  - feat: detect restored notifications and stop them re-alerting ([#2723](https://github.com/OneSignal/OneSignal-Android-SDK/pull/2723))
  - feat: send host FID-readiness signals on API request headers ([#2729](https://github.com/OneSignal/OneSignal-Android-SDK/pull/2729))
  - refactor: remove the otel observability path and OpenTelemetry dependency ([#2724](https://github.com/OneSignal/OneSignal-Android-SDK/pull/2724))
- Update iOS SDK from 5.5.6 to 5.6.1
  - fix: restore the deprecated 2-arg NSE selector ([OneSignal-iOS-SDK#1737](https://github.com/OneSignal/OneSignal-iOS-SDK/pull/1737))
  - feat: report host app build toolchain on iOS logs ([OneSignal-iOS-SDK#1728](https://github.com/OneSignal/OneSignal-iOS-SDK/pull/1728))
  - feat: call KMP features API and wire flags into OSFeatureManager ([OneSignal-iOS-SDK#1723](https://github.com/OneSignal/OneSignal-iOS-SDK/pull/1723))
  - feat: drive iOS logging from remote params ([OneSignal-iOS-SDK#1722](https://github.com/OneSignal/OneSignal-iOS-SDK/pull/1722))
  - feat: enable KMP logger on Mac Catalyst ([OneSignal-iOS-SDK#1714](https://github.com/OneSignal/OneSignal-iOS-SDK/pull/1714))
  - feat: add iOS KMP crash capture and upload ([OneSignal-iOS-SDK#1713](https://github.com/OneSignal/OneSignal-iOS-SDK/pull/1713))
  - feat: wire KMP remote logging lifecycle ([OneSignal-iOS-SDK#1703](https://github.com/OneSignal/OneSignal-iOS-SDK/pull/1703))
  - feat: add Swift adapters for KMP logger ([OneSignal-iOS-SDK#1702](https://github.com/OneSignal/OneSignal-iOS-SDK/pull/1702))
  - fix: report unbuildable log requests as a permanent failure ([OneSignal-iOS-SDK#1727](https://github.com/OneSignal/OneSignal-iOS-SDK/pull/1727))
  - fix: bound the crash-record cache on iOS ([OneSignal-iOS-SDK#1725](https://github.com/OneSignal/OneSignal-iOS-SDK/pull/1725))
  - refactor: delegate KMP bumps to shared workflow ([OneSignal-iOS-SDK#1720](https://github.com/OneSignal/OneSignal-iOS-SDK/pull/1720))
