### PR TITLE
fix: [SDK-5191] correct lock screen visibility type

### DIFF
--- a/src/OSNotification.test.ts
+++ b/src/OSNotification.test.ts
@@ -77,7 +77,7 @@ describe('OSNotification', () => {
           collapseId: 'collapse-1',
           fromProjectNumber: '123456789',
           smallIconAccentColor: 'FFFF0000',
-          lockScreenVisibility: '1',
+          lockScreenVisibility: 1,
           androidNotificationId: 456,
         };
         const notification = new OSNotification(androidData);
@@ -93,7 +93,7 @@ describe('OSNotification', () => {
         expect(notification.collapseId).toBe('collapse-1');
         expect(notification.fromProjectNumber).toBe('123456789');
         expect(notification.smallIconAccentColor).toBe('FFFF0000');
-        expect(notification.lockScreenVisibility).toBe('1');
+        expect(notification.lockScreenVisibility).toBe(1);
         expect(notification.androidNotificationId).toBe(456);
       });
 

--- a/src/OSNotification.ts
+++ b/src/OSNotification.ts
@@ -26,7 +26,7 @@ interface AndroidNotificationData extends BaseNotificationData {
   collapseId?: string;
   fromProjectNumber?: string;
   smallIconAccentColor?: string;
-  lockScreenVisibility?: string;
+  lockScreenVisibility?: number;
   androidNotificationId?: number;
 }
 
@@ -68,7 +68,7 @@ export default class OSNotification {
   collapseId?: string;
   fromProjectNumber?: string;
   smallIconAccentColor?: string;
-  lockScreenVisibility?: string;
+  lockScreenVisibility?: number;
   androidNotificationId?: number;
   // ios only
   badge?: string;


### PR DESCRIPTION
# Description

## One Line Summary

Correct the Android `lockScreenVisibility` notification property from `string` to `number`.

## Details

### Motivation

The native Android SDK provides lock screen visibility as a numeric value. The React Native type incorrectly declared it as a string, causing the public notification model to disagree with the runtime value.

### Scope

Updates the Android notification data interface and public `OSNotification` property type. No notification processing or behavior changes.

# Testing

## Unit testing

Updated the `OSNotification` mapping test to verify the numeric value. `vp test` passes.

## Manual testing

Not performed because this is a type correction with existing unit coverage and no runtime behavior change. `vp check` passes.

# Affected code checklist

- [x] Notifications
  - [ ] Display
  - [ ] Open
  - [ ] Push Processing
  - [ ] Confirm Deliveries
- [ ] Outcomes
- [ ] Sessions
- [ ] In-App Messaging
- [ ] REST API requests
- [x] Public API changes

# Checklist

## Overview

- [x] I have filled out all **REQUIRED** sections above
- [x] PR does one thing
- [x] Any Public API changes are explained in the PR details and conform to existing APIs

## Testing

- [x] I have included test coverage for these changes, or explained why they are not needed
- [x] All automated tests pass, or I explained why that is not possible
- [x] I have personally tested this on my device, or explained why that is not possible

## Final pass

- [x] Code is as readable as possible.
- [x] I have reviewed this PR myself, ensuring it meets each checklist item
